### PR TITLE
Add GitHub continuous integration

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,12 +24,13 @@ jobs:
         echo "Unzipping MPS"
         unzip -o "MPS.zip" -d ~
         
+        echo "Creating symbolic link to MPS folder"
         ln -s '/home/runner/MPS ${MPS_VER}'/ MPS
         
         echo "Downloading JBR - JetBrainsRuntime"
         curl -L ${JBR} > "jbr.tar.gz"
         
-        #TODO: Fix JBR location
+        echo "Extracting JBR to MPS folder"
         tar -C '/home/runner/MPS '${MPS_VER}'/' -zxvf "jbr.tar.gz"
         
     - name: Change FASTEN config

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,30 +1,20 @@
 
 name: FASTEN_CI
 
-# Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the master branch
 on: [push, pull_request]
 
 env:
   MPS_VER: "2019.3"
   MPS_ZIP: "https://download.jetbrains.com/mps/2019.3/MPS-2019.3.4.zip"
   JBR: "https://bintray.com/jetbrains/intellij-jbr/download_file?file_path=jbr-11_0_7-windows-x64-b765.57.tar.gz"
-  PLUGIN_SOURCE_FOLDER: 'mbeddr.formal.mps-plugins/platform_2019_3_4/'
-  PLUGIN_TARGET_FOLDER: '/home/runner/MPS 2019.3/plugins/'
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
   build:
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
 
-    # Runs a single command using the runners shell
     - name: Download MPS
       run: |
         echo "Downloading MPS"
@@ -41,13 +31,6 @@ jobs:
         
         #TODO: Fix JBR location
         tar -C '/home/runner/MPS '${MPS_VER}'/' -zxvf "jbr.tar.gz"
-
-    #- name: Download and move plugins
-    #  run: |
-     #   git clone https://github.com/danielratiu/mbeddr.formal.mps-plugins.git
-     #   echo "Copy plugins from $PLUGIN_SOURCE_FOLDER to $PLUGIN_TARGET_FOLDER"
-     #   cd $PLUGIN_SOURCE_FOLDER
-     #   cp * -r -t "$(eval echo "$PLUGIN_TARGET_FOLDER")"
         
     - name: Change FASTEN config
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,82 @@
+
+name: FASTEN_CI
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on: [push, pull_request]
+
+env:
+  MPS_VER: "2019.3"
+  MPS_ZIP: "https://download.jetbrains.com/mps/2019.3/MPS-2019.3.4.zip"
+  JBR: "https://bintray.com/jetbrains/intellij-jbr/download_file?file_path=jbr-11_0_7-windows-x64-b765.57.tar.gz"
+  PLUGIN_SOURCE_FOLDER: 'mbeddr.formal.mps-plugins/platform_2019_3_4/'
+  PLUGIN_TARGET_FOLDER: '/home/runner/MPS 2019.3/plugins/'
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+
+    # Runs a single command using the runners shell
+    - name: Download MPS
+      run: |
+        echo "Downloading MPS"
+        echo ${MPS_ZIP}
+        curl -L ${MPS_ZIP} > "MPS.zip"
+        
+        echo "Unzipping MPS"
+        unzip -o "MPS.zip" -d ~
+        
+        ln -s '/home/runner/MPS ${MPS_VER}'/ MPS
+        
+        echo "Downloading JBR - JetBrainsRuntime"
+        curl -L ${JBR} > "jbr.tar.gz"
+        
+        #TODO: Fix JBR location
+        tar -C '/home/runner/MPS ${MPS_VER}/' -zxvf "jbr.tar.gz"
+
+    #- name: Download and move plugins
+    #  run: |
+     #   git clone https://github.com/danielratiu/mbeddr.formal.mps-plugins.git
+     #   echo "Copy plugins from $PLUGIN_SOURCE_FOLDER to $PLUGIN_TARGET_FOLDER"
+     #   cd $PLUGIN_SOURCE_FOLDER
+     #   cp * -r -t "$(eval echo "$PLUGIN_TARGET_FOLDER")"
+        
+    - name: Change FASTEN config
+      run: |
+        echo "Changing config"
+        echo "mpsHomeDir=/home/runner/MPS ${MPS_VER}" > gradle.properties
+        echo "mps.home=/home/runner/MPS ${MPS_VER}" >> gradle.properties
+        echo "mbeddr.formal.home=/home/runner/work/mbeddr.formal" >> gradle.properties
+        
+        echo "Gradle Properties:"
+        cat gradle.properties
+      
+    - name: Set up Gradle
+      run: |
+        echo "Setting up gradle build..."
+        sudo apt install openjdk-11-jdk
+        sudo apt install gradle
+        
+        chmod +x ./gradlew
+        
+    - name: Running Gradle build
+      run: |
+        export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
+        export JB_JAVA11_HOME=/usr/lib/jvm/java-11-openjdk-amd64
+        export JDK_HOME=/usr/lib/jvm/java-11-openjdk-amd64
+        ./gradlew
+      
+    - name: Archive distribution
+      uses: actions/upload-artifact@v1
+      with:
+        name: fasten-distribution
+        path: build/artifacts/com.mbeddr.formal.safetyDistribution/fasten-1.0-SNAPSHOT.zip
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
         curl -L ${JBR} > "jbr.tar.gz"
         
         #TODO: Fix JBR location
-        tar -C '/home/runner/MPS ${MPS_VER}/' -zxvf "jbr.tar.gz"
+        tar -C '/home/runner/MPS '${MPS_VER}'/' -zxvf "jbr.tar.gz"
 
     #- name: Download and move plugins
     #  run: |
@@ -52,8 +52,8 @@ jobs:
     - name: Change FASTEN config
       run: |
         echo "Changing config"
-        echo "mpsHomeDir=/home/runner/MPS ${MPS_VER}" > gradle.properties
-        echo "mps.home=/home/runner/MPS ${MPS_VER}" >> gradle.properties
+        echo "mpsHomeDir=/home/runner/MPS "${MPS_VER} > gradle.properties
+        echo "mps.home=/home/runner/MPS "${MPS_VER} >> gradle.properties
         echo "mbeddr.formal.home=/home/runner/work/mbeddr.formal" >> gradle.properties
         
         echo "Gradle Properties:"

--- a/code/languages/com.mbeddr.formal.safety/solutions/com.mbeddr.formal.safety.build/models/com.mbeddr.formal.safety.build.mps
+++ b/code/languages/com.mbeddr.formal.safety/solutions/com.mbeddr.formal.safety.build/models/com.mbeddr.formal.safety.build.mps
@@ -309,13 +309,10 @@
     </node>
     <node concept="398rNT" id="42jqVeFkUtk" role="1l3spd">
       <property role="TrG5h" value="mps.home" />
-      <node concept="398BVA" id="42jqVeFkVem" role="398pKh">
+      <node concept="398BVA" id="51uLzzZ6tkM" role="398pKh">
         <ref role="398BVh" node="42jqVeFkUG2" resolve="mbeddr.formal.home" />
-        <node concept="2Ry0Ak" id="5Xjjs0Nf98X" role="iGT6I">
-          <property role="2Ry0Am" value="build" />
-          <node concept="2Ry0Ak" id="5Xjjs0Nf9q8" role="2Ry0An">
-            <property role="2Ry0Am" value="mps" />
-          </node>
+        <node concept="2Ry0Ak" id="51uLzzZ6tyC" role="iGT6I">
+          <property role="2Ry0Am" value="MPS" />
         </node>
       </node>
     </node>
@@ -8742,23 +8739,6 @@
     <property role="2DA0ip" value="./../../../../../build/scripts" />
     <property role="TrG5h" value="com.mbeddr.formal.allScripts" />
     <property role="turDy" value="build_all_scripts.xml" />
-    <node concept="398rNT" id="3GDqItDlo_0" role="1l3spd">
-      <property role="TrG5h" value="mps.home" />
-      <node concept="55IIr" id="3GDqItDlo_3" role="398pKh">
-        <node concept="2Ry0Ak" id="3GDqItDlo_6" role="iGT6I">
-          <property role="2Ry0Am" value=".." />
-          <node concept="2Ry0Ak" id="3GDqItDlo_o" role="2Ry0An">
-            <property role="2Ry0Am" value=".." />
-            <node concept="2Ry0Ak" id="5Xjjs0Nf2qs" role="2Ry0An">
-              <property role="2Ry0Am" value="build" />
-              <node concept="2Ry0Ak" id="5Xjjs0Nf2qx" role="2Ry0An">
-                <property role="2Ry0Am" value="mps" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
     <node concept="398rNT" id="3GDqItDloIT" role="1l3spd">
       <property role="TrG5h" value="mbeddr.formal.home" />
       <node concept="55IIr" id="3GDqItDloJ2" role="398pKh">
@@ -8767,6 +8747,15 @@
           <node concept="2Ry0Ak" id="4MDOjos3hT4" role="2Ry0An">
             <property role="2Ry0Am" value=".." />
           </node>
+        </node>
+      </node>
+    </node>
+    <node concept="398rNT" id="3GDqItDlo_0" role="1l3spd">
+      <property role="TrG5h" value="mps.home" />
+      <node concept="398BVA" id="51uLzzZ6sD_" role="398pKh">
+        <ref role="398BVh" node="3GDqItDloIT" resolve="mbeddr.formal.home" />
+        <node concept="2Ry0Ak" id="51uLzzZ6sDS" role="iGT6I">
+          <property role="2Ry0Am" value="MPS" />
         </node>
       </node>
     </node>
@@ -8940,16 +8929,10 @@
     </node>
     <node concept="398rNT" id="1IhJc2tzD9d" role="1l3spd">
       <property role="TrG5h" value="mps.home" />
-      <node concept="398BVA" id="1IhJc2tzD9e" role="398pKh">
+      <node concept="398BVA" id="51uLzzZ6tO4" role="398pKh">
         <ref role="398BVh" node="1IhJc2tDRxy" resolve="mbeddr.formal.home" />
-        <node concept="2Ry0Ak" id="1IhJc2tzD9f" role="iGT6I">
-          <property role="2Ry0Am" value=".." />
-          <node concept="2Ry0Ak" id="2DcSMg46KsU" role="2Ry0An">
-            <property role="2Ry0Am" value=".." />
-            <node concept="2Ry0Ak" id="7i1hDKUBgIu" role="2Ry0An">
-              <property role="2Ry0Am" value="MPS_2019_2_3_mbeddr_formal" />
-            </node>
-          </node>
+        <node concept="2Ry0Ak" id="51uLzzZ6tO8" role="iGT6I">
+          <property role="2Ry0Am" value="MPS" />
         </node>
       </node>
     </node>
@@ -9233,13 +9216,7 @@
       <node concept="398BVA" id="wUJmWCxY0l" role="398pKh">
         <ref role="398BVh" node="wUJmWCxY0g" resolve="mbeddr.formal.home" />
         <node concept="2Ry0Ak" id="wUJmWCxY0m" role="iGT6I">
-          <property role="2Ry0Am" value=".." />
-          <node concept="2Ry0Ak" id="wUJmWCxY0n" role="2Ry0An">
-            <property role="2Ry0Am" value=".." />
-            <node concept="2Ry0Ak" id="2Ttn9EOyTRM" role="2Ry0An">
-              <property role="2Ry0Am" value="MPS_2019_3_2_mbeddr_formal" />
-            </node>
-          </node>
+          <property role="2Ry0Am" value="MPS" />
         </node>
       </node>
     </node>


### PR DESCRIPTION
This pull request adds GitHub continuous integration to this repository.

Two files are changed:
* code/languages/com.mbeddr.formal.safety/solutions/com.mbeddr.formal.safety.build/models/com.mbeddr.formal.safety.build.mps
  * This file is changed as the relative build paths must point to the location of MPS for the `jbr` files to be copied by the distribution script.
* .github/workflows/main.yml
  * The presence of this file tells GitHub to start the CI process.
  * There are five steps in the CI process, documented in the file itself

Limitations:
* The envs in the main.yml file will need to be modified for rebasing against new versions of MPS
* Only the Windows version of the JBR is packaged
* The changes to the build.mps file are required for this CI to work, and thus must be maintained
* The distribution is an artifact of the CI process. Future work could be to deploy this to a download page
* This script is expensive as it must download MPS each time. Future work could be to investigate caching