### PR TITLE
Make strategy polygon lean to the right

### DIFF
--- a/code/languages/com.mbeddr.formal.safety/languages/com.mbeddr.formal.safety.gsn/models/com.mbeddr.formal.safety.gsn.editor.mps
+++ b/code/languages/com.mbeddr.formal.safety/languages/com.mbeddr.formal.safety.gsn/models/com.mbeddr.formal.safety.gsn.editor.mps
@@ -1929,10 +1929,23 @@
           <node concept="3cpWsn" id="7TjUbLQ9xzQ" role="3cpWs9">
             <property role="TrG5h" value="x1" />
             <node concept="10P55v" id="7TjUbLQ9xzR" role="1tU5fm" />
-            <node concept="2OqwBi" id="7TjUbLQ9xzS" role="33vP2m">
-              <node concept="2xDkLB" id="7TjUbLQ9xzT" role="2Oq$k0" />
-              <node concept="liA8E" id="7TjUbLQ9xzU" role="2OqNvi">
-                <ref role="37wK5l" to="fbzs:~RectangularShape.getX()" resolve="getX" />
+            <node concept="3cpWs3" id="23rbXlValPZ" role="33vP2m">
+              <node concept="2OqwBi" id="7TjUbLQ9xzS" role="3uHU7B">
+                <node concept="2xDkLB" id="7TjUbLQ9xzT" role="2Oq$k0" />
+                <node concept="liA8E" id="7TjUbLQ9xzU" role="2OqNvi">
+                  <ref role="37wK5l" to="fbzs:~RectangularShape.getX()" resolve="getX" />
+                </node>
+              </node>
+              <node concept="FJ1c_" id="23rbXlV9rj_" role="3uHU7w">
+                <node concept="2OqwBi" id="23rbXlV9rjA" role="3uHU7B">
+                  <node concept="2xDkLB" id="23rbXlV9rjB" role="2Oq$k0" />
+                  <node concept="liA8E" id="23rbXlV9rjC" role="2OqNvi">
+                    <ref role="37wK5l" to="fbzs:~RectangularShape.getWidth()" resolve="getWidth" />
+                  </node>
+                </node>
+                <node concept="3cmrfG" id="23rbXlV9rjD" role="3uHU7w">
+                  <property role="3cmrfH" value="10" />
+                </node>
               </node>
             </node>
           </node>
@@ -1954,30 +1967,17 @@
           <node concept="3cpWsn" id="7TjUbLQ9x$3" role="3cpWs9">
             <property role="TrG5h" value="x2" />
             <node concept="10P55v" id="7TjUbLQ9x$4" role="1tU5fm" />
-            <node concept="3cpWsd" id="7TjUbLQ9x$5" role="33vP2m">
-              <node concept="3cpWs3" id="7TjUbLQ9x$6" role="3uHU7B">
-                <node concept="2OqwBi" id="7TjUbLQ9x$7" role="3uHU7w">
-                  <node concept="2xDkLB" id="7TjUbLQ9x$8" role="2Oq$k0" />
-                  <node concept="liA8E" id="7TjUbLQ9x$9" role="2OqNvi">
-                    <ref role="37wK5l" to="fbzs:~RectangularShape.getWidth()" resolve="getWidth" />
-                  </node>
-                </node>
-                <node concept="2OqwBi" id="7TjUbLQ9x$a" role="3uHU7B">
-                  <node concept="2xDkLB" id="7TjUbLQ9x$b" role="2Oq$k0" />
-                  <node concept="liA8E" id="7TjUbLQ9x$c" role="2OqNvi">
-                    <ref role="37wK5l" to="fbzs:~RectangularShape.getX()" resolve="getX" />
-                  </node>
+            <node concept="3cpWs3" id="7TjUbLQ9x$6" role="33vP2m">
+              <node concept="2OqwBi" id="7TjUbLQ9x$7" role="3uHU7w">
+                <node concept="2xDkLB" id="7TjUbLQ9x$8" role="2Oq$k0" />
+                <node concept="liA8E" id="7TjUbLQ9x$9" role="2OqNvi">
+                  <ref role="37wK5l" to="fbzs:~RectangularShape.getWidth()" resolve="getWidth" />
                 </node>
               </node>
-              <node concept="FJ1c_" id="7TjUbLQ9x$d" role="3uHU7w">
-                <node concept="2OqwBi" id="7TjUbLQ9x$e" role="3uHU7B">
-                  <node concept="2xDkLB" id="7TjUbLQ9x$f" role="2Oq$k0" />
-                  <node concept="liA8E" id="7TjUbLQ9x$g" role="2OqNvi">
-                    <ref role="37wK5l" to="fbzs:~RectangularShape.getWidth()" resolve="getWidth" />
-                  </node>
-                </node>
-                <node concept="3cmrfG" id="7TjUbLQ9x$h" role="3uHU7w">
-                  <property role="3cmrfH" value="10" />
+              <node concept="2OqwBi" id="7TjUbLQ9x$a" role="3uHU7B">
+                <node concept="2xDkLB" id="7TjUbLQ9x$b" role="2Oq$k0" />
+                <node concept="liA8E" id="7TjUbLQ9x$c" role="2OqNvi">
+                  <ref role="37wK5l" to="fbzs:~RectangularShape.getX()" resolve="getX" />
                 </node>
               </node>
             </node>
@@ -2000,17 +2000,30 @@
           <node concept="3cpWsn" id="7TjUbLQ9x$q" role="3cpWs9">
             <property role="TrG5h" value="x3" />
             <node concept="10P55v" id="7TjUbLQ9x$r" role="1tU5fm" />
-            <node concept="3cpWs3" id="7TjUbLQ9x$s" role="33vP2m">
-              <node concept="2OqwBi" id="7TjUbLQ9x$t" role="3uHU7w">
-                <node concept="2xDkLB" id="7TjUbLQ9x$u" role="2Oq$k0" />
-                <node concept="liA8E" id="7TjUbLQ9x$v" role="2OqNvi">
-                  <ref role="37wK5l" to="fbzs:~RectangularShape.getWidth()" resolve="getWidth" />
+            <node concept="3cpWsd" id="23rbXlVaqrr" role="33vP2m">
+              <node concept="3cpWs3" id="7TjUbLQ9x$s" role="3uHU7B">
+                <node concept="2OqwBi" id="7TjUbLQ9x$w" role="3uHU7B">
+                  <node concept="2xDkLB" id="7TjUbLQ9x$x" role="2Oq$k0" />
+                  <node concept="liA8E" id="7TjUbLQ9x$y" role="2OqNvi">
+                    <ref role="37wK5l" to="fbzs:~RectangularShape.getX()" resolve="getX" />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="7TjUbLQ9x$t" role="3uHU7w">
+                  <node concept="2xDkLB" id="7TjUbLQ9x$u" role="2Oq$k0" />
+                  <node concept="liA8E" id="7TjUbLQ9x$v" role="2OqNvi">
+                    <ref role="37wK5l" to="fbzs:~RectangularShape.getWidth()" resolve="getWidth" />
+                  </node>
                 </node>
               </node>
-              <node concept="2OqwBi" id="7TjUbLQ9x$w" role="3uHU7B">
-                <node concept="2xDkLB" id="7TjUbLQ9x$x" role="2Oq$k0" />
-                <node concept="liA8E" id="7TjUbLQ9x$y" role="2OqNvi">
-                  <ref role="37wK5l" to="fbzs:~RectangularShape.getX()" resolve="getX" />
+              <node concept="FJ1c_" id="7TjUbLQ9x$d" role="3uHU7w">
+                <node concept="2OqwBi" id="7TjUbLQ9x$e" role="3uHU7B">
+                  <node concept="2xDkLB" id="7TjUbLQ9x$f" role="2Oq$k0" />
+                  <node concept="liA8E" id="7TjUbLQ9x$g" role="2OqNvi">
+                    <ref role="37wK5l" to="fbzs:~RectangularShape.getWidth()" resolve="getWidth" />
+                  </node>
+                </node>
+                <node concept="3cmrfG" id="7TjUbLQ9x$h" role="3uHU7w">
+                  <property role="3cmrfH" value="10" />
                 </node>
               </node>
             </node>
@@ -2041,23 +2054,10 @@
           <node concept="3cpWsn" id="7TjUbLQ9x$J" role="3cpWs9">
             <property role="TrG5h" value="x4" />
             <node concept="10P55v" id="7TjUbLQ9x$K" role="1tU5fm" />
-            <node concept="3cpWs3" id="7TjUbLQ9x$L" role="33vP2m">
-              <node concept="FJ1c_" id="7TjUbLQ9x$M" role="3uHU7w">
-                <node concept="3cmrfG" id="7TjUbLQ9x$N" role="3uHU7w">
-                  <property role="3cmrfH" value="10" />
-                </node>
-                <node concept="2OqwBi" id="7TjUbLQ9x$O" role="3uHU7B">
-                  <node concept="2xDkLB" id="7TjUbLQ9x$P" role="2Oq$k0" />
-                  <node concept="liA8E" id="7TjUbLQ9x$Q" role="2OqNvi">
-                    <ref role="37wK5l" to="fbzs:~RectangularShape.getWidth()" resolve="getWidth" />
-                  </node>
-                </node>
-              </node>
-              <node concept="2OqwBi" id="7TjUbLQ9x$R" role="3uHU7B">
-                <node concept="2xDkLB" id="7TjUbLQ9x$S" role="2Oq$k0" />
-                <node concept="liA8E" id="7TjUbLQ9x$T" role="2OqNvi">
-                  <ref role="37wK5l" to="fbzs:~RectangularShape.getX()" resolve="getX" />
-                </node>
+            <node concept="2OqwBi" id="7TjUbLQ9x$R" role="33vP2m">
+              <node concept="2xDkLB" id="7TjUbLQ9x$S" role="2Oq$k0" />
+              <node concept="liA8E" id="7TjUbLQ9x$T" role="2OqNvi">
+                <ref role="37wK5l" to="fbzs:~RectangularShape.getX()" resolve="getX" />
               </node>
             </node>
           </node>


### PR DESCRIPTION
This is a trivial change, making the GSN strategy polygon lean to the right instead of to the left (feedback from our users).
This should be consistent with common GSN representations (at least the ones I found).