### PR TITLE
Remove empty jbr directory from build script.

### DIFF
--- a/code/languages/com.mbeddr.formal.safety/solutions/com.mbeddr.formal.safety.build/models/com.mbeddr.formal.safety.build.mps
+++ b/code/languages/com.mbeddr.formal.safety/solutions/com.mbeddr.formal.safety.build/models/com.mbeddr.formal.safety.build.mps
@@ -9611,21 +9611,6 @@
               </node>
             </node>
           </node>
-          <node concept="398223" id="5MWJzF9DC6L" role="39821P">
-            <node concept="3_J27D" id="5MWJzF9DC6N" role="Nbhlr">
-              <node concept="3Mxwew" id="5MWJzF9DC9E" role="3MwsjC">
-                <property role="3MwjfP" value="jbr" />
-              </node>
-            </node>
-            <node concept="2HvfSZ" id="5MWJzF9DC9u" role="39821P">
-              <node concept="398BVA" id="5MWJzF9DC9y" role="2HvfZ0">
-                <ref role="398BVh" node="wUJmWCxY0k" resolve="mps.home" />
-                <node concept="2Ry0Ak" id="5MWJzF9DC9C" role="iGT6I">
-                  <property role="2Ry0Am" value="jbr" />
-                </node>
-              </node>
-            </node>
-          </node>
           <node concept="398223" id="42jqVeFkUvx" role="39821P">
             <node concept="3_J27D" id="42jqVeFkUvy" role="Nbhlr">
               <node concept="3Mxwew" id="42jqVeFkUvz" role="3MwsjC">


### PR DESCRIPTION
In com.mbeddr.formal.safety.build.com.mbeddr.formal.safetyDistribution, a "jbr" folder is referenced in the MPS directory. This directory does not exist for a fresh copy of MPS, which causes the gradle script to fail in the packaging step.

This commit removes the copying of this directory in the build script.