### PR TITLE
feature/enable page formatting of gsn diagrams

### DIFF
--- a/code/languages/com.mbeddr.formal.nusmv/languages/com.mbeddr.formal.base/com.mbeddr.formal.base.mpl
+++ b/code/languages/com.mbeddr.formal.nusmv/languages/com.mbeddr.formal.base/com.mbeddr.formal.base.mpl
@@ -15,22 +15,17 @@
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
     <dependency reexport="true">1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)</dependency>
     <dependency reexport="false">8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)</dependency>
-    <dependency reexport="false">3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)</dependency>
     <dependency reexport="false">8d29d73f-ed99-4652-ae0a-083cdfe53c34(jetbrains.mps.ide.platform)</dependency>
     <dependency reexport="false">6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)</dependency>
     <dependency reexport="false">e9ce245b-3106-45ed-8e5b-aff820d09b85(com.mbeddr.formal.base.tooling)</dependency>
-    <dependency reexport="false">848ef45d-e560-4e35-853c-f35a64cc135c(de.itemis.mps.editor.celllayout.runtime)</dependency>
     <dependency reexport="false">8ca79d43-eb45-4791-bdd4-0d6130ff895b(de.itemis.mps.editor.diagram.layout)</dependency>
     <dependency reexport="false">1144260c-e9a5-49a2-9add-39a1a1a7077e(de.itemis.mps.editor.diagram.runtime)</dependency>
     <dependency reexport="false">20c6e580-bdc5-4067-8049-d7e3265a86de(jetbrains.mps.typesystemEngine)</dependency>
-    <dependency reexport="false">c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)</dependency>
-    <dependency reexport="false">2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)</dependency>
     <dependency reexport="false">8da51702-0e05-44c8-96db-8f11d1457c0c(com.mpsbasics.snode.utils)</dependency>
     <dependency reexport="false">498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)</dependency>
     <dependency reexport="false">1f4710e9-f074-4732-a0bd-6fa896d282b7(com.mpsbasics.project.utils)</dependency>
     <dependency reexport="false">792be022-0a7a-4b28-bfd8-b1b2d347b772(com.mpsbasics.core)</dependency>
     <dependency reexport="false">d3a0fd26-445a-466c-900e-10444ddfed52(com.mbeddr.mpsutil.filepicker)</dependency>
-    <dependency reexport="false">e8a04d94-4307-4f88-95a2-25f7c4f39437(com.mbeddr.formal.safety.gsn)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:120e1c9d-4e27-4478-b2af-b2c3bd3850b0:com.mbeddr.mpsutil.editor.querylist" version="0" />
@@ -106,12 +101,8 @@
     <module reference="0022e9df-2136-4ef8-81b2-08650aeb1dc7(de.itemis.mps.tooltips.runtime)" version="0" />
     <module reference="fdaaf35f-8ee3-4c37-b09d-9efaeaaa7a41(jetbrains.mps.core.tool.environment)" version="0" />
     <module reference="8d29d73f-ed99-4652-ae0a-083cdfe53c34(jetbrains.mps.ide.platform)" version="0" />
-    <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
-    <module reference="d936855b-48da-4812-a8a0-2bfddd633ac5(jetbrains.mps.lang.behavior.api)" version="0" />
     <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
     <module reference="a9e4c532-c5f5-4bb7-99ef-42abb73bbb70(jetbrains.mps.lang.descriptor.aspects)" version="0" />
-    <module reference="d7eb0a2a-bd50-4576-beae-e4a89db35f20(jetbrains.mps.lang.scopes.runtime)" version="0" />
-    <module reference="c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)" version="0" />
     <module reference="20c6e580-bdc5-4067-8049-d7e3265a86de(jetbrains.mps.typesystemEngine)" version="0" />
   </dependencyVersions>
   <extendedLanguages />

--- a/code/languages/com.mbeddr.formal.nusmv/languages/com.mbeddr.formal.base/com.mbeddr.formal.base.mpl
+++ b/code/languages/com.mbeddr.formal.nusmv/languages/com.mbeddr.formal.base/com.mbeddr.formal.base.mpl
@@ -30,6 +30,7 @@
     <dependency reexport="false">1f4710e9-f074-4732-a0bd-6fa896d282b7(com.mpsbasics.project.utils)</dependency>
     <dependency reexport="false">792be022-0a7a-4b28-bfd8-b1b2d347b772(com.mpsbasics.core)</dependency>
     <dependency reexport="false">d3a0fd26-445a-466c-900e-10444ddfed52(com.mbeddr.mpsutil.filepicker)</dependency>
+    <dependency reexport="false">e8a04d94-4307-4f88-95a2-25f7c4f39437(com.mbeddr.formal.safety.gsn)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:120e1c9d-4e27-4478-b2af-b2c3bd3850b0:com.mbeddr.mpsutil.editor.querylist" version="0" />

--- a/code/languages/com.mbeddr.formal.nusmv/languages/com.mbeddr.formal.base/models/behavior.mps
+++ b/code/languages/com.mbeddr.formal.nusmv/languages/com.mbeddr.formal.base/models/behavior.mps
@@ -10,7 +10,6 @@
     <import index="b19z" ref="r:11a68676-9d63-4e1c-b920-59aefe77def3(com.mbeddr.formal.base.structure)" />
     <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
-    <import index="tpce" ref="r:00000000-0000-4000-0000-011c89590292(jetbrains.mps.lang.structure.structure)" />
     <import index="u35n" ref="r:f917b204-e25c-4286-9eae-9081d5f78a78(com.mpsbasics.snode.utils.hashcode)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
   </imports>

--- a/code/languages/com.mbeddr.formal.nusmv/languages/com.mbeddr.formal.base/models/behavior.mps
+++ b/code/languages/com.mbeddr.formal.nusmv/languages/com.mbeddr.formal.base/models/behavior.mps
@@ -31,6 +31,10 @@
       <concept id="1225194691553" name="jetbrains.mps.lang.behavior.structure.ThisNodeExpression" flags="nn" index="13iPFW" />
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
+        <child id="1068498886297" name="rValue" index="37vLTx" />
+        <child id="1068498886295" name="lValue" index="37vLTJ" />
+      </concept>
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
@@ -47,6 +51,7 @@
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
       <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
       <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
         <child id="1070534934091" name="type" index="10QFUM" />
@@ -55,13 +60,18 @@
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
+      <concept id="1092119917967" name="jetbrains.mps.baseLanguage.structure.MulExpression" flags="nn" index="17qRlL" />
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
       <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
+      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1111509017652" name="jetbrains.mps.baseLanguage.structure.FloatingPointConstant" flags="nn" index="3b6qkQ">
+        <property id="1113006610751" name="value" index="$nhwW" />
       </concept>
       <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
         <child id="1068580123133" name="returnType" index="3clF45" />
@@ -137,6 +147,14 @@
         <property id="8970989240999019144" name="text" index="1dT_AB" />
       </concept>
     </language>
+    <language id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation">
+      <concept id="5455284157993863837" name="jetbrains.mps.lang.quotation.structure.NodeBuilder" flags="nn" index="2pJPEk">
+        <child id="5455284157993863838" name="quotedNode" index="2pJPEn" />
+      </concept>
+      <concept id="5455284157993863840" name="jetbrains.mps.lang.quotation.structure.NodeBuilderNode" flags="nn" index="2pJPED">
+        <reference id="5455284157993910961" name="concept" index="2pJxaS" />
+      </concept>
+    </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
@@ -192,6 +210,9 @@
       </concept>
       <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
         <reference id="1138056395725" name="property" index="3TsBF5" />
+      </concept>
+      <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
+        <reference id="1138056516764" name="link" index="3Tt5mk" />
       </concept>
       <concept id="1138056282393" name="jetbrains.mps.lang.smodel.structure.SLinkListAccess" flags="nn" index="3Tsc0h">
         <reference id="1138056546658" name="link" index="3TtcxE" />
@@ -824,6 +845,703 @@
     </node>
     <node concept="13hLZK" id="7tmSxcqhbKV" role="13h7CW">
       <node concept="3clFbS" id="7tmSxcqhbKW" role="2VODD2" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="4_xuXPCBwBf">
+    <property role="3GE5qa" value="page_settings" />
+    <ref role="13h7C2" to="b19z:4_xuXPCBvIl" resolve="PageSettingBase" />
+    <node concept="13i0hz" id="4_xuXPCBwK4" role="13h7CS">
+      <property role="TrG5h" value="widthInMillimeters" />
+      <property role="13i0it" value="true" />
+      <property role="13i0iv" value="true" />
+      <node concept="3Tm1VV" id="4_xuXPCBwK5" role="1B3o_S" />
+      <node concept="10Oyi0" id="4_xuXPCBwNe" role="3clF45" />
+      <node concept="3clFbS" id="4_xuXPCBwK7" role="3clF47" />
+    </node>
+    <node concept="13i0hz" id="4_xuXPCBxFM" role="13h7CS">
+      <property role="TrG5h" value="heightInMillimeters" />
+      <property role="13i0it" value="true" />
+      <property role="13i0iv" value="true" />
+      <node concept="3Tm1VV" id="4_xuXPCBxFN" role="1B3o_S" />
+      <node concept="10Oyi0" id="4_xuXPCBxFO" role="3clF45" />
+      <node concept="3clFbS" id="4_xuXPCBxFP" role="3clF47" />
+    </node>
+    <node concept="13hLZK" id="4_xuXPCBwBg" role="13h7CW">
+      <node concept="3clFbS" id="4_xuXPCBwBh" role="2VODD2">
+        <node concept="3clFbF" id="4_xuXPCUrr7" role="3cqZAp">
+          <node concept="37vLTI" id="4_xuXPCUslG" role="3clFbG">
+            <node concept="2pJPEk" id="4_xuXPCUsu3" role="37vLTx">
+              <node concept="2pJPED" id="4_xuXPCUsu5" role="2pJPEn">
+                <ref role="2pJxaS" to="b19z:4_xuXPCP_cL" resolve="PageSettingsTopLeft" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="4_xuXPCUr_b" role="37vLTJ">
+              <node concept="13iPFW" id="4_xuXPCUrr6" role="2Oq$k0" />
+              <node concept="3TrEf2" id="4_xuXPCUrSe" role="2OqNvi">
+                <ref role="3Tt5mk" to="b19z:4_xuXPCPAss" resolve="topLeft" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4_xuXPCUsNP" role="3cqZAp">
+          <node concept="37vLTI" id="4_xuXPCUsNQ" role="3clFbG">
+            <node concept="2pJPEk" id="4_xuXPCUsNR" role="37vLTx">
+              <node concept="2pJPED" id="4_xuXPCUsNS" role="2pJPEn">
+                <ref role="2pJxaS" to="b19z:4_xuXPCP_OB" resolve="PageSettingsBottomRight" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="4_xuXPCUsNT" role="37vLTJ">
+              <node concept="13iPFW" id="4_xuXPCUsNU" role="2Oq$k0" />
+              <node concept="3TrEf2" id="4_xuXPCUsNV" role="2OqNvi">
+                <ref role="3Tt5mk" to="b19z:4_xuXPCPANd" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="13h7C7" id="4_xuXPCByeY">
+    <property role="3GE5qa" value="page_settings" />
+    <ref role="13h7C2" to="b19z:4_xuXPCBwdC" resolve="A4PagePortrait" />
+    <node concept="13hLZK" id="4_xuXPCByeZ" role="13h7CW">
+      <node concept="3clFbS" id="4_xuXPCByf0" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="4_xuXPCByUb" role="13h7CS">
+      <property role="TrG5h" value="widthInMillimeters" />
+      <ref role="13i0hy" node="4_xuXPCBwK4" resolve="widthInInches" />
+      <node concept="3Tm1VV" id="4_xuXPCByUc" role="1B3o_S" />
+      <node concept="3clFbS" id="4_xuXPCByUf" role="3clF47">
+        <node concept="3clFbF" id="4_xuXPCByUi" role="3cqZAp">
+          <node concept="10QFUN" id="4_xuXPCBJH4" role="3clFbG">
+            <node concept="1eOMI4" id="4_xuXPCBJH5" role="10QFUP">
+              <node concept="17qRlL" id="4_xuXPCBJH1" role="1eOMHV">
+                <node concept="3b6qkQ" id="4_xuXPCBJH2" role="3uHU7w">
+                  <property role="$nhwW" value="25.4" />
+                </node>
+                <node concept="3b6qkQ" id="4_xuXPCBJH3" role="3uHU7B">
+                  <property role="$nhwW" value="8.3" />
+                </node>
+              </node>
+            </node>
+            <node concept="10Oyi0" id="4_xuXPCBJHB" role="10QFUM" />
+          </node>
+        </node>
+      </node>
+      <node concept="10Oyi0" id="4_xuXPCByUg" role="3clF45" />
+    </node>
+    <node concept="13i0hz" id="4_xuXPCByUj" role="13h7CS">
+      <property role="TrG5h" value="heightInMillimeters" />
+      <ref role="13i0hy" node="4_xuXPCBxFM" resolve="heightInInches" />
+      <node concept="3Tm1VV" id="4_xuXPCByUk" role="1B3o_S" />
+      <node concept="3clFbS" id="4_xuXPCByUn" role="3clF47">
+        <node concept="3clFbF" id="4_xuXPCBLkw" role="3cqZAp">
+          <node concept="10QFUN" id="4_xuXPCBLkx" role="3clFbG">
+            <node concept="1eOMI4" id="4_xuXPCBLky" role="10QFUP">
+              <node concept="17qRlL" id="4_xuXPCBLkz" role="1eOMHV">
+                <node concept="3b6qkQ" id="4_xuXPCBLk$" role="3uHU7w">
+                  <property role="$nhwW" value="25.4" />
+                </node>
+                <node concept="3b6qkQ" id="4_xuXPCBLk_" role="3uHU7B">
+                  <property role="$nhwW" value="11.7" />
+                </node>
+              </node>
+            </node>
+            <node concept="10Oyi0" id="4_xuXPCBLkA" role="10QFUM" />
+          </node>
+        </node>
+      </node>
+      <node concept="10Oyi0" id="4_xuXPCByUo" role="3clF45" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="4_xuXPCBUSw">
+    <property role="3GE5qa" value="page_settings" />
+    <ref role="13h7C2" to="b19z:4_xuXPCBSAy" resolve="A4PageLandscape" />
+    <node concept="13i0hz" id="4_xuXPCBUYv" role="13h7CS">
+      <property role="TrG5h" value="widthInMillimeters" />
+      <ref role="13i0hy" node="4_xuXPCBwK4" resolve="widthInInches" />
+      <node concept="3Tm1VV" id="4_xuXPCBUYw" role="1B3o_S" />
+      <node concept="3clFbS" id="4_xuXPCBUYx" role="3clF47">
+        <node concept="3clFbF" id="4_xuXPCBUYH" role="3cqZAp">
+          <node concept="10QFUN" id="4_xuXPCBUYI" role="3clFbG">
+            <node concept="1eOMI4" id="4_xuXPCBUYJ" role="10QFUP">
+              <node concept="17qRlL" id="4_xuXPCBUYK" role="1eOMHV">
+                <node concept="3b6qkQ" id="4_xuXPCBUYL" role="3uHU7w">
+                  <property role="$nhwW" value="25.4" />
+                </node>
+                <node concept="3b6qkQ" id="4_xuXPCBUYM" role="3uHU7B">
+                  <property role="$nhwW" value="11.7" />
+                </node>
+              </node>
+            </node>
+            <node concept="10Oyi0" id="4_xuXPCBUYN" role="10QFUM" />
+          </node>
+        </node>
+      </node>
+      <node concept="10Oyi0" id="4_xuXPCBUYD" role="3clF45" />
+    </node>
+    <node concept="13i0hz" id="4_xuXPCBUYE" role="13h7CS">
+      <property role="TrG5h" value="heightInMillimeters" />
+      <ref role="13i0hy" node="4_xuXPCBxFM" resolve="heightInInches" />
+      <node concept="3Tm1VV" id="4_xuXPCBUYF" role="1B3o_S" />
+      <node concept="3clFbS" id="4_xuXPCBUYG" role="3clF47">
+        <node concept="3clFbF" id="4_xuXPCBUYy" role="3cqZAp">
+          <node concept="10QFUN" id="4_xuXPCBUYz" role="3clFbG">
+            <node concept="1eOMI4" id="4_xuXPCBUY$" role="10QFUP">
+              <node concept="17qRlL" id="4_xuXPCBUY_" role="1eOMHV">
+                <node concept="3b6qkQ" id="4_xuXPCBUYA" role="3uHU7w">
+                  <property role="$nhwW" value="25.4" />
+                </node>
+                <node concept="3b6qkQ" id="4_xuXPCBUYB" role="3uHU7B">
+                  <property role="$nhwW" value="8.3" />
+                </node>
+              </node>
+            </node>
+            <node concept="10Oyi0" id="4_xuXPCBUYC" role="10QFUM" />
+          </node>
+        </node>
+      </node>
+      <node concept="10Oyi0" id="4_xuXPCBUYO" role="3clF45" />
+    </node>
+    <node concept="13hLZK" id="4_xuXPCBUSx" role="13h7CW">
+      <node concept="3clFbS" id="4_xuXPCBUSy" role="2VODD2" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="4_xuXPCZgZe">
+    <property role="3GE5qa" value="page_settings" />
+    <ref role="13h7C2" to="b19z:4_xuXPCP_OB" resolve="PageSettingsBottomRight" />
+    <node concept="13hLZK" id="4_xuXPCZgZf" role="13h7CW">
+      <node concept="3clFbS" id="4_xuXPCZgZg" role="2VODD2" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="4_xuXPD3kvY">
+    <property role="3GE5qa" value="page_settings" />
+    <ref role="13h7C2" to="b19z:4_xuXPD3jwz" resolve="A3PageLandscape" />
+    <node concept="13i0hz" id="4_xuXPD3k_X" role="13h7CS">
+      <property role="TrG5h" value="widthInMillimeters" />
+      <ref role="13i0hy" node="4_xuXPCBwK4" resolve="widthInInches" />
+      <node concept="3Tm1VV" id="4_xuXPD3k_Y" role="1B3o_S" />
+      <node concept="3clFbS" id="4_xuXPD3k_Z" role="3clF47">
+        <node concept="3clFbF" id="4_xuXPD3kA0" role="3cqZAp">
+          <node concept="10QFUN" id="4_xuXPD3kA1" role="3clFbG">
+            <node concept="1eOMI4" id="4_xuXPD3kA2" role="10QFUP">
+              <node concept="17qRlL" id="4_xuXPD3kA3" role="1eOMHV">
+                <node concept="3b6qkQ" id="4_xuXPD3kA4" role="3uHU7w">
+                  <property role="$nhwW" value="25.4" />
+                </node>
+                <node concept="3b6qkQ" id="4_xuXPD3kA5" role="3uHU7B">
+                  <property role="$nhwW" value="16.5" />
+                </node>
+              </node>
+            </node>
+            <node concept="10Oyi0" id="4_xuXPD3kA6" role="10QFUM" />
+          </node>
+        </node>
+      </node>
+      <node concept="10Oyi0" id="4_xuXPD3kA7" role="3clF45" />
+    </node>
+    <node concept="13i0hz" id="4_xuXPD3kA8" role="13h7CS">
+      <property role="TrG5h" value="heightInMillimeters" />
+      <ref role="13i0hy" node="4_xuXPCBxFM" resolve="heightInInches" />
+      <node concept="3Tm1VV" id="4_xuXPD3kA9" role="1B3o_S" />
+      <node concept="3clFbS" id="4_xuXPD3kAa" role="3clF47">
+        <node concept="3clFbF" id="4_xuXPD3kAb" role="3cqZAp">
+          <node concept="10QFUN" id="4_xuXPD3kAc" role="3clFbG">
+            <node concept="1eOMI4" id="4_xuXPD3kAd" role="10QFUP">
+              <node concept="17qRlL" id="4_xuXPD3kAe" role="1eOMHV">
+                <node concept="3b6qkQ" id="4_xuXPD3kAf" role="3uHU7w">
+                  <property role="$nhwW" value="25.4" />
+                </node>
+                <node concept="3b6qkQ" id="4_xuXPD3kAg" role="3uHU7B">
+                  <property role="$nhwW" value="11.7" />
+                </node>
+              </node>
+            </node>
+            <node concept="10Oyi0" id="4_xuXPD3kAh" role="10QFUM" />
+          </node>
+        </node>
+      </node>
+      <node concept="10Oyi0" id="4_xuXPD3kAi" role="3clF45" />
+    </node>
+    <node concept="13hLZK" id="4_xuXPD3kvZ" role="13h7CW">
+      <node concept="3clFbS" id="4_xuXPD3kw0" role="2VODD2" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="4_xuXPD3m$T">
+    <property role="3GE5qa" value="page_settings" />
+    <ref role="13h7C2" to="b19z:4_xuXPD3lZU" resolve="A3PagePortrait" />
+    <node concept="13i0hz" id="4_xuXPD3mQg" role="13h7CS">
+      <property role="TrG5h" value="widthInMillimeters" />
+      <ref role="13i0hy" node="4_xuXPCBwK4" resolve="widthInInches" />
+      <node concept="3Tm1VV" id="4_xuXPD3mQh" role="1B3o_S" />
+      <node concept="3clFbS" id="4_xuXPD3mQi" role="3clF47">
+        <node concept="3clFbF" id="4_xuXPD3mQu" role="3cqZAp">
+          <node concept="10QFUN" id="4_xuXPD3mQv" role="3clFbG">
+            <node concept="1eOMI4" id="4_xuXPD3mQw" role="10QFUP">
+              <node concept="17qRlL" id="4_xuXPD3mQx" role="1eOMHV">
+                <node concept="3b6qkQ" id="4_xuXPD3mQy" role="3uHU7w">
+                  <property role="$nhwW" value="25.4" />
+                </node>
+                <node concept="3b6qkQ" id="4_xuXPD3mQz" role="3uHU7B">
+                  <property role="$nhwW" value="11.7" />
+                </node>
+              </node>
+            </node>
+            <node concept="10Oyi0" id="4_xuXPD3mQ$" role="10QFUM" />
+          </node>
+        </node>
+      </node>
+      <node concept="10Oyi0" id="4_xuXPD3mQq" role="3clF45" />
+    </node>
+    <node concept="13i0hz" id="4_xuXPD3mQr" role="13h7CS">
+      <property role="TrG5h" value="heightInMillimeters" />
+      <ref role="13i0hy" node="4_xuXPCBxFM" resolve="heightInInches" />
+      <node concept="3Tm1VV" id="4_xuXPD3mQs" role="1B3o_S" />
+      <node concept="3clFbS" id="4_xuXPD3mQt" role="3clF47">
+        <node concept="3clFbF" id="4_xuXPD3mQj" role="3cqZAp">
+          <node concept="10QFUN" id="4_xuXPD3mQk" role="3clFbG">
+            <node concept="1eOMI4" id="4_xuXPD3mQl" role="10QFUP">
+              <node concept="17qRlL" id="4_xuXPD3mQm" role="1eOMHV">
+                <node concept="3b6qkQ" id="4_xuXPD3mQn" role="3uHU7w">
+                  <property role="$nhwW" value="25.4" />
+                </node>
+                <node concept="3b6qkQ" id="4_xuXPD3mQo" role="3uHU7B">
+                  <property role="$nhwW" value="16.5" />
+                </node>
+              </node>
+            </node>
+            <node concept="10Oyi0" id="4_xuXPD3mQp" role="10QFUM" />
+          </node>
+        </node>
+      </node>
+      <node concept="10Oyi0" id="4_xuXPD3mQ_" role="3clF45" />
+    </node>
+    <node concept="13hLZK" id="4_xuXPD3m$U" role="13h7CW">
+      <node concept="3clFbS" id="4_xuXPD3m$V" role="2VODD2" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="4_xuXPD3$xd">
+    <property role="3GE5qa" value="page_settings" />
+    <ref role="13h7C2" to="b19z:4_xuXPD3$4K" resolve="A5PageLandscape" />
+    <node concept="13i0hz" id="4_xuXPD3$M$" role="13h7CS">
+      <property role="TrG5h" value="widthInMillimeters" />
+      <ref role="13i0hy" node="4_xuXPCBwK4" resolve="widthInInches" />
+      <node concept="3Tm1VV" id="4_xuXPD3$M_" role="1B3o_S" />
+      <node concept="3clFbS" id="4_xuXPD3$MA" role="3clF47">
+        <node concept="3clFbF" id="4_xuXPD3$MB" role="3cqZAp">
+          <node concept="10QFUN" id="4_xuXPD3$MC" role="3clFbG">
+            <node concept="1eOMI4" id="4_xuXPD3$MD" role="10QFUP">
+              <node concept="17qRlL" id="4_xuXPD3$ME" role="1eOMHV">
+                <node concept="3b6qkQ" id="4_xuXPD3$MF" role="3uHU7w">
+                  <property role="$nhwW" value="25.4" />
+                </node>
+                <node concept="3b6qkQ" id="4_xuXPD3_s0" role="3uHU7B">
+                  <property role="$nhwW" value="8.3" />
+                </node>
+              </node>
+            </node>
+            <node concept="10Oyi0" id="4_xuXPD3$MH" role="10QFUM" />
+          </node>
+        </node>
+      </node>
+      <node concept="10Oyi0" id="4_xuXPD3$MI" role="3clF45" />
+    </node>
+    <node concept="13i0hz" id="4_xuXPD3$MJ" role="13h7CS">
+      <property role="TrG5h" value="heightInMillimeters" />
+      <ref role="13i0hy" node="4_xuXPCBxFM" resolve="heightInInches" />
+      <node concept="3Tm1VV" id="4_xuXPD3$MK" role="1B3o_S" />
+      <node concept="3clFbS" id="4_xuXPD3$ML" role="3clF47">
+        <node concept="3clFbF" id="4_xuXPD3$MM" role="3cqZAp">
+          <node concept="10QFUN" id="4_xuXPD3$MN" role="3clFbG">
+            <node concept="1eOMI4" id="4_xuXPD3$MO" role="10QFUP">
+              <node concept="17qRlL" id="4_xuXPD3$MP" role="1eOMHV">
+                <node concept="3b6qkQ" id="4_xuXPD3$MQ" role="3uHU7w">
+                  <property role="$nhwW" value="25.4" />
+                </node>
+                <node concept="3b6qkQ" id="4_xuXPD3_yn" role="3uHU7B">
+                  <property role="$nhwW" value="5.8" />
+                </node>
+              </node>
+            </node>
+            <node concept="10Oyi0" id="4_xuXPD3$MS" role="10QFUM" />
+          </node>
+        </node>
+      </node>
+      <node concept="10Oyi0" id="4_xuXPD3$MT" role="3clF45" />
+    </node>
+    <node concept="13hLZK" id="4_xuXPD3$xe" role="13h7CW">
+      <node concept="3clFbS" id="4_xuXPD3$xf" role="2VODD2" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="4_xuXPD3AMB">
+    <property role="3GE5qa" value="page_settings" />
+    <ref role="13h7C2" to="b19z:4_xuXPD3AaM" resolve="A5PagePortrait" />
+    <node concept="13i0hz" id="4_xuXPD3Bxg" role="13h7CS">
+      <property role="TrG5h" value="widthInMillimeters" />
+      <ref role="13i0hy" node="4_xuXPCBwK4" resolve="widthInInches" />
+      <node concept="3Tm1VV" id="4_xuXPD3Bxh" role="1B3o_S" />
+      <node concept="3clFbS" id="4_xuXPD3Bxi" role="3clF47">
+        <node concept="3clFbF" id="4_xuXPD3Bxu" role="3cqZAp">
+          <node concept="10QFUN" id="4_xuXPD3Bxv" role="3clFbG">
+            <node concept="1eOMI4" id="4_xuXPD3Bxw" role="10QFUP">
+              <node concept="17qRlL" id="4_xuXPD3Bxx" role="1eOMHV">
+                <node concept="3b6qkQ" id="4_xuXPD3Bxy" role="3uHU7w">
+                  <property role="$nhwW" value="25.4" />
+                </node>
+                <node concept="3b6qkQ" id="4_xuXPD3Bxz" role="3uHU7B">
+                  <property role="$nhwW" value="5.8" />
+                </node>
+              </node>
+            </node>
+            <node concept="10Oyi0" id="4_xuXPD3Bx$" role="10QFUM" />
+          </node>
+        </node>
+      </node>
+      <node concept="10Oyi0" id="4_xuXPD3Bxq" role="3clF45" />
+    </node>
+    <node concept="13i0hz" id="4_xuXPD3Bxr" role="13h7CS">
+      <property role="TrG5h" value="heightInMillimeters" />
+      <ref role="13i0hy" node="4_xuXPCBxFM" resolve="heightInInches" />
+      <node concept="3Tm1VV" id="4_xuXPD3Bxs" role="1B3o_S" />
+      <node concept="3clFbS" id="4_xuXPD3Bxt" role="3clF47">
+        <node concept="3clFbF" id="4_xuXPD3Bxj" role="3cqZAp">
+          <node concept="10QFUN" id="4_xuXPD3Bxk" role="3clFbG">
+            <node concept="1eOMI4" id="4_xuXPD3Bxl" role="10QFUP">
+              <node concept="17qRlL" id="4_xuXPD3Bxm" role="1eOMHV">
+                <node concept="3b6qkQ" id="4_xuXPD3Bxn" role="3uHU7w">
+                  <property role="$nhwW" value="25.4" />
+                </node>
+                <node concept="3b6qkQ" id="4_xuXPD3Bxo" role="3uHU7B">
+                  <property role="$nhwW" value="8.3" />
+                </node>
+              </node>
+            </node>
+            <node concept="10Oyi0" id="4_xuXPD3Bxp" role="10QFUM" />
+          </node>
+        </node>
+      </node>
+      <node concept="10Oyi0" id="4_xuXPD3Bx_" role="3clF45" />
+    </node>
+    <node concept="13hLZK" id="4_xuXPD3AMC" role="13h7CW">
+      <node concept="3clFbS" id="4_xuXPD3AMD" role="2VODD2" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="4_xuXPD3EQG">
+    <property role="3GE5qa" value="page_settings" />
+    <ref role="13h7C2" to="b19z:4_xuXPD3EvV" resolve="A2PageLandscape" />
+    <node concept="13i0hz" id="4_xuXPD3FuN" role="13h7CS">
+      <property role="TrG5h" value="widthInMillimeters" />
+      <ref role="13i0hy" node="4_xuXPCBwK4" resolve="widthInInches" />
+      <node concept="3Tm1VV" id="4_xuXPD3FuO" role="1B3o_S" />
+      <node concept="3clFbS" id="4_xuXPD3FuP" role="3clF47">
+        <node concept="3clFbF" id="4_xuXPD3Fv1" role="3cqZAp">
+          <node concept="10QFUN" id="4_xuXPD3Fv2" role="3clFbG">
+            <node concept="1eOMI4" id="4_xuXPD3Fv3" role="10QFUP">
+              <node concept="17qRlL" id="4_xuXPD3Fv4" role="1eOMHV">
+                <node concept="3b6qkQ" id="4_xuXPD3Fv5" role="3uHU7w">
+                  <property role="$nhwW" value="25.4" />
+                </node>
+                <node concept="3b6qkQ" id="4_xuXPD3Fv6" role="3uHU7B">
+                  <property role="$nhwW" value="23.4" />
+                </node>
+              </node>
+            </node>
+            <node concept="10Oyi0" id="4_xuXPD3Fv7" role="10QFUM" />
+          </node>
+        </node>
+      </node>
+      <node concept="10Oyi0" id="4_xuXPD3FuX" role="3clF45" />
+    </node>
+    <node concept="13i0hz" id="4_xuXPD3FuY" role="13h7CS">
+      <property role="TrG5h" value="heightInMillimeters" />
+      <ref role="13i0hy" node="4_xuXPCBxFM" resolve="heightInInches" />
+      <node concept="3Tm1VV" id="4_xuXPD3FuZ" role="1B3o_S" />
+      <node concept="3clFbS" id="4_xuXPD3Fv0" role="3clF47">
+        <node concept="3clFbF" id="4_xuXPD3FuQ" role="3cqZAp">
+          <node concept="10QFUN" id="4_xuXPD3FuR" role="3clFbG">
+            <node concept="1eOMI4" id="4_xuXPD3FuS" role="10QFUP">
+              <node concept="17qRlL" id="4_xuXPD3FuT" role="1eOMHV">
+                <node concept="3b6qkQ" id="4_xuXPD3FuU" role="3uHU7w">
+                  <property role="$nhwW" value="25.4" />
+                </node>
+                <node concept="3b6qkQ" id="4_xuXPD3FuV" role="3uHU7B">
+                  <property role="$nhwW" value="16.5" />
+                </node>
+              </node>
+            </node>
+            <node concept="10Oyi0" id="4_xuXPD3FuW" role="10QFUM" />
+          </node>
+        </node>
+      </node>
+      <node concept="10Oyi0" id="4_xuXPD3Fv8" role="3clF45" />
+    </node>
+    <node concept="13hLZK" id="4_xuXPD3EQH" role="13h7CW">
+      <node concept="3clFbS" id="4_xuXPD3EQI" role="2VODD2" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="4_xuXPD3Ip5">
+    <property role="3GE5qa" value="page_settings" />
+    <ref role="13h7C2" to="b19z:4_xuXPD3HWC" resolve="A2PagePortrait" />
+    <node concept="13i0hz" id="4_xuXPD3J4i" role="13h7CS">
+      <property role="TrG5h" value="widthInMillimeters" />
+      <ref role="13i0hy" node="4_xuXPCBwK4" resolve="widthInInches" />
+      <node concept="3Tm1VV" id="4_xuXPD3J4j" role="1B3o_S" />
+      <node concept="3clFbS" id="4_xuXPD3J4k" role="3clF47">
+        <node concept="3clFbF" id="4_xuXPD3J4w" role="3cqZAp">
+          <node concept="10QFUN" id="4_xuXPD3J4x" role="3clFbG">
+            <node concept="1eOMI4" id="4_xuXPD3J4y" role="10QFUP">
+              <node concept="17qRlL" id="4_xuXPD3J4z" role="1eOMHV">
+                <node concept="3b6qkQ" id="4_xuXPD3J4$" role="3uHU7w">
+                  <property role="$nhwW" value="25.4" />
+                </node>
+                <node concept="3b6qkQ" id="4_xuXPD3J4_" role="3uHU7B">
+                  <property role="$nhwW" value="16.5" />
+                </node>
+              </node>
+            </node>
+            <node concept="10Oyi0" id="4_xuXPD3J4A" role="10QFUM" />
+          </node>
+        </node>
+      </node>
+      <node concept="10Oyi0" id="4_xuXPD3J4s" role="3clF45" />
+    </node>
+    <node concept="13i0hz" id="4_xuXPD3J4t" role="13h7CS">
+      <property role="TrG5h" value="heightInMillimeters" />
+      <ref role="13i0hy" node="4_xuXPCBxFM" resolve="heightInInches" />
+      <node concept="3Tm1VV" id="4_xuXPD3J4u" role="1B3o_S" />
+      <node concept="3clFbS" id="4_xuXPD3J4v" role="3clF47">
+        <node concept="3clFbF" id="4_xuXPD3J4l" role="3cqZAp">
+          <node concept="10QFUN" id="4_xuXPD3J4m" role="3clFbG">
+            <node concept="1eOMI4" id="4_xuXPD3J4n" role="10QFUP">
+              <node concept="17qRlL" id="4_xuXPD3J4o" role="1eOMHV">
+                <node concept="3b6qkQ" id="4_xuXPD3J4p" role="3uHU7w">
+                  <property role="$nhwW" value="25.4" />
+                </node>
+                <node concept="3b6qkQ" id="4_xuXPD3J4q" role="3uHU7B">
+                  <property role="$nhwW" value="23.4" />
+                </node>
+              </node>
+            </node>
+            <node concept="10Oyi0" id="4_xuXPD3J4r" role="10QFUM" />
+          </node>
+        </node>
+      </node>
+      <node concept="10Oyi0" id="4_xuXPD3J4B" role="3clF45" />
+    </node>
+    <node concept="13hLZK" id="4_xuXPD3Ip6" role="13h7CW">
+      <node concept="3clFbS" id="4_xuXPD3Ip7" role="2VODD2" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="1P450_2stOl">
+    <property role="3GE5qa" value="page_settings" />
+    <ref role="13h7C2" to="b19z:1P450_2sti0" resolve="A1PageLandscape" />
+    <node concept="13i0hz" id="1P450_2stPW" role="13h7CS">
+      <property role="TrG5h" value="widthInMillimeters" />
+      <ref role="13i0hy" node="4_xuXPCBwK4" resolve="widthInInches" />
+      <node concept="3Tm1VV" id="1P450_2stPX" role="1B3o_S" />
+      <node concept="3clFbS" id="1P450_2stPY" role="3clF47">
+        <node concept="3clFbF" id="1P450_2stQa" role="3cqZAp">
+          <node concept="10QFUN" id="1P450_2stQb" role="3clFbG">
+            <node concept="1eOMI4" id="1P450_2stQc" role="10QFUP">
+              <node concept="17qRlL" id="1P450_2stQd" role="1eOMHV">
+                <node concept="3b6qkQ" id="1P450_2stQe" role="3uHU7w">
+                  <property role="$nhwW" value="25.4" />
+                </node>
+                <node concept="3b6qkQ" id="1P450_2stQf" role="3uHU7B">
+                  <property role="$nhwW" value="33.1" />
+                </node>
+              </node>
+            </node>
+            <node concept="10Oyi0" id="1P450_2stQg" role="10QFUM" />
+          </node>
+        </node>
+      </node>
+      <node concept="10Oyi0" id="1P450_2stQ6" role="3clF45" />
+    </node>
+    <node concept="13i0hz" id="1P450_2stQ7" role="13h7CS">
+      <property role="TrG5h" value="heightInMillimeters" />
+      <ref role="13i0hy" node="4_xuXPCBxFM" resolve="heightInInches" />
+      <node concept="3Tm1VV" id="1P450_2stQ8" role="1B3o_S" />
+      <node concept="3clFbS" id="1P450_2stQ9" role="3clF47">
+        <node concept="3clFbF" id="1P450_2stPZ" role="3cqZAp">
+          <node concept="10QFUN" id="1P450_2stQ0" role="3clFbG">
+            <node concept="1eOMI4" id="1P450_2stQ1" role="10QFUP">
+              <node concept="17qRlL" id="1P450_2stQ2" role="1eOMHV">
+                <node concept="3b6qkQ" id="1P450_2stQ3" role="3uHU7w">
+                  <property role="$nhwW" value="25.4" />
+                </node>
+                <node concept="3b6qkQ" id="1P450_2stQ4" role="3uHU7B">
+                  <property role="$nhwW" value="23.4" />
+                </node>
+              </node>
+            </node>
+            <node concept="10Oyi0" id="1P450_2stQ5" role="10QFUM" />
+          </node>
+        </node>
+      </node>
+      <node concept="10Oyi0" id="1P450_2stQh" role="3clF45" />
+    </node>
+    <node concept="13hLZK" id="1P450_2stOm" role="13h7CW">
+      <node concept="3clFbS" id="1P450_2stOn" role="2VODD2" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="1P450_2sw$9">
+    <property role="3GE5qa" value="page_settings" />
+    <ref role="13h7C2" to="b19z:1P450_2sw0G" resolve="A1PagePortrait" />
+    <node concept="13i0hz" id="1P450_2sw_6" role="13h7CS">
+      <property role="TrG5h" value="widthInMillimeters" />
+      <ref role="13i0hy" node="4_xuXPCBwK4" resolve="widthInInches" />
+      <node concept="3Tm1VV" id="1P450_2sw_7" role="1B3o_S" />
+      <node concept="3clFbS" id="1P450_2sw_8" role="3clF47">
+        <node concept="3clFbF" id="1P450_2sw_k" role="3cqZAp">
+          <node concept="10QFUN" id="1P450_2sw_l" role="3clFbG">
+            <node concept="1eOMI4" id="1P450_2sw_m" role="10QFUP">
+              <node concept="17qRlL" id="1P450_2sw_n" role="1eOMHV">
+                <node concept="3b6qkQ" id="1P450_2sw_o" role="3uHU7w">
+                  <property role="$nhwW" value="25.4" />
+                </node>
+                <node concept="3b6qkQ" id="1P450_2sw_p" role="3uHU7B">
+                  <property role="$nhwW" value="23.4" />
+                </node>
+              </node>
+            </node>
+            <node concept="10Oyi0" id="1P450_2sw_q" role="10QFUM" />
+          </node>
+        </node>
+      </node>
+      <node concept="10Oyi0" id="1P450_2sw_g" role="3clF45" />
+    </node>
+    <node concept="13i0hz" id="1P450_2sw_h" role="13h7CS">
+      <property role="TrG5h" value="heightInMillimeters" />
+      <ref role="13i0hy" node="4_xuXPCBxFM" resolve="heightInInches" />
+      <node concept="3Tm1VV" id="1P450_2sw_i" role="1B3o_S" />
+      <node concept="3clFbS" id="1P450_2sw_j" role="3clF47">
+        <node concept="3clFbF" id="1P450_2sw_9" role="3cqZAp">
+          <node concept="10QFUN" id="1P450_2sw_a" role="3clFbG">
+            <node concept="1eOMI4" id="1P450_2sw_b" role="10QFUP">
+              <node concept="17qRlL" id="1P450_2sw_c" role="1eOMHV">
+                <node concept="3b6qkQ" id="1P450_2sw_d" role="3uHU7w">
+                  <property role="$nhwW" value="25.4" />
+                </node>
+                <node concept="3b6qkQ" id="1P450_2sw_e" role="3uHU7B">
+                  <property role="$nhwW" value="33.1" />
+                </node>
+              </node>
+            </node>
+            <node concept="10Oyi0" id="1P450_2sw_f" role="10QFUM" />
+          </node>
+        </node>
+      </node>
+      <node concept="10Oyi0" id="1P450_2sw_r" role="3clF45" />
+    </node>
+    <node concept="13hLZK" id="1P450_2sw$a" role="13h7CW">
+      <node concept="3clFbS" id="1P450_2sw$b" role="2VODD2" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="1P450_2s$bZ">
+    <property role="3GE5qa" value="page_settings" />
+    <ref role="13h7C2" to="b19z:1P450_2s$64" resolve="A0PageLandscape" />
+    <node concept="13i0hz" id="1P450_2s$gU" role="13h7CS">
+      <property role="TrG5h" value="widthInMillimeters" />
+      <ref role="13i0hy" node="4_xuXPCBwK4" resolve="widthInInches" />
+      <node concept="3Tm1VV" id="1P450_2s$gV" role="1B3o_S" />
+      <node concept="3clFbS" id="1P450_2s$gW" role="3clF47">
+        <node concept="3clFbF" id="1P450_2s$h8" role="3cqZAp">
+          <node concept="10QFUN" id="1P450_2s$h9" role="3clFbG">
+            <node concept="1eOMI4" id="1P450_2s$ha" role="10QFUP">
+              <node concept="17qRlL" id="1P450_2s$hb" role="1eOMHV">
+                <node concept="3b6qkQ" id="1P450_2s$hc" role="3uHU7w">
+                  <property role="$nhwW" value="25.4" />
+                </node>
+                <node concept="3b6qkQ" id="1P450_2s$hd" role="3uHU7B">
+                  <property role="$nhwW" value="46.8" />
+                </node>
+              </node>
+            </node>
+            <node concept="10Oyi0" id="1P450_2s$he" role="10QFUM" />
+          </node>
+        </node>
+      </node>
+      <node concept="10Oyi0" id="1P450_2s$h4" role="3clF45" />
+    </node>
+    <node concept="13i0hz" id="1P450_2s$h5" role="13h7CS">
+      <property role="TrG5h" value="heightInMillimeters" />
+      <ref role="13i0hy" node="4_xuXPCBxFM" resolve="heightInInches" />
+      <node concept="3Tm1VV" id="1P450_2s$h6" role="1B3o_S" />
+      <node concept="3clFbS" id="1P450_2s$h7" role="3clF47">
+        <node concept="3clFbF" id="1P450_2s$gX" role="3cqZAp">
+          <node concept="10QFUN" id="1P450_2s$gY" role="3clFbG">
+            <node concept="1eOMI4" id="1P450_2s$gZ" role="10QFUP">
+              <node concept="17qRlL" id="1P450_2s$h0" role="1eOMHV">
+                <node concept="3b6qkQ" id="1P450_2s$h1" role="3uHU7w">
+                  <property role="$nhwW" value="25.4" />
+                </node>
+                <node concept="3b6qkQ" id="1P450_2s$h2" role="3uHU7B">
+                  <property role="$nhwW" value="33.1" />
+                </node>
+              </node>
+            </node>
+            <node concept="10Oyi0" id="1P450_2s$h3" role="10QFUM" />
+          </node>
+        </node>
+      </node>
+      <node concept="10Oyi0" id="1P450_2s$hf" role="3clF45" />
+    </node>
+    <node concept="13hLZK" id="1P450_2s$c0" role="13h7CW">
+      <node concept="3clFbS" id="1P450_2s$c1" role="2VODD2" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="1P450_2sA6T">
+    <property role="3GE5qa" value="page_settings" />
+    <ref role="13h7C2" to="b19z:1P450_2sA0k" resolve="A0PagePortrait" />
+    <node concept="13i0hz" id="1P450_2sAb8" role="13h7CS">
+      <property role="TrG5h" value="widthInMillimeters" />
+      <ref role="13i0hy" node="4_xuXPCBwK4" resolve="widthInInches" />
+      <node concept="3Tm1VV" id="1P450_2sAb9" role="1B3o_S" />
+      <node concept="3clFbS" id="1P450_2sAba" role="3clF47">
+        <node concept="3clFbF" id="1P450_2sAbm" role="3cqZAp">
+          <node concept="10QFUN" id="1P450_2sAbn" role="3clFbG">
+            <node concept="1eOMI4" id="1P450_2sAbo" role="10QFUP">
+              <node concept="17qRlL" id="1P450_2sAbp" role="1eOMHV">
+                <node concept="3b6qkQ" id="1P450_2sAbq" role="3uHU7w">
+                  <property role="$nhwW" value="25.4" />
+                </node>
+                <node concept="3b6qkQ" id="1P450_2sAbr" role="3uHU7B">
+                  <property role="$nhwW" value="33.1" />
+                </node>
+              </node>
+            </node>
+            <node concept="10Oyi0" id="1P450_2sAbs" role="10QFUM" />
+          </node>
+        </node>
+      </node>
+      <node concept="10Oyi0" id="1P450_2sAbi" role="3clF45" />
+    </node>
+    <node concept="13i0hz" id="1P450_2sAbj" role="13h7CS">
+      <property role="TrG5h" value="heightInMillimeters" />
+      <ref role="13i0hy" node="4_xuXPCBxFM" resolve="heightInInches" />
+      <node concept="3Tm1VV" id="1P450_2sAbk" role="1B3o_S" />
+      <node concept="3clFbS" id="1P450_2sAbl" role="3clF47">
+        <node concept="3clFbF" id="1P450_2sAbb" role="3cqZAp">
+          <node concept="10QFUN" id="1P450_2sAbc" role="3clFbG">
+            <node concept="1eOMI4" id="1P450_2sAbd" role="10QFUP">
+              <node concept="17qRlL" id="1P450_2sAbe" role="1eOMHV">
+                <node concept="3b6qkQ" id="1P450_2sAbf" role="3uHU7w">
+                  <property role="$nhwW" value="25.4" />
+                </node>
+                <node concept="3b6qkQ" id="1P450_2sAbg" role="3uHU7B">
+                  <property role="$nhwW" value="46.8" />
+                </node>
+              </node>
+            </node>
+            <node concept="10Oyi0" id="1P450_2sAbh" role="10QFUM" />
+          </node>
+        </node>
+      </node>
+      <node concept="10Oyi0" id="1P450_2sAbt" role="3clF45" />
+    </node>
+    <node concept="13hLZK" id="1P450_2sA6U" role="13h7CW">
+      <node concept="3clFbS" id="1P450_2sA6V" role="2VODD2" />
     </node>
   </node>
 </model>

--- a/code/languages/com.mbeddr.formal.nusmv/languages/com.mbeddr.formal.base/models/behavior.mps
+++ b/code/languages/com.mbeddr.formal.nusmv/languages/com.mbeddr.formal.base/models/behavior.mps
@@ -892,7 +892,7 @@
             <node concept="2OqwBi" id="4_xuXPCUsNT" role="37vLTJ">
               <node concept="13iPFW" id="4_xuXPCUsNU" role="2Oq$k0" />
               <node concept="3TrEf2" id="4_xuXPCUsNV" role="2OqNvi">
-                <ref role="3Tt5mk" to="b19z:4_xuXPCPANd" />
+                <ref role="3Tt5mk" to="b19z:4_xuXPCPANd" resolve="bottomRight" />
               </node>
             </node>
           </node>
@@ -908,7 +908,7 @@
     </node>
     <node concept="13i0hz" id="4_xuXPCByUb" role="13h7CS">
       <property role="TrG5h" value="widthInMillimeters" />
-      <ref role="13i0hy" node="4_xuXPCBwK4" resolve="widthInInches" />
+      <ref role="13i0hy" node="4_xuXPCBwK4" resolve="widthInMillimeters" />
       <node concept="3Tm1VV" id="4_xuXPCByUc" role="1B3o_S" />
       <node concept="3clFbS" id="4_xuXPCByUf" role="3clF47">
         <node concept="3clFbF" id="4_xuXPCByUi" role="3cqZAp">
@@ -931,7 +931,7 @@
     </node>
     <node concept="13i0hz" id="4_xuXPCByUj" role="13h7CS">
       <property role="TrG5h" value="heightInMillimeters" />
-      <ref role="13i0hy" node="4_xuXPCBxFM" resolve="heightInInches" />
+      <ref role="13i0hy" node="4_xuXPCBxFM" resolve="heightInMillimeters" />
       <node concept="3Tm1VV" id="4_xuXPCByUk" role="1B3o_S" />
       <node concept="3clFbS" id="4_xuXPCByUn" role="3clF47">
         <node concept="3clFbF" id="4_xuXPCBLkw" role="3cqZAp">
@@ -958,7 +958,7 @@
     <ref role="13h7C2" to="b19z:4_xuXPCBSAy" resolve="A4PageLandscape" />
     <node concept="13i0hz" id="4_xuXPCBUYv" role="13h7CS">
       <property role="TrG5h" value="widthInMillimeters" />
-      <ref role="13i0hy" node="4_xuXPCBwK4" resolve="widthInInches" />
+      <ref role="13i0hy" node="4_xuXPCBwK4" resolve="widthInMillimeters" />
       <node concept="3Tm1VV" id="4_xuXPCBUYw" role="1B3o_S" />
       <node concept="3clFbS" id="4_xuXPCBUYx" role="3clF47">
         <node concept="3clFbF" id="4_xuXPCBUYH" role="3cqZAp">
@@ -981,7 +981,7 @@
     </node>
     <node concept="13i0hz" id="4_xuXPCBUYE" role="13h7CS">
       <property role="TrG5h" value="heightInMillimeters" />
-      <ref role="13i0hy" node="4_xuXPCBxFM" resolve="heightInInches" />
+      <ref role="13i0hy" node="4_xuXPCBxFM" resolve="heightInMillimeters" />
       <node concept="3Tm1VV" id="4_xuXPCBUYF" role="1B3o_S" />
       <node concept="3clFbS" id="4_xuXPCBUYG" role="3clF47">
         <node concept="3clFbF" id="4_xuXPCBUYy" role="3cqZAp">
@@ -1018,7 +1018,7 @@
     <ref role="13h7C2" to="b19z:4_xuXPD3jwz" resolve="A3PageLandscape" />
     <node concept="13i0hz" id="4_xuXPD3k_X" role="13h7CS">
       <property role="TrG5h" value="widthInMillimeters" />
-      <ref role="13i0hy" node="4_xuXPCBwK4" resolve="widthInInches" />
+      <ref role="13i0hy" node="4_xuXPCBwK4" resolve="widthInMillimeters" />
       <node concept="3Tm1VV" id="4_xuXPD3k_Y" role="1B3o_S" />
       <node concept="3clFbS" id="4_xuXPD3k_Z" role="3clF47">
         <node concept="3clFbF" id="4_xuXPD3kA0" role="3cqZAp">
@@ -1041,7 +1041,7 @@
     </node>
     <node concept="13i0hz" id="4_xuXPD3kA8" role="13h7CS">
       <property role="TrG5h" value="heightInMillimeters" />
-      <ref role="13i0hy" node="4_xuXPCBxFM" resolve="heightInInches" />
+      <ref role="13i0hy" node="4_xuXPCBxFM" resolve="heightInMillimeters" />
       <node concept="3Tm1VV" id="4_xuXPD3kA9" role="1B3o_S" />
       <node concept="3clFbS" id="4_xuXPD3kAa" role="3clF47">
         <node concept="3clFbF" id="4_xuXPD3kAb" role="3cqZAp">
@@ -1071,7 +1071,7 @@
     <ref role="13h7C2" to="b19z:4_xuXPD3lZU" resolve="A3PagePortrait" />
     <node concept="13i0hz" id="4_xuXPD3mQg" role="13h7CS">
       <property role="TrG5h" value="widthInMillimeters" />
-      <ref role="13i0hy" node="4_xuXPCBwK4" resolve="widthInInches" />
+      <ref role="13i0hy" node="4_xuXPCBwK4" resolve="widthInMillimeters" />
       <node concept="3Tm1VV" id="4_xuXPD3mQh" role="1B3o_S" />
       <node concept="3clFbS" id="4_xuXPD3mQi" role="3clF47">
         <node concept="3clFbF" id="4_xuXPD3mQu" role="3cqZAp">
@@ -1094,7 +1094,7 @@
     </node>
     <node concept="13i0hz" id="4_xuXPD3mQr" role="13h7CS">
       <property role="TrG5h" value="heightInMillimeters" />
-      <ref role="13i0hy" node="4_xuXPCBxFM" resolve="heightInInches" />
+      <ref role="13i0hy" node="4_xuXPCBxFM" resolve="heightInMillimeters" />
       <node concept="3Tm1VV" id="4_xuXPD3mQs" role="1B3o_S" />
       <node concept="3clFbS" id="4_xuXPD3mQt" role="3clF47">
         <node concept="3clFbF" id="4_xuXPD3mQj" role="3cqZAp">
@@ -1124,7 +1124,7 @@
     <ref role="13h7C2" to="b19z:4_xuXPD3$4K" resolve="A5PageLandscape" />
     <node concept="13i0hz" id="4_xuXPD3$M$" role="13h7CS">
       <property role="TrG5h" value="widthInMillimeters" />
-      <ref role="13i0hy" node="4_xuXPCBwK4" resolve="widthInInches" />
+      <ref role="13i0hy" node="4_xuXPCBwK4" resolve="widthInMillimeters" />
       <node concept="3Tm1VV" id="4_xuXPD3$M_" role="1B3o_S" />
       <node concept="3clFbS" id="4_xuXPD3$MA" role="3clF47">
         <node concept="3clFbF" id="4_xuXPD3$MB" role="3cqZAp">
@@ -1147,7 +1147,7 @@
     </node>
     <node concept="13i0hz" id="4_xuXPD3$MJ" role="13h7CS">
       <property role="TrG5h" value="heightInMillimeters" />
-      <ref role="13i0hy" node="4_xuXPCBxFM" resolve="heightInInches" />
+      <ref role="13i0hy" node="4_xuXPCBxFM" resolve="heightInMillimeters" />
       <node concept="3Tm1VV" id="4_xuXPD3$MK" role="1B3o_S" />
       <node concept="3clFbS" id="4_xuXPD3$ML" role="3clF47">
         <node concept="3clFbF" id="4_xuXPD3$MM" role="3cqZAp">
@@ -1177,7 +1177,7 @@
     <ref role="13h7C2" to="b19z:4_xuXPD3AaM" resolve="A5PagePortrait" />
     <node concept="13i0hz" id="4_xuXPD3Bxg" role="13h7CS">
       <property role="TrG5h" value="widthInMillimeters" />
-      <ref role="13i0hy" node="4_xuXPCBwK4" resolve="widthInInches" />
+      <ref role="13i0hy" node="4_xuXPCBwK4" resolve="widthInMillimeters" />
       <node concept="3Tm1VV" id="4_xuXPD3Bxh" role="1B3o_S" />
       <node concept="3clFbS" id="4_xuXPD3Bxi" role="3clF47">
         <node concept="3clFbF" id="4_xuXPD3Bxu" role="3cqZAp">
@@ -1200,7 +1200,7 @@
     </node>
     <node concept="13i0hz" id="4_xuXPD3Bxr" role="13h7CS">
       <property role="TrG5h" value="heightInMillimeters" />
-      <ref role="13i0hy" node="4_xuXPCBxFM" resolve="heightInInches" />
+      <ref role="13i0hy" node="4_xuXPCBxFM" resolve="heightInMillimeters" />
       <node concept="3Tm1VV" id="4_xuXPD3Bxs" role="1B3o_S" />
       <node concept="3clFbS" id="4_xuXPD3Bxt" role="3clF47">
         <node concept="3clFbF" id="4_xuXPD3Bxj" role="3cqZAp">
@@ -1230,7 +1230,7 @@
     <ref role="13h7C2" to="b19z:4_xuXPD3EvV" resolve="A2PageLandscape" />
     <node concept="13i0hz" id="4_xuXPD3FuN" role="13h7CS">
       <property role="TrG5h" value="widthInMillimeters" />
-      <ref role="13i0hy" node="4_xuXPCBwK4" resolve="widthInInches" />
+      <ref role="13i0hy" node="4_xuXPCBwK4" resolve="widthInMillimeters" />
       <node concept="3Tm1VV" id="4_xuXPD3FuO" role="1B3o_S" />
       <node concept="3clFbS" id="4_xuXPD3FuP" role="3clF47">
         <node concept="3clFbF" id="4_xuXPD3Fv1" role="3cqZAp">
@@ -1253,7 +1253,7 @@
     </node>
     <node concept="13i0hz" id="4_xuXPD3FuY" role="13h7CS">
       <property role="TrG5h" value="heightInMillimeters" />
-      <ref role="13i0hy" node="4_xuXPCBxFM" resolve="heightInInches" />
+      <ref role="13i0hy" node="4_xuXPCBxFM" resolve="heightInMillimeters" />
       <node concept="3Tm1VV" id="4_xuXPD3FuZ" role="1B3o_S" />
       <node concept="3clFbS" id="4_xuXPD3Fv0" role="3clF47">
         <node concept="3clFbF" id="4_xuXPD3FuQ" role="3cqZAp">
@@ -1283,7 +1283,7 @@
     <ref role="13h7C2" to="b19z:4_xuXPD3HWC" resolve="A2PagePortrait" />
     <node concept="13i0hz" id="4_xuXPD3J4i" role="13h7CS">
       <property role="TrG5h" value="widthInMillimeters" />
-      <ref role="13i0hy" node="4_xuXPCBwK4" resolve="widthInInches" />
+      <ref role="13i0hy" node="4_xuXPCBwK4" resolve="widthInMillimeters" />
       <node concept="3Tm1VV" id="4_xuXPD3J4j" role="1B3o_S" />
       <node concept="3clFbS" id="4_xuXPD3J4k" role="3clF47">
         <node concept="3clFbF" id="4_xuXPD3J4w" role="3cqZAp">
@@ -1306,7 +1306,7 @@
     </node>
     <node concept="13i0hz" id="4_xuXPD3J4t" role="13h7CS">
       <property role="TrG5h" value="heightInMillimeters" />
-      <ref role="13i0hy" node="4_xuXPCBxFM" resolve="heightInInches" />
+      <ref role="13i0hy" node="4_xuXPCBxFM" resolve="heightInMillimeters" />
       <node concept="3Tm1VV" id="4_xuXPD3J4u" role="1B3o_S" />
       <node concept="3clFbS" id="4_xuXPD3J4v" role="3clF47">
         <node concept="3clFbF" id="4_xuXPD3J4l" role="3cqZAp">
@@ -1336,7 +1336,7 @@
     <ref role="13h7C2" to="b19z:1P450_2sti0" resolve="A1PageLandscape" />
     <node concept="13i0hz" id="1P450_2stPW" role="13h7CS">
       <property role="TrG5h" value="widthInMillimeters" />
-      <ref role="13i0hy" node="4_xuXPCBwK4" resolve="widthInInches" />
+      <ref role="13i0hy" node="4_xuXPCBwK4" resolve="widthInMillimeters" />
       <node concept="3Tm1VV" id="1P450_2stPX" role="1B3o_S" />
       <node concept="3clFbS" id="1P450_2stPY" role="3clF47">
         <node concept="3clFbF" id="1P450_2stQa" role="3cqZAp">
@@ -1359,7 +1359,7 @@
     </node>
     <node concept="13i0hz" id="1P450_2stQ7" role="13h7CS">
       <property role="TrG5h" value="heightInMillimeters" />
-      <ref role="13i0hy" node="4_xuXPCBxFM" resolve="heightInInches" />
+      <ref role="13i0hy" node="4_xuXPCBxFM" resolve="heightInMillimeters" />
       <node concept="3Tm1VV" id="1P450_2stQ8" role="1B3o_S" />
       <node concept="3clFbS" id="1P450_2stQ9" role="3clF47">
         <node concept="3clFbF" id="1P450_2stPZ" role="3cqZAp">
@@ -1389,7 +1389,7 @@
     <ref role="13h7C2" to="b19z:1P450_2sw0G" resolve="A1PagePortrait" />
     <node concept="13i0hz" id="1P450_2sw_6" role="13h7CS">
       <property role="TrG5h" value="widthInMillimeters" />
-      <ref role="13i0hy" node="4_xuXPCBwK4" resolve="widthInInches" />
+      <ref role="13i0hy" node="4_xuXPCBwK4" resolve="widthInMillimeters" />
       <node concept="3Tm1VV" id="1P450_2sw_7" role="1B3o_S" />
       <node concept="3clFbS" id="1P450_2sw_8" role="3clF47">
         <node concept="3clFbF" id="1P450_2sw_k" role="3cqZAp">
@@ -1412,7 +1412,7 @@
     </node>
     <node concept="13i0hz" id="1P450_2sw_h" role="13h7CS">
       <property role="TrG5h" value="heightInMillimeters" />
-      <ref role="13i0hy" node="4_xuXPCBxFM" resolve="heightInInches" />
+      <ref role="13i0hy" node="4_xuXPCBxFM" resolve="heightInMillimeters" />
       <node concept="3Tm1VV" id="1P450_2sw_i" role="1B3o_S" />
       <node concept="3clFbS" id="1P450_2sw_j" role="3clF47">
         <node concept="3clFbF" id="1P450_2sw_9" role="3cqZAp">
@@ -1442,7 +1442,7 @@
     <ref role="13h7C2" to="b19z:1P450_2s$64" resolve="A0PageLandscape" />
     <node concept="13i0hz" id="1P450_2s$gU" role="13h7CS">
       <property role="TrG5h" value="widthInMillimeters" />
-      <ref role="13i0hy" node="4_xuXPCBwK4" resolve="widthInInches" />
+      <ref role="13i0hy" node="4_xuXPCBwK4" resolve="widthInMillimeters" />
       <node concept="3Tm1VV" id="1P450_2s$gV" role="1B3o_S" />
       <node concept="3clFbS" id="1P450_2s$gW" role="3clF47">
         <node concept="3clFbF" id="1P450_2s$h8" role="3cqZAp">
@@ -1465,7 +1465,7 @@
     </node>
     <node concept="13i0hz" id="1P450_2s$h5" role="13h7CS">
       <property role="TrG5h" value="heightInMillimeters" />
-      <ref role="13i0hy" node="4_xuXPCBxFM" resolve="heightInInches" />
+      <ref role="13i0hy" node="4_xuXPCBxFM" resolve="heightInMillimeters" />
       <node concept="3Tm1VV" id="1P450_2s$h6" role="1B3o_S" />
       <node concept="3clFbS" id="1P450_2s$h7" role="3clF47">
         <node concept="3clFbF" id="1P450_2s$gX" role="3cqZAp">
@@ -1495,7 +1495,7 @@
     <ref role="13h7C2" to="b19z:1P450_2sA0k" resolve="A0PagePortrait" />
     <node concept="13i0hz" id="1P450_2sAb8" role="13h7CS">
       <property role="TrG5h" value="widthInMillimeters" />
-      <ref role="13i0hy" node="4_xuXPCBwK4" resolve="widthInInches" />
+      <ref role="13i0hy" node="4_xuXPCBwK4" resolve="widthInMillimeters" />
       <node concept="3Tm1VV" id="1P450_2sAb9" role="1B3o_S" />
       <node concept="3clFbS" id="1P450_2sAba" role="3clF47">
         <node concept="3clFbF" id="1P450_2sAbm" role="3cqZAp">
@@ -1518,7 +1518,7 @@
     </node>
     <node concept="13i0hz" id="1P450_2sAbj" role="13h7CS">
       <property role="TrG5h" value="heightInMillimeters" />
-      <ref role="13i0hy" node="4_xuXPCBxFM" resolve="heightInInches" />
+      <ref role="13i0hy" node="4_xuXPCBxFM" resolve="heightInMillimeters" />
       <node concept="3Tm1VV" id="1P450_2sAbk" role="1B3o_S" />
       <node concept="3clFbS" id="1P450_2sAbl" role="3clF47">
         <node concept="3clFbF" id="1P450_2sAbb" role="3cqZAp">

--- a/code/languages/com.mbeddr.formal.nusmv/languages/com.mbeddr.formal.base/models/editor.mps
+++ b/code/languages/com.mbeddr.formal.nusmv/languages/com.mbeddr.formal.base/models/editor.mps
@@ -5061,7 +5061,7 @@
               </node>
               <node concept="3cpWs3" id="4_xuXPCLIxk" role="37wK5m">
                 <node concept="37vLTw" id="4_xuXPCLJGW" role="3uHU7w">
-                  <ref role="3cqZAo" node="4_xuXPCLIGA" resolve="lineSize" />
+                  <ref role="3cqZAo" node="4_xuXPCLIGA" resolve="LINE_SIZE" />
                 </node>
                 <node concept="37vLTw" id="4_xuXPCLGyo" role="3uHU7B">
                   <ref role="3cqZAo" node="4_xuXPCKLK4" resolve="LEFT_PADDING" />
@@ -5115,7 +5115,7 @@
         <property role="3F0ifm" value="Page Setting:" />
       </node>
       <node concept="3F1sOY" id="4_xuXPCBZAe" role="3EZMnx">
-        <ref role="1NtTu8" to="b19z:4_xuXPCBYpe" />
+        <ref role="1NtTu8" to="b19z:4_xuXPCBYpe" resolve="pageSetting" />
         <node concept="2w$q5c" id="4_xuXPCCoZW" role="3xwHhi">
           <node concept="2aJ2om" id="4_xuXPCCoZX" role="2w$qW5">
             <ref role="2$4xQ3" node="4_xuXPCCof$" resolve="PAGE_SETTING_TEXTUAL" />

--- a/code/languages/com.mbeddr.formal.nusmv/languages/com.mbeddr.formal.base/models/editor.mps
+++ b/code/languages/com.mbeddr.formal.nusmv/languages/com.mbeddr.formal.base/models/editor.mps
@@ -16,11 +16,9 @@
     <import index="z60i" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt(JDK/)" />
     <import index="dxuu" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:javax.swing(JDK/)" />
     <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" />
-    <import index="jan3" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt.image(JDK/)" />
     <import index="exr9" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor(MPS.Editor/)" />
     <import index="g51k" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.cells(MPS.Editor/)" />
     <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" />
-    <import index="mhfm" ref="3f233e7f-b8a6-46d2-a57f-795d56775243/java:org.jetbrains.annotations(Annotations/)" />
     <import index="sn11" ref="r:836426ab-a6f4-4fa3-9a9c-34c02ed6ab5d(jetbrains.mps.ide.icons)" />
     <import index="b19z" ref="r:11a68676-9d63-4e1c-b920-59aefe77def3(com.mbeddr.formal.base.structure)" />
     <import index="hyam" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt.event(JDK/)" />
@@ -30,15 +28,12 @@
     <import index="9z78" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:javax.swing.border(JDK/)" />
     <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" />
     <import index="f4zo" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.cells(MPS.Editor/)" />
-    <import index="mc8f" ref="r:02240f59-d215-4642-b459-56f9f2ccb58d(de.itemis.mps.editor.celllayout.runtime.cells)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
     <import index="b3bi" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.editor.runtime.impl.cellActions(MPS.Editor/)" />
-    <import index="xnls" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide.icons(MPS.Platform/)" />
     <import index="c9r8" ref="r:7a0d71dd-b922-4116-87c2-af6c95c3f7c3(com.mbeddr.formal.base.tooling.results_model)" />
     <import index="e57x" ref="r:99808a14-1913-4248-aed8-3139a5d05f88(com.mbeddr.formal.base.styles)" />
     <import index="iihn" ref="r:1ca0ad9f-f283-47a0-9785-0fcac08d0fee(com.mbeddr.formal.base.prefixed_names_utils)" />
     <import index="w873" ref="r:0de03bcd-6ad8-423c-b85e-ae3dd18ed2b3(com.mbeddr.formal.base.behavior)" />
-    <import index="tpce" ref="r:00000000-0000-4000-0000-011c89590292(jetbrains.mps.lang.structure.structure)" />
     <import index="htnt" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:javax.swing.plaf.basic(JDK/)" />
     <import index="g1qu" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.util.ui(MPS.IDEA/)" />
     <import index="orxl" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:javax.swing.plaf(JDK/)" />
@@ -47,8 +42,6 @@
     <import index="1ks0" ref="r:3f04aa5b-eee7-48ea-a2c7-fc975c7f8656(com.mpsbasics.core.editor)" />
     <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" />
     <import index="48kf" ref="r:5f41c82d-84d1-4fb1-a1cf-6697d2365854(com.mbeddr.mpsutil.filepicker.behavior)" />
-    <import index="py52" ref="r:14bd9e1a-63cf-4fde-816f-1d68e4acbfba(com.mbeddr.formal.safety.gsn.structure)" />
-    <import index="95j3" ref="r:b59c48c6-3515-4a72-8146-4b8c723b8307(com.mbeddr.formal.base.diagram_utils)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
     <import index="tpco" ref="r:00000000-0000-4000-0000-011c89590284(jetbrains.mps.lang.core.editor)" implicit="true" />
   </imports>

--- a/code/languages/com.mbeddr.formal.nusmv/languages/com.mbeddr.formal.base/models/editor.mps
+++ b/code/languages/com.mbeddr.formal.nusmv/languages/com.mbeddr.formal.base/models/editor.mps
@@ -47,7 +47,10 @@
     <import index="1ks0" ref="r:3f04aa5b-eee7-48ea-a2c7-fc975c7f8656(com.mpsbasics.core.editor)" />
     <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" />
     <import index="48kf" ref="r:5f41c82d-84d1-4fb1-a1cf-6697d2365854(com.mbeddr.mpsutil.filepicker.behavior)" />
+    <import index="py52" ref="r:14bd9e1a-63cf-4fde-816f-1d68e4acbfba(com.mbeddr.formal.safety.gsn.structure)" />
+    <import index="95j3" ref="r:b59c48c6-3515-4a72-8146-4b8c723b8307(com.mbeddr.formal.base.diagram_utils)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
+    <import index="tpco" ref="r:00000000-0000-4000-0000-011c89590284(jetbrains.mps.lang.core.editor)" implicit="true" />
   </imports>
   <registry>
     <language id="982eb8df-2c96-4bd7-9963-11712ea622e5" name="jetbrains.mps.lang.resources">
@@ -61,7 +64,9 @@
     <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
       <concept id="1402906326895675325" name="jetbrains.mps.lang.editor.structure.CellActionMap_FunctionParm_selectedNode" flags="nn" index="0IXxy" />
       <concept id="5991739802479784073" name="jetbrains.mps.lang.editor.structure.MenuTypeDefault" flags="ng" index="22hDWj" />
-      <concept id="1071666914219" name="jetbrains.mps.lang.editor.structure.ConceptEditorDeclaration" flags="ig" index="24kQdi" />
+      <concept id="1071666914219" name="jetbrains.mps.lang.editor.structure.ConceptEditorDeclaration" flags="ig" index="24kQdi">
+        <child id="2597348684684069742" name="contextHints" index="CpUAK" />
+      </concept>
       <concept id="1164052439493" name="jetbrains.mps.lang.editor.structure.CellMenuPart_AbstractGroup_MatchingText" flags="in" index="6VE3a" />
       <concept id="1597643335227097138" name="jetbrains.mps.lang.editor.structure.QueryFunctionParameter_TransformationMenu_node" flags="ng" index="7Obwk" />
       <concept id="6516520003787916624" name="jetbrains.mps.lang.editor.structure.QueryFunction_TransformationMenu_Condition" flags="ig" index="27VH4U" />
@@ -209,7 +214,9 @@
       <concept id="1219418625346" name="jetbrains.mps.lang.editor.structure.IStyleContainer" flags="ngI" index="3F0Thp">
         <child id="1219418656006" name="styleItem" index="3F10Kt" />
       </concept>
-      <concept id="1073389882823" name="jetbrains.mps.lang.editor.structure.CellModel_RefNode" flags="sg" stub="730538219795960754" index="3F1sOY" />
+      <concept id="1073389882823" name="jetbrains.mps.lang.editor.structure.CellModel_RefNode" flags="sg" stub="730538219795960754" index="3F1sOY">
+        <child id="5861024100072578575" name="addHints" index="3xwHhi" />
+      </concept>
       <concept id="1073390211982" name="jetbrains.mps.lang.editor.structure.CellModel_RefNodeList" flags="sg" stub="2794558372793454595" index="3F2HdR">
         <child id="7279578193766667846" name="addHints" index="78xua" />
       </concept>
@@ -269,6 +276,7 @@
       <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ngI" index="2AJDlI">
         <child id="1188208488637" name="annotation" index="2AJF6D" />
       </concept>
+      <concept id="1095950406618" name="jetbrains.mps.baseLanguage.structure.DivExpression" flags="nn" index="FJ1c_" />
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
@@ -332,6 +340,9 @@
       <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="nn" index="17R0WA" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1111509017652" name="jetbrains.mps.baseLanguage.structure.FloatingPointConstant" flags="nn" index="3b6qkQ">
+        <property id="1113006610751" name="value" index="$nhwW" />
       </concept>
       <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
         <property id="4276006055363816570" name="isSynchronized" index="od$2w" />
@@ -450,13 +461,38 @@
       </concept>
     </language>
     <language id="fa13cc63-c476-4d46-9c96-d53670abe7bc" name="de.itemis.mps.editor.diagram">
+      <concept id="7462505633627560581" name="de.itemis.mps.editor.diagram.structure.DrawNoShadow" flags="ig" index="2lafZg" />
+      <concept id="7464726264117247548" name="de.itemis.mps.editor.diagram.structure.ShapeDefinition" flags="ng" index="2xDbr0">
+        <child id="7464726264122072730" name="drawShadow" index="2x7_pA" />
+        <child id="7464726264118062179" name="draw" index="2xOiiv" />
+        <child id="7592386925311538038" name="defaultSize" index="3pRy3o" />
+        <child id="3454709602156469310" name="parameters" index="1xmOgE" />
+      </concept>
+      <concept id="7464726264117345981" name="de.itemis.mps.editor.diagram.structure.Function_DrawShape" flags="ig" index="2xDzp1" />
+      <concept id="7464726264117388668" name="de.itemis.mps.editor.diagram.structure.Parameter_Graphics2D" flags="ng" index="2xDIQ0" />
+      <concept id="7464726264117677937" name="de.itemis.mps.editor.diagram.structure.ShapeReference" flags="ng" index="2xQOud">
+        <reference id="7464726264117677938" name="shape" index="2xQOue" />
+        <child id="3454709602159778495" name="parameterValues" index="1xbcaF" />
+      </concept>
+      <concept id="6237710625713195816" name="de.itemis.mps.editor.diagram.structure.CellModel_DiagramNode" flags="ng" index="2ZK4vF">
+        <child id="7464726264117682823" name="shape" index="2xQQDV" />
+        <child id="5885378216888005965" name="boxID" index="NKQk3" />
+        <child id="1315262826372527521" name="editor" index="1ytjkN" />
+      </concept>
       <concept id="5051221038171022699" name="de.itemis.mps.editor.diagram.structure.ShadeColor" flags="lg" index="38c6YI" />
       <concept id="7899485855304485736" name="de.itemis.mps.editor.diagram.structure.QueryFunction_Float" flags="ig" index="1k1hvw" />
+      <concept id="3454709602156468860" name="de.itemis.mps.editor.diagram.structure.ShapeParameterDeclaration" flags="ng" index="1xmO9C">
+        <child id="3454709602156468949" name="type" index="1xmOb1" />
+      </concept>
+      <concept id="3454709602156593329" name="de.itemis.mps.editor.diagram.structure.ShapeParameterReference" flags="ng" index="1xnly_">
+        <reference id="3454709602156593404" name="parameter" index="1xnlzC" />
+      </concept>
       <concept id="6987730699889040828" name="de.itemis.mps.editor.diagram.structure.LineColor" flags="lg" index="3C0NmK" />
       <concept id="6987730699889040827" name="de.itemis.mps.editor.diagram.structure.LineWidth" flags="lg" index="3C0NmR">
         <property id="6987730699889499559" name="value" index="3DY3mF" />
         <child id="7899485855304492241" name="query" index="1k1jxp" />
       </concept>
+      <concept id="8587703283519920118" name="de.itemis.mps.editor.diagram.structure.ThisNodeExpression" flags="ng" index="1Pxb5l" />
     </language>
     <language id="120e1c9d-4e27-4478-b2af-b2c3bd3850b0" name="com.mbeddr.mpsutil.editor.querylist">
       <concept id="6202678563380238499" name="com.mbeddr.mpsutil.editor.querylist.structure.Function_GetElements" flags="ig" index="s8sZD" />
@@ -475,6 +511,10 @@
         <child id="1144104376918" name="parameter" index="1xVPHs" />
       </concept>
       <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
+      <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
+        <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
+        <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
+      </concept>
       <concept id="8866923313515890008" name="jetbrains.mps.lang.smodel.structure.AsNodeOperation" flags="nn" index="FGMqu" />
       <concept id="1143234257716" name="jetbrains.mps.lang.smodel.structure.Node_GetModelOperation" flags="nn" index="I4A8Y" />
       <concept id="1883223317721008708" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfStatement" flags="nn" index="Jncv_">
@@ -507,6 +547,7 @@
       <concept id="6407023681583031218" name="jetbrains.mps.lang.smodel.structure.AttributeAccess" flags="nn" index="3CFZ6_">
         <child id="6407023681583036852" name="qualifier" index="3CFYIz" />
       </concept>
+      <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI" />
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
       </concept>
@@ -4961,6 +5002,462 @@
         </node>
       </node>
       <node concept="2iRfu4" id="3aXq4CufQaX" role="2iSdaV" />
+    </node>
+  </node>
+  <node concept="24kQdi" id="4_xuXPCBTVR">
+    <property role="3GE5qa" value="page_settings" />
+    <ref role="1XX52x" to="b19z:4_xuXPCBvIl" resolve="PageSettingBase" />
+    <node concept="PMmxH" id="4_xuXPCBU4t" role="2wV5jI">
+      <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
+    </node>
+    <node concept="2aJ2om" id="4_xuXPCCoOz" role="CpUAK">
+      <ref role="2$4xQ3" node="4_xuXPCCof$" resolve="PAGE_SETTING_TEXTUAL" />
+    </node>
+  </node>
+  <node concept="2ABfQD" id="4_xuXPCCny3">
+    <property role="3GE5qa" value="page_settings" />
+    <property role="TrG5h" value="PAGE_SETTING" />
+    <node concept="2BsEeg" id="4_xuXPCCof$" role="2ABdcP">
+      <property role="2gpH_U" value="true" />
+      <property role="TrG5h" value="PAGE_SETTING_TEXTUAL" />
+    </node>
+  </node>
+  <node concept="2xDbr0" id="4_xuXPCjfze">
+    <property role="TrG5h" value="PageSettingTopLeftShape" />
+    <property role="3GE5qa" value="page_settings" />
+    <node concept="2xDzp1" id="4_xuXPCICIT" role="2xOiiv">
+      <node concept="3clFbS" id="4_xuXPCICIU" role="2VODD2">
+        <node concept="3cpWs8" id="4_xuXPCKLK1" role="3cqZAp">
+          <node concept="3cpWsn" id="4_xuXPCKLK4" role="3cpWs9">
+            <property role="TrG5h" value="LEFT_PADDING" />
+            <node concept="10Oyi0" id="4_xuXPCKLJZ" role="1tU5fm" />
+            <node concept="3cmrfG" id="4_xuXPCKLX6" role="33vP2m">
+              <property role="3cmrfH" value="10" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="4_xuXPCKNcf" role="3cqZAp">
+          <node concept="3cpWsn" id="4_xuXPCKNcg" role="3cpWs9">
+            <property role="TrG5h" value="TOP_PADDING" />
+            <node concept="10Oyi0" id="4_xuXPCKNch" role="1tU5fm" />
+            <node concept="3cmrfG" id="4_xuXPCKNci" role="33vP2m">
+              <property role="3cmrfH" value="10" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="4_xuXPCNr_r" role="3cqZAp" />
+        <node concept="3cpWs8" id="4_xuXPCLIGz" role="3cqZAp">
+          <node concept="3cpWsn" id="4_xuXPCLIGA" role="3cpWs9">
+            <property role="TrG5h" value="LINE_SIZE" />
+            <node concept="10Oyi0" id="4_xuXPCLIGx" role="1tU5fm" />
+            <node concept="3cmrfG" id="4_xuXPCLJ5X" role="33vP2m">
+              <property role="3cmrfH" value="20" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4_xuXPCLFnF" role="3cqZAp">
+          <node concept="2OqwBi" id="4_xuXPCLFAD" role="3clFbG">
+            <node concept="2xDIQ0" id="4_xuXPCLFnE" role="2Oq$k0" />
+            <node concept="liA8E" id="4_xuXPCLG2i" role="2OqNvi">
+              <ref role="37wK5l" to="z60i:~Graphics.drawLine(int,int,int,int)" resolve="drawLine" />
+              <node concept="37vLTw" id="4_xuXPCLGh7" role="37wK5m">
+                <ref role="3cqZAo" node="4_xuXPCKLK4" resolve="LEFT_PADDING" />
+              </node>
+              <node concept="37vLTw" id="4_xuXPCLGh8" role="37wK5m">
+                <ref role="3cqZAo" node="4_xuXPCKNcg" resolve="TOP_PADDING" />
+              </node>
+              <node concept="3cpWs3" id="4_xuXPCLIxk" role="37wK5m">
+                <node concept="37vLTw" id="4_xuXPCLJGW" role="3uHU7w">
+                  <ref role="3cqZAo" node="4_xuXPCLIGA" resolve="lineSize" />
+                </node>
+                <node concept="37vLTw" id="4_xuXPCLGyo" role="3uHU7B">
+                  <ref role="3cqZAo" node="4_xuXPCKLK4" resolve="LEFT_PADDING" />
+                </node>
+              </node>
+              <node concept="37vLTw" id="4_xuXPCLLeY" role="37wK5m">
+                <ref role="3cqZAo" node="4_xuXPCKNcg" resolve="TOP_PADDING" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4_xuXPCLLq0" role="3cqZAp">
+          <node concept="2OqwBi" id="4_xuXPCLLq1" role="3clFbG">
+            <node concept="2xDIQ0" id="4_xuXPCLLq2" role="2Oq$k0" />
+            <node concept="liA8E" id="4_xuXPCLLq3" role="2OqNvi">
+              <ref role="37wK5l" to="z60i:~Graphics.drawLine(int,int,int,int)" resolve="drawLine" />
+              <node concept="37vLTw" id="4_xuXPCLLq4" role="37wK5m">
+                <ref role="3cqZAo" node="4_xuXPCKLK4" resolve="LEFT_PADDING" />
+              </node>
+              <node concept="37vLTw" id="4_xuXPCLLq5" role="37wK5m">
+                <ref role="3cqZAo" node="4_xuXPCKNcg" resolve="TOP_PADDING" />
+              </node>
+              <node concept="37vLTw" id="4_xuXPCLLq8" role="37wK5m">
+                <ref role="3cqZAo" node="4_xuXPCKLK4" resolve="LEFT_PADDING" />
+              </node>
+              <node concept="3cpWs3" id="4_xuXPCLNJB" role="37wK5m">
+                <node concept="37vLTw" id="4_xuXPCLNQd" role="3uHU7w">
+                  <ref role="3cqZAo" node="4_xuXPCLIGA" resolve="LINE_SIZE" />
+                </node>
+                <node concept="37vLTw" id="4_xuXPCLLq9" role="3uHU7B">
+                  <ref role="3cqZAo" node="4_xuXPCKNcg" resolve="TOP_PADDING" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2lafZg" id="4_xuXPCIEnI" role="2x7_pA">
+      <node concept="3clFbS" id="4_xuXPCIEnJ" role="2VODD2" />
+    </node>
+    <node concept="3cmrfG" id="4_xuXPCMoGu" role="3pRy3o">
+      <property role="3cmrfH" value="1" />
+    </node>
+  </node>
+  <node concept="PKFIW" id="4_xuXPCDGuW">
+    <property role="TrG5h" value="DiagramWithPageSettingContainerEditorComponent" />
+    <ref role="1XX52x" to="b19z:4_xuXPCBuBe" resolve="IDiagramWithPageSettingContainer" />
+    <node concept="3EZMnI" id="4_xuXPCBZnT" role="2wV5jI">
+      <node concept="3F0ifn" id="4_xuXPCBZqN" role="3EZMnx">
+        <property role="3F0ifm" value="Page Setting:" />
+      </node>
+      <node concept="3F1sOY" id="4_xuXPCBZAe" role="3EZMnx">
+        <ref role="1NtTu8" to="b19z:4_xuXPCBYpe" />
+        <node concept="2w$q5c" id="4_xuXPCCoZW" role="3xwHhi">
+          <node concept="2aJ2om" id="4_xuXPCCoZX" role="2w$qW5">
+            <ref role="2$4xQ3" node="4_xuXPCCof$" resolve="PAGE_SETTING_TEXTUAL" />
+          </node>
+        </node>
+      </node>
+      <node concept="2iRfu4" id="4_xuXPCBZnW" role="2iSdaV" />
+    </node>
+  </node>
+  <node concept="312cEu" id="4_xuXPCH9JQ">
+    <property role="TrG5h" value="PageSettingUtils" />
+    <property role="3GE5qa" value="page_settings" />
+    <node concept="2tJIrI" id="4_xuXPCH9SY" role="jymVt" />
+    <node concept="Wx3nA" id="4_xuXPD1HLg" role="jymVt">
+      <property role="TrG5h" value="PAGE_SETTING_BOTTOM_RIGHT" />
+      <node concept="3Tm1VV" id="4_xuXPD1G$5" role="1B3o_S" />
+      <node concept="17QB3L" id="4_xuXPD1HeG" role="1tU5fm" />
+      <node concept="Xl_RD" id="4_xuXPD1HXL" role="33vP2m">
+        <property role="Xl_RC" value="PAGE_SETTING_BOTTOM_RIGHT" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="4_xuXPD1Ga2" role="jymVt" />
+    <node concept="2tJIrI" id="4_xuXPD1Ga3" role="jymVt" />
+    <node concept="2YIFZL" id="4_xuXPCHbcs" role="jymVt">
+      <property role="TrG5h" value="getPageWidth" />
+      <node concept="3clFbS" id="4_xuXPCHbcv" role="3clF47">
+        <node concept="3cpWs8" id="4_xuXPCHf_V" role="3cqZAp">
+          <node concept="3cpWsn" id="4_xuXPCHf_W" role="3cpWs9">
+            <property role="TrG5h" value="screenResolutionInDotPerInch" />
+            <node concept="10Oyi0" id="4_xuXPCHfwI" role="1tU5fm" />
+            <node concept="2OqwBi" id="4_xuXPCHf_X" role="33vP2m">
+              <node concept="2YIFZM" id="4_xuXPCHf_Y" role="2Oq$k0">
+                <ref role="37wK5l" to="z60i:~Toolkit.getDefaultToolkit()" resolve="getDefaultToolkit" />
+                <ref role="1Pybhc" to="z60i:~Toolkit" resolve="Toolkit" />
+              </node>
+              <node concept="liA8E" id="4_xuXPCHf_Z" role="2OqNvi">
+                <ref role="37wK5l" to="z60i:~Toolkit.getScreenResolution()" resolve="getScreenResolution" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4_xuXPCHi00" role="3cqZAp">
+          <node concept="1eOMI4" id="4_xuXPCHAYh" role="3clFbG">
+            <node concept="10QFUN" id="4_xuXPCHAYg" role="1eOMHV">
+              <node concept="1eOMI4" id="4_xuXPCHAYi" role="10QFUP">
+                <node concept="17qRlL" id="4_xuXPCHAY8" role="1eOMHV">
+                  <node concept="37vLTw" id="4_xuXPCHAY9" role="3uHU7w">
+                    <ref role="3cqZAo" node="4_xuXPCHf_W" resolve="screenResolutionInDotPerInch" />
+                  </node>
+                  <node concept="1eOMI4" id="4_xuXPCHAYa" role="3uHU7B">
+                    <node concept="FJ1c_" id="4_xuXPCHAYb" role="1eOMHV">
+                      <node concept="2OqwBi" id="4_xuXPCHAYc" role="3uHU7B">
+                        <node concept="37vLTw" id="4_xuXPCHAYd" role="2Oq$k0">
+                          <ref role="3cqZAo" node="4_xuXPCHbyS" resolve="pageSetting" />
+                        </node>
+                        <node concept="2qgKlT" id="4_xuXPCHAYe" role="2OqNvi">
+                          <ref role="37wK5l" to="w873:4_xuXPCBwK4" resolve="widthInMillimeters" />
+                        </node>
+                      </node>
+                      <node concept="3b6qkQ" id="4_xuXPCHAYf" role="3uHU7w">
+                        <property role="$nhwW" value="25.4" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="10Oyi0" id="4_xuXPCHBAb" role="10QFUM" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="4_xuXPCHahN" role="1B3o_S" />
+      <node concept="10Oyi0" id="4_xuXPCHaPy" role="3clF45" />
+      <node concept="37vLTG" id="4_xuXPCHbyS" role="3clF46">
+        <property role="TrG5h" value="pageSetting" />
+        <node concept="3Tqbb2" id="4_xuXPCHbyR" role="1tU5fm">
+          <ref role="ehGHo" to="b19z:4_xuXPCBvIl" resolve="PageSettingBase" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="4_xuXPCHCUs" role="jymVt" />
+    <node concept="2YIFZL" id="4_xuXPCHC2L" role="jymVt">
+      <property role="TrG5h" value="getPageHeight" />
+      <node concept="3clFbS" id="4_xuXPCHC2M" role="3clF47">
+        <node concept="3cpWs8" id="4_xuXPCHC2N" role="3cqZAp">
+          <node concept="3cpWsn" id="4_xuXPCHC2O" role="3cpWs9">
+            <property role="TrG5h" value="screenResolutionInDotPerInch" />
+            <node concept="10Oyi0" id="4_xuXPCHC2P" role="1tU5fm" />
+            <node concept="2OqwBi" id="4_xuXPCHC2Q" role="33vP2m">
+              <node concept="2YIFZM" id="4_xuXPCHC2R" role="2Oq$k0">
+                <ref role="37wK5l" to="z60i:~Toolkit.getDefaultToolkit()" resolve="getDefaultToolkit" />
+                <ref role="1Pybhc" to="z60i:~Toolkit" resolve="Toolkit" />
+              </node>
+              <node concept="liA8E" id="4_xuXPCHC2S" role="2OqNvi">
+                <ref role="37wK5l" to="z60i:~Toolkit.getScreenResolution()" resolve="getScreenResolution" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4_xuXPCHC2T" role="3cqZAp">
+          <node concept="1eOMI4" id="4_xuXPCHC2U" role="3clFbG">
+            <node concept="10QFUN" id="4_xuXPCHC2V" role="1eOMHV">
+              <node concept="1eOMI4" id="4_xuXPCHC2W" role="10QFUP">
+                <node concept="17qRlL" id="4_xuXPCHC2X" role="1eOMHV">
+                  <node concept="37vLTw" id="4_xuXPCHC2Y" role="3uHU7w">
+                    <ref role="3cqZAo" node="4_xuXPCHC2O" resolve="screenResolutionInDotPerInch" />
+                  </node>
+                  <node concept="1eOMI4" id="4_xuXPCHC2Z" role="3uHU7B">
+                    <node concept="FJ1c_" id="4_xuXPCHC30" role="1eOMHV">
+                      <node concept="2OqwBi" id="4_xuXPCHC31" role="3uHU7B">
+                        <node concept="37vLTw" id="4_xuXPCHC32" role="2Oq$k0">
+                          <ref role="3cqZAo" node="4_xuXPCHC38" resolve="pageSetting" />
+                        </node>
+                        <node concept="2qgKlT" id="4_xuXPCHC33" role="2OqNvi">
+                          <ref role="37wK5l" to="w873:4_xuXPCBxFM" resolve="heightInMillimeters" />
+                        </node>
+                      </node>
+                      <node concept="3b6qkQ" id="4_xuXPCHC34" role="3uHU7w">
+                        <property role="$nhwW" value="25.4" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="10Oyi0" id="4_xuXPCHC35" role="10QFUM" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="4_xuXPCHC36" role="1B3o_S" />
+      <node concept="10Oyi0" id="4_xuXPCHC37" role="3clF45" />
+      <node concept="37vLTG" id="4_xuXPCHC38" role="3clF46">
+        <property role="TrG5h" value="pageSetting" />
+        <node concept="3Tqbb2" id="4_xuXPCHC39" role="1tU5fm">
+          <ref role="ehGHo" to="b19z:4_xuXPCBvIl" resolve="PageSettingBase" />
+        </node>
+      </node>
+    </node>
+    <node concept="3Tm1VV" id="4_xuXPCH9JR" role="1B3o_S" />
+  </node>
+  <node concept="24kQdi" id="4_xuXPCPC9i">
+    <property role="3GE5qa" value="page_settings" />
+    <ref role="1XX52x" to="b19z:4_xuXPCP_cL" resolve="PageSettingsTopLeft" />
+    <node concept="2ZK4vF" id="4_xuXPCPCw4" role="2wV5jI">
+      <node concept="2xQOud" id="4_xuXPCV7Kl" role="2xQQDV">
+        <ref role="2xQOue" node="4_xuXPCjfze" resolve="PageSettingTopLeftShape" />
+      </node>
+      <node concept="3F0ifn" id="4_xuXPCV88a" role="1ytjkN" />
+    </node>
+  </node>
+  <node concept="2xDbr0" id="4_xuXPCPEHj">
+    <property role="TrG5h" value="PageSettingBottomRightShape" />
+    <property role="3GE5qa" value="page_settings" />
+    <node concept="1xmO9C" id="4_xuXPCPEHk" role="1xmOgE">
+      <property role="TrG5h" value="pageSetting" />
+      <node concept="3Tqbb2" id="4_xuXPCPEHl" role="1xmOb1">
+        <ref role="ehGHo" to="b19z:4_xuXPCBvIl" resolve="PageSettingBase" />
+      </node>
+    </node>
+    <node concept="2xDzp1" id="4_xuXPCPEHm" role="2xOiiv">
+      <node concept="3clFbS" id="4_xuXPCPEHn" role="2VODD2">
+        <node concept="3cpWs8" id="4_xuXPCPFlO" role="3cqZAp">
+          <node concept="3cpWsn" id="4_xuXPCPFlP" role="3cpWs9">
+            <property role="TrG5h" value="width" />
+            <node concept="10Oyi0" id="4_xuXPCPFlQ" role="1tU5fm" />
+            <node concept="2YIFZM" id="4_xuXPCPFlR" role="33vP2m">
+              <ref role="37wK5l" node="4_xuXPCHbcs" resolve="getPageWidth" />
+              <ref role="1Pybhc" node="4_xuXPCH9JQ" resolve="PageSettingUtils" />
+              <node concept="1xnly_" id="4_xuXPCPFlS" role="37wK5m">
+                <ref role="1xnlzC" node="4_xuXPCPEHk" resolve="pageSetting" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="4_xuXPCPFlT" role="3cqZAp">
+          <node concept="3cpWsn" id="4_xuXPCPFlU" role="3cpWs9">
+            <property role="TrG5h" value="height" />
+            <node concept="10Oyi0" id="4_xuXPCPFlV" role="1tU5fm" />
+            <node concept="2YIFZM" id="4_xuXPCPFlW" role="33vP2m">
+              <ref role="37wK5l" node="4_xuXPCHC2L" resolve="getPageHeight" />
+              <ref role="1Pybhc" node="4_xuXPCH9JQ" resolve="PageSettingUtils" />
+              <node concept="1xnly_" id="4_xuXPCPFlX" role="37wK5m">
+                <ref role="1xnlzC" node="4_xuXPCPEHk" resolve="pageSetting" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="4_xuXPCPFm2" role="3cqZAp">
+          <node concept="3cpWsn" id="4_xuXPCPFm3" role="3cpWs9">
+            <property role="TrG5h" value="RIGHT_PADDING" />
+            <node concept="10Oyi0" id="4_xuXPCPFm4" role="1tU5fm" />
+            <node concept="3cmrfG" id="4_xuXPCPFm5" role="33vP2m">
+              <property role="3cmrfH" value="10" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="4_xuXPCPFma" role="3cqZAp">
+          <node concept="3cpWsn" id="4_xuXPCPFmb" role="3cpWs9">
+            <property role="TrG5h" value="BOTTOM_PADDING" />
+            <node concept="10Oyi0" id="4_xuXPCPFmc" role="1tU5fm" />
+            <node concept="3cmrfG" id="4_xuXPCPFmd" role="33vP2m">
+              <property role="3cmrfH" value="10" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="4_xuXPCPFme" role="3cqZAp" />
+        <node concept="3cpWs8" id="4_xuXPCPFmf" role="3cqZAp">
+          <node concept="3cpWsn" id="4_xuXPCPFmg" role="3cpWs9">
+            <property role="TrG5h" value="LINE_SIZE" />
+            <node concept="10Oyi0" id="4_xuXPCPFmh" role="1tU5fm" />
+            <node concept="3cmrfG" id="4_xuXPCPFmi" role="33vP2m">
+              <property role="3cmrfH" value="20" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4_xuXPCPFny" role="3cqZAp">
+          <node concept="2OqwBi" id="4_xuXPCPFnz" role="3clFbG">
+            <node concept="2xDIQ0" id="4_xuXPCPFn$" role="2Oq$k0" />
+            <node concept="liA8E" id="4_xuXPCPFn_" role="2OqNvi">
+              <ref role="37wK5l" to="z60i:~Graphics.drawLine(int,int,int,int)" resolve="drawLine" />
+              <node concept="3cpWsd" id="4_xuXPCPFnA" role="37wK5m">
+                <node concept="37vLTw" id="4_xuXPCPFnB" role="3uHU7w">
+                  <ref role="3cqZAo" node="4_xuXPCPFmg" resolve="LINE_SIZE" />
+                </node>
+                <node concept="3cpWsd" id="4_xuXPCPFnC" role="3uHU7B">
+                  <node concept="37vLTw" id="4_xuXPCPFnD" role="3uHU7B">
+                    <ref role="3cqZAo" node="4_xuXPCPFlP" resolve="width" />
+                  </node>
+                  <node concept="37vLTw" id="4_xuXPCPFnE" role="3uHU7w">
+                    <ref role="3cqZAo" node="4_xuXPCPFm3" resolve="RIGHT_PADDING" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3cpWsd" id="4_xuXPCPFnF" role="37wK5m">
+                <node concept="37vLTw" id="4_xuXPCPFnG" role="3uHU7w">
+                  <ref role="3cqZAo" node="4_xuXPCPFmb" resolve="BOTTOM_PADDING" />
+                </node>
+                <node concept="37vLTw" id="4_xuXPCPFnH" role="3uHU7B">
+                  <ref role="3cqZAo" node="4_xuXPCPFlU" resolve="height" />
+                </node>
+              </node>
+              <node concept="3cpWsd" id="4_xuXPCPFnI" role="37wK5m">
+                <node concept="37vLTw" id="4_xuXPCPFnJ" role="3uHU7w">
+                  <ref role="3cqZAo" node="4_xuXPCPFm3" resolve="RIGHT_PADDING" />
+                </node>
+                <node concept="37vLTw" id="4_xuXPCPFnK" role="3uHU7B">
+                  <ref role="3cqZAo" node="4_xuXPCPFlP" resolve="width" />
+                </node>
+              </node>
+              <node concept="3cpWsd" id="4_xuXPCPFnL" role="37wK5m">
+                <node concept="37vLTw" id="4_xuXPCPFnM" role="3uHU7w">
+                  <ref role="3cqZAo" node="4_xuXPCPFmb" resolve="BOTTOM_PADDING" />
+                </node>
+                <node concept="37vLTw" id="4_xuXPCPFnN" role="3uHU7B">
+                  <ref role="3cqZAo" node="4_xuXPCPFlU" resolve="height" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4_xuXPCPFnO" role="3cqZAp">
+          <node concept="2OqwBi" id="4_xuXPCPFnP" role="3clFbG">
+            <node concept="2xDIQ0" id="4_xuXPCPFnQ" role="2Oq$k0" />
+            <node concept="liA8E" id="4_xuXPCPFnR" role="2OqNvi">
+              <ref role="37wK5l" to="z60i:~Graphics.drawLine(int,int,int,int)" resolve="drawLine" />
+              <node concept="3cpWsd" id="4_xuXPCPFnS" role="37wK5m">
+                <node concept="37vLTw" id="4_xuXPCPFnT" role="3uHU7w">
+                  <ref role="3cqZAo" node="4_xuXPCPFm3" resolve="RIGHT_PADDING" />
+                </node>
+                <node concept="37vLTw" id="4_xuXPCPFnU" role="3uHU7B">
+                  <ref role="3cqZAo" node="4_xuXPCPFlP" resolve="width" />
+                </node>
+              </node>
+              <node concept="3cpWsd" id="4_xuXPCPFnV" role="37wK5m">
+                <node concept="37vLTw" id="4_xuXPCPFnW" role="3uHU7w">
+                  <ref role="3cqZAo" node="4_xuXPCPFmb" resolve="BOTTOM_PADDING" />
+                </node>
+                <node concept="37vLTw" id="4_xuXPCPFnX" role="3uHU7B">
+                  <ref role="3cqZAo" node="4_xuXPCPFlU" resolve="height" />
+                </node>
+              </node>
+              <node concept="3cpWsd" id="4_xuXPCPFnY" role="37wK5m">
+                <node concept="37vLTw" id="4_xuXPCPFnZ" role="3uHU7w">
+                  <ref role="3cqZAo" node="4_xuXPCPFm3" resolve="RIGHT_PADDING" />
+                </node>
+                <node concept="37vLTw" id="4_xuXPCPFo0" role="3uHU7B">
+                  <ref role="3cqZAo" node="4_xuXPCPFlP" resolve="width" />
+                </node>
+              </node>
+              <node concept="3cpWsd" id="4_xuXPCPFo1" role="37wK5m">
+                <node concept="37vLTw" id="4_xuXPCPFo2" role="3uHU7w">
+                  <ref role="3cqZAo" node="4_xuXPCPFmg" resolve="LINE_SIZE" />
+                </node>
+                <node concept="3cpWsd" id="4_xuXPCPFo3" role="3uHU7B">
+                  <node concept="37vLTw" id="4_xuXPCPFo4" role="3uHU7B">
+                    <ref role="3cqZAo" node="4_xuXPCPFlU" resolve="height" />
+                  </node>
+                  <node concept="37vLTw" id="4_xuXPCPFo5" role="3uHU7w">
+                    <ref role="3cqZAo" node="4_xuXPCPFmb" resolve="BOTTOM_PADDING" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2lafZg" id="4_xuXPCPEHT" role="2x7_pA">
+      <node concept="3clFbS" id="4_xuXPCPEHU" role="2VODD2" />
+    </node>
+    <node concept="3cmrfG" id="4_xuXPCPEHV" role="3pRy3o">
+      <property role="3cmrfH" value="1" />
+    </node>
+  </node>
+  <node concept="24kQdi" id="4_xuXPCRkfX">
+    <property role="3GE5qa" value="page_settings" />
+    <ref role="1XX52x" to="b19z:4_xuXPCP_OB" resolve="PageSettingsBottomRight" />
+    <node concept="2ZK4vF" id="4_xuXPCRkfY" role="2wV5jI">
+      <node concept="2xQOud" id="4_xuXPD16Oc" role="2xQQDV">
+        <ref role="2xQOue" node="4_xuXPCPEHj" resolve="PageSettingBottomRightShape" />
+        <node concept="1PxgMI" id="4_xuXPD16WZ" role="1xbcaF">
+          <node concept="chp4Y" id="4_xuXPD16X0" role="3oSUPX">
+            <ref role="cht4Q" to="b19z:4_xuXPCBvIl" resolve="PageSettingBase" />
+          </node>
+          <node concept="2OqwBi" id="4_xuXPD16X1" role="1m5AlR">
+            <node concept="1Pxb5l" id="4_xuXPD16X2" role="2Oq$k0" />
+            <node concept="1mfA1w" id="4_xuXPD16X3" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+      <node concept="3F0ifn" id="4_xuXPD1oye" role="1ytjkN" />
+      <node concept="10M0yZ" id="4_xuXPD20fq" role="NKQk3">
+        <ref role="3cqZAo" node="4_xuXPD1HLg" resolve="PAGE_SETTING_BOTTOM_RIGHT" />
+        <ref role="1PxDUh" node="4_xuXPCH9JQ" resolve="PageSettingUtils" />
+      </node>
     </node>
   </node>
 </model>

--- a/code/languages/com.mbeddr.formal.nusmv/languages/com.mbeddr.formal.base/models/structure.mps
+++ b/code/languages/com.mbeddr.formal.nusmv/languages/com.mbeddr.formal.base/models/structure.mps
@@ -7,7 +7,6 @@
   </languages>
   <imports>
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
-    <import index="tpce" ref="r:00000000-0000-4000-0000-011c89590292(jetbrains.mps.lang.structure.structure)" />
     <import index="68mc" ref="r:2a10821d-612f-4a73-b7b0-ed6b57106321(com.mbeddr.mpsutil.filepicker.structure)" />
   </imports>
   <registry>

--- a/code/languages/com.mbeddr.formal.nusmv/languages/com.mbeddr.formal.base/models/structure.mps
+++ b/code/languages/com.mbeddr.formal.nusmv/languages/com.mbeddr.formal.base/models/structure.mps
@@ -328,7 +328,7 @@
     <property role="3GE5qa" value="page_settings" />
     <property role="TrG5h" value="PageSettingBase" />
     <property role="R5$K7" value="true" />
-    <ref role="1TJDcQ" to="tpck:gw2VY9q" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
     <node concept="1TJgyj" id="4_xuXPCPAss" role="1TKVEi">
       <property role="IQ2ns" value="5287643628386543388" />
       <property role="20lmBu" value="fLJjDmT/aggregation" />
@@ -362,13 +362,13 @@
     <property role="EcuMT" value="5287643628386538289" />
     <property role="3GE5qa" value="page_settings" />
     <property role="TrG5h" value="PageSettingsTopLeft" />
-    <ref role="1TJDcQ" to="tpck:gw2VY9q" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
   </node>
   <node concept="1TIwiD" id="4_xuXPCP_OB">
     <property role="EcuMT" value="5287643628386540839" />
     <property role="3GE5qa" value="page_settings" />
     <property role="TrG5h" value="PageSettingsBottomRight" />
-    <ref role="1TJDcQ" to="tpck:gw2VY9q" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
   </node>
   <node concept="1TIwiD" id="4_xuXPD3jwz">
     <property role="EcuMT" value="5287643628390135843" />

--- a/code/languages/com.mbeddr.formal.nusmv/languages/com.mbeddr.formal.base/models/structure.mps
+++ b/code/languages/com.mbeddr.formal.nusmv/languages/com.mbeddr.formal.base/models/structure.mps
@@ -313,5 +313,133 @@
       <ref role="20lvS9" to="68mc:5Wocj7wnotA" resolve="AbstractFilePicker" />
     </node>
   </node>
+  <node concept="PlHQZ" id="4_xuXPCBuBe">
+    <property role="EcuMT" value="5287643628382841294" />
+    <property role="TrG5h" value="IDiagramWithPageSettingContainer" />
+    <property role="3GE5qa" value="page_settings" />
+    <node concept="1TJgyj" id="4_xuXPCBYpe" role="1TKVEi">
+      <property role="IQ2ns" value="5287643628382971470" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="pageSetting" />
+      <ref role="20lvS9" node="4_xuXPCBvIl" resolve="PageSettingBase" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="4_xuXPCBvIl">
+    <property role="EcuMT" value="5287643628382845845" />
+    <property role="3GE5qa" value="page_settings" />
+    <property role="TrG5h" value="PageSettingBase" />
+    <property role="R5$K7" value="true" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" />
+    <node concept="1TJgyj" id="4_xuXPCPAss" role="1TKVEi">
+      <property role="IQ2ns" value="5287643628386543388" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="topLeft" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" node="4_xuXPCP_cL" resolve="PageSettingsTopLeft" />
+    </node>
+    <node concept="1TJgyj" id="4_xuXPCPANd" role="1TKVEi">
+      <property role="IQ2ns" value="5287643628386544845" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="bottomRight" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" node="4_xuXPCP_OB" resolve="PageSettingsBottomRight" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="4_xuXPCBwdC">
+    <property role="EcuMT" value="5287643628382847848" />
+    <property role="3GE5qa" value="page_settings" />
+    <property role="TrG5h" value="A4PagePortrait" />
+    <property role="34LRSv" value="A4 portrait" />
+    <ref role="1TJDcQ" node="4_xuXPCBvIl" resolve="PageSettingBase" />
+  </node>
+  <node concept="1TIwiD" id="4_xuXPCBSAy">
+    <property role="EcuMT" value="5287643628382947746" />
+    <property role="3GE5qa" value="page_settings" />
+    <property role="TrG5h" value="A4PageLandscape" />
+    <property role="34LRSv" value="A4 landscape" />
+    <ref role="1TJDcQ" node="4_xuXPCBvIl" resolve="PageSettingBase" />
+  </node>
+  <node concept="1TIwiD" id="4_xuXPCP_cL">
+    <property role="EcuMT" value="5287643628386538289" />
+    <property role="3GE5qa" value="page_settings" />
+    <property role="TrG5h" value="PageSettingsTopLeft" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" />
+  </node>
+  <node concept="1TIwiD" id="4_xuXPCP_OB">
+    <property role="EcuMT" value="5287643628386540839" />
+    <property role="3GE5qa" value="page_settings" />
+    <property role="TrG5h" value="PageSettingsBottomRight" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" />
+  </node>
+  <node concept="1TIwiD" id="4_xuXPD3jwz">
+    <property role="EcuMT" value="5287643628390135843" />
+    <property role="3GE5qa" value="page_settings" />
+    <property role="TrG5h" value="A3PageLandscape" />
+    <property role="34LRSv" value="A3 landscape" />
+    <ref role="1TJDcQ" node="4_xuXPCBvIl" resolve="PageSettingBase" />
+  </node>
+  <node concept="1TIwiD" id="4_xuXPD3lZU">
+    <property role="EcuMT" value="5287643628390146042" />
+    <property role="3GE5qa" value="page_settings" />
+    <property role="TrG5h" value="A3PagePortrait" />
+    <property role="34LRSv" value="A3 portrait" />
+    <ref role="1TJDcQ" node="4_xuXPCBvIl" resolve="PageSettingBase" />
+  </node>
+  <node concept="1TIwiD" id="4_xuXPD3$4K">
+    <property role="EcuMT" value="5287643628390203696" />
+    <property role="3GE5qa" value="page_settings" />
+    <property role="TrG5h" value="A5PageLandscape" />
+    <property role="34LRSv" value="A5 landscape" />
+    <ref role="1TJDcQ" node="4_xuXPCBvIl" resolve="PageSettingBase" />
+  </node>
+  <node concept="1TIwiD" id="4_xuXPD3AaM">
+    <property role="EcuMT" value="5287643628390212274" />
+    <property role="3GE5qa" value="page_settings" />
+    <property role="TrG5h" value="A5PagePortrait" />
+    <property role="34LRSv" value="A5 portrait" />
+    <ref role="1TJDcQ" node="4_xuXPCBvIl" resolve="PageSettingBase" />
+  </node>
+  <node concept="1TIwiD" id="4_xuXPD3EvV">
+    <property role="EcuMT" value="5287643628390230011" />
+    <property role="3GE5qa" value="page_settings" />
+    <property role="TrG5h" value="A2PageLandscape" />
+    <property role="34LRSv" value="A2 landscape" />
+    <ref role="1TJDcQ" node="4_xuXPCBvIl" resolve="PageSettingBase" />
+  </node>
+  <node concept="1TIwiD" id="4_xuXPD3HWC">
+    <property role="EcuMT" value="5287643628390244136" />
+    <property role="3GE5qa" value="page_settings" />
+    <property role="TrG5h" value="A2PagePortrait" />
+    <property role="34LRSv" value="A2 portrait" />
+    <ref role="1TJDcQ" node="4_xuXPCBvIl" resolve="PageSettingBase" />
+  </node>
+  <node concept="1TIwiD" id="1P450_2sti0">
+    <property role="EcuMT" value="2108832555518252160" />
+    <property role="3GE5qa" value="page_settings" />
+    <property role="TrG5h" value="A1PageLandscape" />
+    <property role="34LRSv" value="A1 landscape" />
+    <ref role="1TJDcQ" node="4_xuXPCBvIl" resolve="PageSettingBase" />
+  </node>
+  <node concept="1TIwiD" id="1P450_2sw0G">
+    <property role="EcuMT" value="2108832555518263340" />
+    <property role="3GE5qa" value="page_settings" />
+    <property role="TrG5h" value="A1PagePortrait" />
+    <property role="34LRSv" value="A1 portrait" />
+    <ref role="1TJDcQ" node="4_xuXPCBvIl" resolve="PageSettingBase" />
+  </node>
+  <node concept="1TIwiD" id="1P450_2s$64">
+    <property role="EcuMT" value="2108832555518280068" />
+    <property role="3GE5qa" value="page_settings" />
+    <property role="TrG5h" value="A0PageLandscape" />
+    <property role="34LRSv" value="A0 landscape" />
+    <ref role="1TJDcQ" node="4_xuXPCBvIl" resolve="PageSettingBase" />
+  </node>
+  <node concept="1TIwiD" id="1P450_2sA0k">
+    <property role="EcuMT" value="2108832555518287892" />
+    <property role="3GE5qa" value="page_settings" />
+    <property role="TrG5h" value="A0PagePortrait" />
+    <property role="34LRSv" value="A0 portrait" />
+    <ref role="1TJDcQ" node="4_xuXPCBvIl" resolve="PageSettingBase" />
+  </node>
 </model>
 

--- a/code/languages/com.mbeddr.formal.nusmv/languages/com.mbeddr.formal.base/models/typesystem.mps
+++ b/code/languages/com.mbeddr.formal.nusmv/languages/com.mbeddr.formal.base/models/typesystem.mps
@@ -1063,7 +1063,7 @@
         </node>
         <node concept="3Cnw8n" id="4_xuXPD2WMS" role="1urrFz">
           <property role="ARO6o" value="true" />
-          <ref role="QpYPw" node="4_xuXPD2WMP" resolve="fix_" />
+          <ref role="QpYPw" node="4_xuXPD2WMP" resolve="fix_BottomRightPosition" />
           <node concept="3CnSsL" id="4_xuXPD35Wo" role="3Coj4f">
             <ref role="QkamJ" node="4_xuXPD2Y_v" resolve="pageSettingBottomRight" />
             <node concept="1YBJjd" id="4_xuXPD3655" role="3CoRuB">

--- a/code/languages/com.mbeddr.formal.nusmv/languages/com.mbeddr.formal.base/models/typesystem.mps
+++ b/code/languages/com.mbeddr.formal.nusmv/languages/com.mbeddr.formal.base/models/typesystem.mps
@@ -5,6 +5,7 @@
     <use id="1a8554c4-eb84-43ba-8c34-6f0d90c6e75a" name="jetbrains.mps.lang.smodel.query" version="3" />
     <use id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections" version="2" />
     <use id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text" version="0" />
+    <use id="63650c59-16c8-498a-99c8-005c7ee9515d" name="jetbrains.mps.lang.access" version="0" />
     <devkit ref="00000000-0000-4000-0000-1de82b3a4936(jetbrains.mps.devkit.aspect.typesystem)" />
   </languages>
   <imports>
@@ -17,6 +18,11 @@
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
     <import index="tpd5" ref="r:00000000-0000-4000-0000-011c895902b5(jetbrains.mps.lang.typesystem.dependencies)" />
     <import index="agne" ref="r:2538c08a-32a3-4d93-89c3-b508268173db(com.mpsbasics.project.utils.project_finder)" />
+    <import index="xnej" ref="r:bff9a19b-7e5d-44c3-8cfc-aec191022422(com.mbeddr.formal.base.editor)" />
+    <import index="95j3" ref="r:b59c48c6-3515-4a72-8146-4b8c723b8307(com.mbeddr.formal.base.diagram_utils)" />
+    <import index="nkm5" ref="r:095345ad-6627-42ca-9d3f-fc1b2d9fbd61(de.itemis.mps.editor.diagram.runtime.model)" />
+    <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" />
+    <import index="suqv" ref="r:9a28b49a-e98c-4186-a7e1-7e782b3f4fc3(de.itemis.mps.editor.diagram.layout.structure)" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
@@ -58,6 +64,10 @@
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
+      <concept id="1070533707846" name="jetbrains.mps.baseLanguage.structure.StaticFieldReference" flags="nn" index="10M0yZ">
+        <reference id="1144433057691" name="classifier" index="1PxDUh" />
+      </concept>
+      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
       <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu" />
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
@@ -69,6 +79,7 @@
       <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
       <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="nn" index="17R0WA" />
       <concept id="1225271369338" name="jetbrains.mps.baseLanguage.structure.IsEmptyOperation" flags="nn" index="17RlXB" />
       <concept id="1225271408483" name="jetbrains.mps.baseLanguage.structure.IsNotEmptyOperation" flags="nn" index="17RvpY" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
@@ -83,6 +94,7 @@
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
       <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
         <child id="1082485599094" name="ifFalseStatement" index="9aQIa" />
         <child id="1068580123160" name="condition" index="3clFbw" />
@@ -91,6 +103,9 @@
       </concept>
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
+        <property id="1068580123138" name="value" index="3clFbU" />
       </concept>
       <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
         <property id="1068580320021" name="value" index="3cmrfH" />
@@ -140,6 +155,23 @@
         <child id="8356039341262087992" name="line" index="1aUNEU" />
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+      <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
+    </language>
+    <language id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation">
+      <concept id="5455284157993911077" name="jetbrains.mps.lang.quotation.structure.NodeBuilderInitProperty" flags="ng" index="2pJxcG">
+        <reference id="5455284157993911078" name="property" index="2pJxcJ" />
+        <child id="1595412875168045201" name="initValue" index="28ntcv" />
+      </concept>
+      <concept id="5455284157993863837" name="jetbrains.mps.lang.quotation.structure.NodeBuilder" flags="nn" index="2pJPEk">
+        <child id="5455284157993863838" name="quotedNode" index="2pJPEn" />
+      </concept>
+      <concept id="5455284157993863840" name="jetbrains.mps.lang.quotation.structure.NodeBuilderNode" flags="nn" index="2pJPED">
+        <reference id="5455284157993910961" name="concept" index="2pJxaS" />
+        <child id="5455284157993911099" name="values" index="2pJxcM" />
+      </concept>
+      <concept id="6985522012210254362" name="jetbrains.mps.lang.quotation.structure.NodeBuilderPropertyExpression" flags="nn" index="WxPPo">
+        <child id="6985522012210254363" name="expression" index="WxPPp" />
+      </concept>
     </language>
     <language id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem">
       <concept id="1175517400280" name="jetbrains.mps.lang.typesystem.structure.AssertStatement" flags="nn" index="2Mj0R9">
@@ -172,6 +204,7 @@
         <child id="3937244445246642781" name="nodeToReport" index="1urrMF" />
       </concept>
       <concept id="1210784285454" name="jetbrains.mps.lang.typesystem.structure.TypesystemIntention" flags="ng" index="3Cnw8n">
+        <property id="1216127910019" name="applyImmediately" index="ARO6o" />
         <reference id="1216388525179" name="quickFix" index="QpYPw" />
         <child id="1210784493590" name="actualArgument" index="3Coj4f" />
       </concept>
@@ -198,6 +231,14 @@
       </concept>
       <concept id="7453996997717780434" name="jetbrains.mps.lang.smodel.structure.Node_GetSConceptOperation" flags="nn" index="2yIwOk" />
       <concept id="1173122760281" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorsOperation" flags="nn" index="z$bX8" />
+      <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
+        <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
+        <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
+      </concept>
+      <concept id="1139613262185" name="jetbrains.mps.lang.smodel.structure.Node_GetParentOperation" flags="nn" index="1mfA1w" />
+      <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI">
+        <property id="1238684351431" name="asCast" index="1BlNFB" />
+      </concept>
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
       </concept>
@@ -206,6 +247,9 @@
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+      </concept>
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
@@ -857,6 +901,394 @@
       </node>
     </node>
     <node concept="3Tm1VV" id="84ljAGCVUn" role="1B3o_S" />
+  </node>
+  <node concept="18kY7G" id="4_xuXPD0ocS">
+    <property role="TrG5h" value="check_PageSettingsBottomRight" />
+    <property role="3GE5qa" value="page_settings" />
+    <node concept="3clFbS" id="4_xuXPD0ocT" role="18ibNy">
+      <node concept="3cpWs8" id="4_xuXPD2qpF" role="3cqZAp">
+        <node concept="3cpWsn" id="4_xuXPD2qpG" role="3cpWs9">
+          <property role="TrG5h" value="myX" />
+          <node concept="17QB3L" id="4_xuXPD2pQ5" role="1tU5fm" />
+          <node concept="3cpWs3" id="4_xuXPD2qpH" role="33vP2m">
+            <node concept="Xl_RD" id="4_xuXPD2qpI" role="3uHU7w">
+              <property role="Xl_RC" value="" />
+            </node>
+            <node concept="2YIFZM" id="4_xuXPD2qpJ" role="3uHU7B">
+              <ref role="37wK5l" to="xnej:4_xuXPCHbcs" resolve="getPageWidth" />
+              <ref role="1Pybhc" to="xnej:4_xuXPCH9JQ" resolve="PageSettingUtils" />
+              <node concept="1PxgMI" id="4_xuXPD2qpK" role="37wK5m">
+                <property role="1BlNFB" value="true" />
+                <node concept="chp4Y" id="4_xuXPD2qpL" role="3oSUPX">
+                  <ref role="cht4Q" to="b19z:4_xuXPCBvIl" resolve="PageSettingBase" />
+                </node>
+                <node concept="2OqwBi" id="4_xuXPD2qpM" role="1m5AlR">
+                  <node concept="1YBJjd" id="4_xuXPD2qpN" role="2Oq$k0">
+                    <ref role="1YBMHb" node="4_xuXPD0ocV" resolve="pageSettingsBottomRight" />
+                  </node>
+                  <node concept="1mfA1w" id="4_xuXPD2qpO" role="2OqNvi" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3cpWs8" id="4_xuXPD2rER" role="3cqZAp">
+        <node concept="3cpWsn" id="4_xuXPD2rES" role="3cpWs9">
+          <property role="TrG5h" value="myY" />
+          <node concept="17QB3L" id="4_xuXPD2rsP" role="1tU5fm" />
+          <node concept="3cpWs3" id="4_xuXPD2rET" role="33vP2m">
+            <node concept="Xl_RD" id="4_xuXPD2rEU" role="3uHU7w">
+              <property role="Xl_RC" value="" />
+            </node>
+            <node concept="2YIFZM" id="4_xuXPD2rEV" role="3uHU7B">
+              <ref role="37wK5l" to="xnej:4_xuXPCHC2L" resolve="getPageHeight" />
+              <ref role="1Pybhc" to="xnej:4_xuXPCH9JQ" resolve="PageSettingUtils" />
+              <node concept="1PxgMI" id="4_xuXPD2rEW" role="37wK5m">
+                <property role="1BlNFB" value="true" />
+                <node concept="chp4Y" id="4_xuXPD2rEX" role="3oSUPX">
+                  <ref role="cht4Q" to="b19z:4_xuXPCBvIl" resolve="PageSettingBase" />
+                </node>
+                <node concept="2OqwBi" id="4_xuXPD2rEY" role="1m5AlR">
+                  <node concept="1YBJjd" id="4_xuXPD2rEZ" role="2Oq$k0">
+                    <ref role="1YBMHb" node="4_xuXPD0ocV" resolve="pageSettingsBottomRight" />
+                  </node>
+                  <node concept="1mfA1w" id="4_xuXPD2rF0" role="2OqNvi" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbH" id="4_xuXPD0pyc" role="3cqZAp" />
+      <node concept="3cpWs8" id="5pJnDA9hrMl" role="3cqZAp">
+        <node concept="3cpWsn" id="5pJnDA9hrMm" role="3cpWs9">
+          <property role="TrG5h" value="topLayout" />
+          <node concept="3uibUv" id="7gJ8ddCbm41" role="1tU5fm">
+            <ref role="3uigEE" to="nkm5:7L$rKAVfOqc" resolve="LayoutMap" />
+          </node>
+          <node concept="2YIFZM" id="7gJ8ddCbj$M" role="33vP2m">
+            <ref role="37wK5l" to="nkm5:7L$rKAVgSYS" resolve="getInstance" />
+            <ref role="1Pybhc" to="nkm5:7L$rKAVfOqc" resolve="LayoutMap" />
+            <node concept="2OqwBi" id="4_xuXPD2n2H" role="37wK5m">
+              <node concept="2OqwBi" id="4_xuXPD2n2I" role="2Oq$k0">
+                <node concept="1YBJjd" id="4_xuXPD2n2J" role="2Oq$k0">
+                  <ref role="1YBMHb" node="4_xuXPD0ocV" resolve="pageSettingsBottomRight" />
+                </node>
+                <node concept="1mfA1w" id="4_xuXPD2n2K" role="2OqNvi" />
+              </node>
+              <node concept="1mfA1w" id="4_xuXPD2n2L" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3cpWs8" id="5pJnDA9jC9B" role="3cqZAp">
+        <node concept="3cpWsn" id="5pJnDA9jC9C" role="3cpWs9">
+          <property role="TrG5h" value="nodeId" />
+          <node concept="17QB3L" id="5pJnDA9jCFz" role="1tU5fm" />
+          <node concept="10M0yZ" id="4_xuXPD2nns" role="33vP2m">
+            <ref role="3cqZAo" to="xnej:4_xuXPD1HLg" resolve="PAGE_SETTING_BOTTOM_RIGHT" />
+            <ref role="1PxDUh" to="xnej:4_xuXPCH9JQ" resolve="PageSettingUtils" />
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbH" id="4_xuXPD2KmA" role="3cqZAp" />
+      <node concept="3cpWs8" id="5pJnDA9hrMw" role="3cqZAp">
+        <node concept="3cpWsn" id="5pJnDA9hrMx" role="3cpWs9">
+          <property role="TrG5h" value="lb" />
+          <node concept="3Tqbb2" id="5pJnDA9hrMy" role="1tU5fm">
+            <ref role="ehGHo" to="suqv:5P3ZJ9da_0I" resolve="Layout_Box" />
+          </node>
+          <node concept="1PxgMI" id="7gJ8ddCbvAz" role="33vP2m">
+            <property role="1BlNFB" value="true" />
+            <node concept="chp4Y" id="7gJ8ddCbwJk" role="3oSUPX">
+              <ref role="cht4Q" to="suqv:5P3ZJ9da_0I" resolve="Layout_Box" />
+            </node>
+            <node concept="2OqwBi" id="7gJ8ddCbnnX" role="1m5AlR">
+              <node concept="37vLTw" id="5pJnDA9hrM_" role="2Oq$k0">
+                <ref role="3cqZAo" node="5pJnDA9hrMm" resolve="topLayout" />
+              </node>
+              <node concept="liA8E" id="7gJ8ddCboJ9" role="2OqNvi">
+                <ref role="37wK5l" to="nkm5:7L$rKAVgv$I" resolve="getValue" />
+                <node concept="37vLTw" id="7gJ8ddCbpXv" role="37wK5m">
+                  <ref role="3cqZAo" node="5pJnDA9jC9C" resolve="nodeId" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2Mj0R9" id="4_xuXPD2KMY" role="3cqZAp">
+        <node concept="1Wc70l" id="4_xuXPD2QUX" role="2MkoU_">
+          <node concept="17R0WA" id="4_xuXPD2T77" role="3uHU7w">
+            <node concept="37vLTw" id="4_xuXPD2UlZ" role="3uHU7w">
+              <ref role="3cqZAo" node="4_xuXPD2rES" resolve="myY" />
+            </node>
+            <node concept="2OqwBi" id="4_xuXPD2RpR" role="3uHU7B">
+              <node concept="37vLTw" id="4_xuXPD2R91" role="2Oq$k0">
+                <ref role="3cqZAo" node="5pJnDA9hrMx" resolve="lb" />
+              </node>
+              <node concept="3TrcHB" id="4_xuXPD2R_O" role="2OqNvi">
+                <ref role="3TsBF5" to="suqv:5P3ZJ9da_2e" resolve="bounds_y" />
+              </node>
+            </node>
+          </node>
+          <node concept="1Wc70l" id="4_xuXPD2MrS" role="3uHU7B">
+            <node concept="3y3z36" id="4_xuXPD2M2R" role="3uHU7B">
+              <node concept="37vLTw" id="4_xuXPD2LGv" role="3uHU7B">
+                <ref role="3cqZAo" node="5pJnDA9hrMx" resolve="lb" />
+              </node>
+              <node concept="10Nm6u" id="4_xuXPD2Mk0" role="3uHU7w" />
+            </node>
+            <node concept="17R0WA" id="4_xuXPD2QHq" role="3uHU7w">
+              <node concept="2OqwBi" id="4_xuXPD2MIJ" role="3uHU7B">
+                <node concept="37vLTw" id="4_xuXPD2MAG" role="2Oq$k0">
+                  <ref role="3cqZAo" node="5pJnDA9hrMx" resolve="lb" />
+                </node>
+                <node concept="3TrcHB" id="4_xuXPD2Nfh" role="2OqNvi">
+                  <ref role="3TsBF5" to="suqv:5P3ZJ9da_2d" resolve="bounds_x" />
+                </node>
+              </node>
+              <node concept="37vLTw" id="4_xuXPD2QP$" role="3uHU7w">
+                <ref role="3cqZAo" node="4_xuXPD2qpG" resolve="myX" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="Xl_RD" id="4_xuXPD2Uxk" role="2MkJ7o">
+          <property role="Xl_RC" value="bounds are fixed" />
+        </node>
+        <node concept="1YBJjd" id="4_xuXPD2Vkn" role="1urrMF">
+          <ref role="1YBMHb" node="4_xuXPD0ocV" resolve="pageSettingsBottomRight" />
+        </node>
+        <node concept="3Cnw8n" id="4_xuXPD2WMS" role="1urrFz">
+          <property role="ARO6o" value="true" />
+          <ref role="QpYPw" node="4_xuXPD2WMP" resolve="fix_" />
+          <node concept="3CnSsL" id="4_xuXPD35Wo" role="3Coj4f">
+            <ref role="QkamJ" node="4_xuXPD2Y_v" resolve="pageSettingBottomRight" />
+            <node concept="1YBJjd" id="4_xuXPD3655" role="3CoRuB">
+              <ref role="1YBMHb" node="4_xuXPD0ocV" resolve="pageSettingsBottomRight" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="4_xuXPD0ocV" role="1YuTPh">
+      <property role="TrG5h" value="pageSettingsBottomRight" />
+      <ref role="1YaFvo" to="b19z:4_xuXPCP_OB" resolve="PageSettingsBottomRight" />
+    </node>
+  </node>
+  <node concept="Q5z_Y" id="4_xuXPD2WMP">
+    <property role="TrG5h" value="fix_BottomRightPosition" />
+    <node concept="Q6JDH" id="4_xuXPD2Y_v" role="Q6Id_">
+      <property role="TrG5h" value="pageSettingBottomRight" />
+      <node concept="3Tqbb2" id="4_xuXPD2YFM" role="Q6QK4">
+        <ref role="ehGHo" to="b19z:4_xuXPCP_OB" resolve="PageSettingsBottomRight" />
+      </node>
+    </node>
+    <node concept="Q5ZZ6" id="4_xuXPD2WMQ" role="Q6x$H">
+      <node concept="3clFbS" id="4_xuXPD2WMR" role="2VODD2">
+        <node concept="3cpWs8" id="4_xuXPD2Zt7" role="3cqZAp">
+          <node concept="3cpWsn" id="4_xuXPD2Zt8" role="3cpWs9">
+            <property role="TrG5h" value="myX" />
+            <node concept="17QB3L" id="4_xuXPD2Zt9" role="1tU5fm" />
+            <node concept="3cpWs3" id="4_xuXPD2Zta" role="33vP2m">
+              <node concept="Xl_RD" id="4_xuXPD2Ztb" role="3uHU7w">
+                <property role="Xl_RC" value="" />
+              </node>
+              <node concept="2YIFZM" id="4_xuXPD2Ztc" role="3uHU7B">
+                <ref role="37wK5l" to="xnej:4_xuXPCHbcs" resolve="getPageWidth" />
+                <ref role="1Pybhc" to="xnej:4_xuXPCH9JQ" resolve="PageSettingUtils" />
+                <node concept="1PxgMI" id="4_xuXPD2Ztd" role="37wK5m">
+                  <property role="1BlNFB" value="true" />
+                  <node concept="chp4Y" id="4_xuXPD2Zte" role="3oSUPX">
+                    <ref role="cht4Q" to="b19z:4_xuXPCBvIl" resolve="PageSettingBase" />
+                  </node>
+                  <node concept="2OqwBi" id="4_xuXPD2Ztf" role="1m5AlR">
+                    <node concept="1mfA1w" id="4_xuXPD2Zth" role="2OqNvi" />
+                    <node concept="QwW4i" id="4_xuXPD33OF" role="2Oq$k0">
+                      <ref role="QwW4h" node="4_xuXPD2Y_v" resolve="pageSettingBottomRight" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="4_xuXPD2Zti" role="3cqZAp">
+          <node concept="3cpWsn" id="4_xuXPD2Ztj" role="3cpWs9">
+            <property role="TrG5h" value="myY" />
+            <node concept="17QB3L" id="4_xuXPD2Ztk" role="1tU5fm" />
+            <node concept="3cpWs3" id="4_xuXPD2Ztl" role="33vP2m">
+              <node concept="Xl_RD" id="4_xuXPD2Ztm" role="3uHU7w">
+                <property role="Xl_RC" value="" />
+              </node>
+              <node concept="2YIFZM" id="4_xuXPD2Ztn" role="3uHU7B">
+                <ref role="37wK5l" to="xnej:4_xuXPCHC2L" resolve="getPageHeight" />
+                <ref role="1Pybhc" to="xnej:4_xuXPCH9JQ" resolve="PageSettingUtils" />
+                <node concept="1PxgMI" id="4_xuXPD2Zto" role="37wK5m">
+                  <property role="1BlNFB" value="true" />
+                  <node concept="chp4Y" id="4_xuXPD2Ztp" role="3oSUPX">
+                    <ref role="cht4Q" to="b19z:4_xuXPCBvIl" resolve="PageSettingBase" />
+                  </node>
+                  <node concept="2OqwBi" id="4_xuXPD2Ztq" role="1m5AlR">
+                    <node concept="QwW4i" id="4_xuXPD3409" role="2Oq$k0">
+                      <ref role="QwW4h" node="4_xuXPD2Y_v" resolve="pageSettingBottomRight" />
+                    </node>
+                    <node concept="1mfA1w" id="4_xuXPD2Zts" role="2OqNvi" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="4_xuXPD2Ztt" role="3cqZAp" />
+        <node concept="3cpWs8" id="4_xuXPD2Ztu" role="3cqZAp">
+          <node concept="3cpWsn" id="4_xuXPD2Ztv" role="3cpWs9">
+            <property role="TrG5h" value="topLayout" />
+            <node concept="3uibUv" id="4_xuXPD2Ztw" role="1tU5fm">
+              <ref role="3uigEE" to="nkm5:7L$rKAVfOqc" resolve="LayoutMap" />
+            </node>
+            <node concept="2YIFZM" id="4_xuXPD2Ztx" role="33vP2m">
+              <ref role="37wK5l" to="nkm5:7L$rKAVgSYS" resolve="getInstance" />
+              <ref role="1Pybhc" to="nkm5:7L$rKAVfOqc" resolve="LayoutMap" />
+              <node concept="2OqwBi" id="4_xuXPD2Zty" role="37wK5m">
+                <node concept="2OqwBi" id="4_xuXPD2Ztz" role="2Oq$k0">
+                  <node concept="QwW4i" id="4_xuXPD34b_" role="2Oq$k0">
+                    <ref role="QwW4h" node="4_xuXPD2Y_v" resolve="pageSettingBottomRight" />
+                  </node>
+                  <node concept="1mfA1w" id="4_xuXPD2Zt_" role="2OqNvi" />
+                </node>
+                <node concept="1mfA1w" id="4_xuXPD2ZtA" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="4_xuXPD2ZtB" role="3cqZAp">
+          <node concept="3cpWsn" id="4_xuXPD2ZtC" role="3cpWs9">
+            <property role="TrG5h" value="nodeId" />
+            <node concept="17QB3L" id="4_xuXPD2ZtD" role="1tU5fm" />
+            <node concept="10M0yZ" id="4_xuXPD2ZtE" role="33vP2m">
+              <ref role="3cqZAo" to="xnej:4_xuXPD1HLg" resolve="PAGE_SETTING_BOTTOM_RIGHT" />
+              <ref role="1PxDUh" to="xnej:4_xuXPCH9JQ" resolve="PageSettingUtils" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="4_xuXPD2ZtF" role="3cqZAp" />
+        <node concept="3cpWs8" id="4_xuXPD2ZtH" role="3cqZAp">
+          <node concept="3cpWsn" id="4_xuXPD2ZtI" role="3cpWs9">
+            <property role="TrG5h" value="lb" />
+            <node concept="3Tqbb2" id="4_xuXPD2ZtJ" role="1tU5fm">
+              <ref role="ehGHo" to="suqv:5P3ZJ9da_0I" resolve="Layout_Box" />
+            </node>
+            <node concept="1PxgMI" id="4_xuXPD2ZtK" role="33vP2m">
+              <property role="1BlNFB" value="true" />
+              <node concept="chp4Y" id="4_xuXPD2ZtL" role="3oSUPX">
+                <ref role="cht4Q" to="suqv:5P3ZJ9da_0I" resolve="Layout_Box" />
+              </node>
+              <node concept="2OqwBi" id="4_xuXPD2ZtM" role="1m5AlR">
+                <node concept="37vLTw" id="4_xuXPD2ZtN" role="2Oq$k0">
+                  <ref role="3cqZAo" node="4_xuXPD2Ztv" resolve="topLayout" />
+                </node>
+                <node concept="liA8E" id="4_xuXPD2ZtO" role="2OqNvi">
+                  <ref role="37wK5l" to="nkm5:7L$rKAVgv$I" resolve="getValue" />
+                  <node concept="37vLTw" id="4_xuXPD2ZtP" role="37wK5m">
+                    <ref role="3cqZAo" node="4_xuXPD2ZtC" resolve="nodeId" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="4_xuXPD2Zub" role="3cqZAp">
+          <node concept="3clFbS" id="4_xuXPD2Zuc" role="3clFbx">
+            <node concept="3clFbF" id="4_xuXPD2Zud" role="3cqZAp">
+              <node concept="37vLTI" id="4_xuXPD2Zue" role="3clFbG">
+                <node concept="37vLTw" id="4_xuXPD2Zuf" role="37vLTJ">
+                  <ref role="3cqZAo" node="4_xuXPD2ZtI" resolve="lb" />
+                </node>
+                <node concept="2pJPEk" id="4_xuXPD2Zug" role="37vLTx">
+                  <node concept="2pJPED" id="4_xuXPD2Zuh" role="2pJPEn">
+                    <ref role="2pJxaS" to="suqv:5P3ZJ9da_0I" resolve="Layout_Box" />
+                    <node concept="2pJxcG" id="4_xuXPD2Zui" role="2pJxcM">
+                      <ref role="2pJxcJ" to="suqv:5P3ZJ9da_2f" resolve="bounds_width" />
+                      <node concept="WxPPo" id="4_xuXPD2Zuj" role="28ntcv">
+                        <node concept="Xl_RD" id="4_xuXPD2Zuk" role="WxPPp">
+                          <property role="Xl_RC" value="75" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2pJxcG" id="4_xuXPD2Zul" role="2pJxcM">
+                      <ref role="2pJxcJ" to="suqv:5P3ZJ9da_2g" resolve="bounds_height" />
+                      <node concept="WxPPo" id="4_xuXPD2Zum" role="28ntcv">
+                        <node concept="Xl_RD" id="4_xuXPD2Zun" role="WxPPp">
+                          <property role="Xl_RC" value="35" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="4_xuXPD2Zuo" role="3cqZAp">
+              <node concept="2OqwBi" id="4_xuXPD2Zup" role="3clFbG">
+                <node concept="37vLTw" id="4_xuXPD2Zuq" role="2Oq$k0">
+                  <ref role="3cqZAo" node="4_xuXPD2Ztv" resolve="topLayout" />
+                </node>
+                <node concept="liA8E" id="4_xuXPD2Zur" role="2OqNvi">
+                  <ref role="37wK5l" to="nkm5:7L$rKAVfYPL" resolve="setValue" />
+                  <node concept="37vLTw" id="4_xuXPD2Zus" role="37wK5m">
+                    <ref role="3cqZAo" node="4_xuXPD2ZtC" resolve="nodeId" />
+                  </node>
+                  <node concept="37vLTw" id="4_xuXPD2Zut" role="37wK5m">
+                    <ref role="3cqZAo" node="4_xuXPD2ZtI" resolve="lb" />
+                  </node>
+                  <node concept="3clFbT" id="4_xuXPD2Zuu" role="37wK5m">
+                    <property role="3clFbU" value="true" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbC" id="4_xuXPD2Zuv" role="3clFbw">
+            <node concept="10Nm6u" id="4_xuXPD2Zuw" role="3uHU7w" />
+            <node concept="37vLTw" id="4_xuXPD2Zux" role="3uHU7B">
+              <ref role="3cqZAo" node="4_xuXPD2ZtI" resolve="lb" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4_xuXPD2Zuy" role="3cqZAp">
+          <node concept="37vLTI" id="4_xuXPD2Zuz" role="3clFbG">
+            <node concept="37vLTw" id="4_xuXPD2Zu$" role="37vLTx">
+              <ref role="3cqZAo" node="4_xuXPD2Zt8" resolve="myX" />
+            </node>
+            <node concept="2OqwBi" id="4_xuXPD2Zu_" role="37vLTJ">
+              <node concept="37vLTw" id="4_xuXPD2ZuA" role="2Oq$k0">
+                <ref role="3cqZAo" node="4_xuXPD2ZtI" resolve="lb" />
+              </node>
+              <node concept="3TrcHB" id="4_xuXPD2ZuB" role="2OqNvi">
+                <ref role="3TsBF5" to="suqv:5P3ZJ9da_2d" resolve="bounds_x" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4_xuXPD2ZuC" role="3cqZAp">
+          <node concept="37vLTI" id="4_xuXPD2ZuD" role="3clFbG">
+            <node concept="2OqwBi" id="4_xuXPD2ZuE" role="37vLTJ">
+              <node concept="37vLTw" id="4_xuXPD2ZuF" role="2Oq$k0">
+                <ref role="3cqZAo" node="4_xuXPD2ZtI" resolve="lb" />
+              </node>
+              <node concept="3TrcHB" id="4_xuXPD2ZuG" role="2OqNvi">
+                <ref role="3TsBF5" to="suqv:5P3ZJ9da_2e" resolve="bounds_y" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="4_xuXPD2ZuH" role="37vLTx">
+              <ref role="3cqZAo" node="4_xuXPD2Ztj" resolve="myY" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
   </node>
 </model>
 

--- a/code/languages/com.mbeddr.formal.safety/languages/com.mbeddr.formal.safety.gsn/models/com.mbeddr.formal.safety.gsn.constraints.mps
+++ b/code/languages/com.mbeddr.formal.safety/languages/com.mbeddr.formal.safety.gsn/models/com.mbeddr.formal.safety.gsn.constraints.mps
@@ -9,9 +9,11 @@
     <import index="o8zo" ref="r:314576fc-3aee-4386-a0a5-a38348ac317d(jetbrains.mps.scope)" />
     <import index="py52" ref="r:14bd9e1a-63cf-4fde-816f-1d68e4acbfba(com.mbeddr.formal.safety.gsn.structure)" />
     <import index="89jy" ref="r:b084f3b4-d6a1-4460-8222-b4a956bb5d23(com.mbeddr.formal.safety.gsn.behavior)" implicit="true" />
+    <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1080223426719" name="jetbrains.mps.baseLanguage.structure.OrExpression" flags="nn" index="22lmx$" />
       <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
         <child id="1068498886297" name="rValue" index="37vLTx" />
         <child id="1068498886295" name="lValue" index="37vLTJ" />
@@ -348,18 +350,26 @@
     <node concept="9S07l" id="6BXRcBg9IIi" role="9Vyp8">
       <node concept="3clFbS" id="6BXRcBg9IIj" role="2VODD2">
         <node concept="3clFbF" id="6BXRcBg9KDt" role="3cqZAp">
-          <node concept="2OqwBi" id="6BXRcBg9Oa4" role="3clFbG">
-            <node concept="2OqwBi" id="6BXRcBg9L74" role="2Oq$k0">
-              <node concept="nLn13" id="6BXRcBg9KDs" role="2Oq$k0" />
-              <node concept="2Xjw5R" id="6BXRcBg9Ngf" role="2OqNvi">
-                <node concept="1xMEDy" id="6BXRcBg9Ngh" role="1xVPHs">
-                  <node concept="chp4Y" id="6BXRcBg9NvS" role="ri$Ld">
-                    <ref role="cht4Q" to="py52:3GRi4m$qNsQ" resolve="GoalStructure" />
+          <node concept="22lmx$" id="1P450_2qtAb" role="3clFbG">
+            <node concept="2OqwBi" id="1P450_2quNw" role="3uHU7B">
+              <node concept="EsrRn" id="1P450_2qujt" role="2Oq$k0" />
+              <node concept="2qgKlT" id="1P450_2qwGB" role="2OqNvi">
+                <ref role="37wK5l" to="tpcu:hEwIMij" resolve="isInTemplates" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="6BXRcBg9Oa4" role="3uHU7w">
+              <node concept="2OqwBi" id="6BXRcBg9L74" role="2Oq$k0">
+                <node concept="nLn13" id="6BXRcBg9KDs" role="2Oq$k0" />
+                <node concept="2Xjw5R" id="6BXRcBg9Ngf" role="2OqNvi">
+                  <node concept="1xMEDy" id="6BXRcBg9Ngh" role="1xVPHs">
+                    <node concept="chp4Y" id="6BXRcBg9NvS" role="ri$Ld">
+                      <ref role="cht4Q" to="py52:3GRi4m$qNsQ" resolve="GoalStructure" />
+                    </node>
                   </node>
                 </node>
               </node>
+              <node concept="3x8VRR" id="6BXRcBg9ORy" role="2OqNvi" />
             </node>
-            <node concept="3x8VRR" id="6BXRcBg9ORy" role="2OqNvi" />
           </node>
         </node>
       </node>

--- a/code/languages/com.mbeddr.formal.safety/languages/com.mbeddr.formal.safety.gsn/models/com.mbeddr.formal.safety.gsn.editor.mps
+++ b/code/languages/com.mbeddr.formal.safety/languages/com.mbeddr.formal.safety.gsn/models/com.mbeddr.formal.safety.gsn.editor.mps
@@ -50,6 +50,7 @@
     <import index="1ks0" ref="r:3f04aa5b-eee7-48ea-a2c7-fc975c7f8656(com.mpsbasics.core.editor)" />
     <import index="u8j" ref="1144260c-e9a5-49a2-9add-39a1a1a7077e/java:org.eclipse.elk.alg.layered.options(de.itemis.mps.editor.diagram.runtime/)" />
     <import index="18t6" ref="1144260c-e9a5-49a2-9add-39a1a1a7077e/java:com.mxgraph.util(de.itemis.mps.editor.diagram.runtime/)" />
+    <import index="b19z" ref="r:11a68676-9d63-4e1c-b920-59aefe77def3(com.mbeddr.formal.base.structure)" />
     <import index="88j9" ref="r:20c4aa5c-ab36-4815-af32-01895ee9c2f5(de.itemis.mps.editor.diagram.editor)" implicit="true" />
     <import index="tpco" ref="r:00000000-0000-4000-0000-011c89590284(jetbrains.mps.lang.core.editor)" implicit="true" />
     <import index="tbr6" ref="r:6a005c26-87c0-43c4-8cf3-49ffba1099df(de.slisson.mps.richtext.behavior)" implicit="true" />
@@ -2787,6 +2788,59 @@
                   <node concept="2I9FWS" id="1e9opmoU6TN" role="2T96Bj" />
                 </node>
               </node>
+            </node>
+          </node>
+          <node concept="3clFbJ" id="4_xuXPCF641" role="3cqZAp">
+            <node concept="3clFbS" id="4_xuXPCF643" role="3clFbx">
+              <node concept="3clFbF" id="4_xuXPCFbrR" role="3cqZAp">
+                <node concept="2OqwBi" id="4_xuXPCFdTO" role="3clFbG">
+                  <node concept="37vLTw" id="4_xuXPCFbrP" role="2Oq$k0">
+                    <ref role="3cqZAo" node="1e9opmoU6ad" resolve="elements" />
+                  </node>
+                  <node concept="TSZUe" id="4_xuXPCFix$" role="2OqNvi">
+                    <node concept="2OqwBi" id="4_xuXPCPLi1" role="25WWJ7">
+                      <node concept="2OqwBi" id="4_xuXPCFjPk" role="2Oq$k0">
+                        <node concept="2ZN8Hh" id="4_xuXPCFja$" role="2Oq$k0" />
+                        <node concept="3TrEf2" id="4_xuXPCFlqM" role="2OqNvi">
+                          <ref role="3Tt5mk" to="b19z:4_xuXPCBYpe" resolve="pageSetting" />
+                        </node>
+                      </node>
+                      <node concept="3TrEf2" id="4_xuXPCPMjn" role="2OqNvi">
+                        <ref role="3Tt5mk" to="b19z:4_xuXPCPAss" resolve="topLeft" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="4_xuXPCPN6E" role="3cqZAp">
+                <node concept="2OqwBi" id="4_xuXPCPN6F" role="3clFbG">
+                  <node concept="37vLTw" id="4_xuXPCPN6G" role="2Oq$k0">
+                    <ref role="3cqZAo" node="1e9opmoU6ad" resolve="elements" />
+                  </node>
+                  <node concept="TSZUe" id="4_xuXPCPN6H" role="2OqNvi">
+                    <node concept="2OqwBi" id="4_xuXPCPN6I" role="25WWJ7">
+                      <node concept="2OqwBi" id="4_xuXPCPN6J" role="2Oq$k0">
+                        <node concept="2ZN8Hh" id="4_xuXPCPN6K" role="2Oq$k0" />
+                        <node concept="3TrEf2" id="4_xuXPCPN6L" role="2OqNvi">
+                          <ref role="3Tt5mk" to="b19z:4_xuXPCBYpe" resolve="pageSetting" />
+                        </node>
+                      </node>
+                      <node concept="3TrEf2" id="4_xuXPCPN6M" role="2OqNvi">
+                        <ref role="3Tt5mk" to="b19z:4_xuXPCPANd" resolve="bottomRight" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2OqwBi" id="4_xuXPCF9M1" role="3clFbw">
+              <node concept="2OqwBi" id="4_xuXPCF7gt" role="2Oq$k0">
+                <node concept="2ZN8Hh" id="4_xuXPCF6By" role="2Oq$k0" />
+                <node concept="3TrEf2" id="4_xuXPCF8xG" role="2OqNvi">
+                  <ref role="3Tt5mk" to="b19z:4_xuXPCBYpe" resolve="pageSetting" />
+                </node>
+              </node>
+              <node concept="3x8VRR" id="4_xuXPCFaEX" role="2OqNvi" />
             </node>
           </node>
           <node concept="3clFbF" id="1e9opmoU71u" role="3cqZAp">
@@ -14410,6 +14464,9 @@
           <ref role="1NtTu8" to="py52:5WyjFZRl16s" resolve="displayRelationNames" />
         </node>
         <node concept="2iRfu4" id="3ydH56R7QiV" role="2iSdaV" />
+      </node>
+      <node concept="PMmxH" id="4_xuXPCDHTZ" role="3EZMnx">
+        <ref role="PMmxG" to="xnej:4_xuXPCDGuW" resolve="DiagramWithPageSettingContainerEditorComponent" />
       </node>
       <node concept="3F0ifn" id="3ydH56R7QiW" role="3EZMnx" />
       <node concept="PMmxH" id="3ydH56R7QiX" role="3EZMnx">

--- a/code/languages/com.mbeddr.formal.safety/languages/com.mbeddr.formal.safety.gsn/models/com.mbeddr.formal.safety.gsn.structure.mps
+++ b/code/languages/com.mbeddr.formal.safety/languages/com.mbeddr.formal.safety.gsn/models/com.mbeddr.formal.safety.gsn.structure.mps
@@ -129,6 +129,9 @@
     <node concept="PrWs8" id="6FJpOMB2Hre" role="PzmwI">
       <ref role="PrY4T" to="iy8y:6xXHcqxdSHU" resolve="IAllowGenericWords" />
     </node>
+    <node concept="PrWs8" id="4_xuXPCDEmY" role="PzmwI">
+      <ref role="PrY4T" to="b19z:4_xuXPCBuBe" resolve="IDiagramWithPageSettingContainer" />
+    </node>
     <node concept="1irR5M" id="2LDKh2uE0R3" role="rwd14">
       <property role="2$rrk2" value="1" />
       <node concept="1irR9n" id="2LDKh2uE1oj" role="1irR9h">

--- a/code/languages/com.mbeddr.formal.safety/solutions/com.mbeddr.formal.safety.gsn.sandbox/models/com.mbeddr.formal.safety.gsn.sandbox._010_simple_examples.mps
+++ b/code/languages/com.mbeddr.formal.safety/solutions/com.mbeddr.formal.safety.gsn.sandbox/models/com.mbeddr.formal.safety.gsn.sandbox._010_simple_examples.mps
@@ -83,6 +83,16 @@
       </concept>
     </language>
     <language id="83ed2dfe-f724-46cc-852a-dce086daee3f" name="com.mbeddr.formal.base">
+      <concept id="5287643628386540839" name="com.mbeddr.formal.base.structure.PageSettingsBottomRight" flags="ng" index="xHMrU" />
+      <concept id="5287643628386538289" name="com.mbeddr.formal.base.structure.PageSettingsTopLeft" flags="ng" index="xHMzG" />
+      <concept id="5287643628382845845" name="com.mbeddr.formal.base.structure.PageSettingBase" flags="ng" index="xZ818">
+        <child id="5287643628386544845" name="bottomRight" index="xHLsg" />
+        <child id="5287643628386543388" name="topLeft" index="xHLN1" />
+      </concept>
+      <concept id="5287643628382841294" name="com.mbeddr.formal.base.structure.IDiagramWithPageSettingContainer" flags="ngI" index="xZ98j">
+        <child id="5287643628382971470" name="pageSetting" index="xZDQj" />
+      </concept>
+      <concept id="5287643628382847848" name="com.mbeddr.formal.base.structure.A4PagePortrait" flags="ng" index="xZRyP" />
       <concept id="4445845612600281072" name="com.mbeddr.formal.base.structure.IContainerForEntitiesWithPrefixedNames" flags="ngI" index="2GXxrR">
         <property id="3731513482755311319" name="crtMaxIndex" index="3dZJ_E" />
         <property id="3731513482755309878" name="idPrefix" index="3dZJUb" />
@@ -154,8 +164,8 @@
         <node concept="gqqVs" id="3GRi4m$reG7" role="37mO4d">
           <property role="gqqTZ" value="254.0" />
           <property role="gqqTW" value="80.0" />
-          <property role="gqqTX" value="130.0" />
-          <property role="gqqTy" value="61.0" />
+          <property role="gqqTX" value="127.0" />
+          <property role="gqqTy" value="54.0" />
           <property role="TgtnS" value="1.0;0.0;0.0;1.0;0.0;0.0" />
         </node>
       </node>
@@ -228,8 +238,8 @@
         <node concept="gqqVs" id="2ccN23o9Vee" role="37mO4d">
           <property role="gqqTZ" value="151.0002983642578" />
           <property role="gqqTW" value="303.0" />
-          <property role="gqqTX" value="112.0" />
-          <property role="gqqTy" value="61.0" />
+          <property role="gqqTX" value="99.0" />
+          <property role="gqqTy" value="54.0" />
           <property role="TgtnS" value="1.0;0.0;0.0;1.0;0.0;0.0" />
         </node>
       </node>
@@ -238,8 +248,8 @@
         <node concept="gqqVs" id="2ccN23o9Veg" role="37mO4d">
           <property role="gqqTZ" value="402.0001" />
           <property role="gqqTW" value="303.0" />
-          <property role="gqqTX" value="102.0" />
-          <property role="gqqTy" value="61.0" />
+          <property role="gqqTX" value="92.0" />
+          <property role="gqqTy" value="54.0" />
           <property role="TgtnS" value="1.0;0.0;0.0;1.0;0.0;0.0" />
         </node>
       </node>
@@ -248,38 +258,38 @@
         <node concept="gqqVs" id="2ccN23oa9Bd" role="37mO4d">
           <property role="gqqTZ" value="39.0001" />
           <property role="gqqTW" value="95.0" />
-          <property role="gqqTX" value="93.0" />
-          <property role="gqqTy" value="47.0" />
+          <property role="gqqTX" value="97.0" />
+          <property role="gqqTy" value="40.0" />
           <property role="TgtnS" value="1.0;0.0;0.0;1.0;0.0;0.0" />
         </node>
       </node>
       <node concept="37mRIm" id="2ccN23oa9Bg" role="37mRID">
         <property role="37mO49" value="4266958635905494759" />
         <node concept="gqqVs" id="2ccN23oa9Bf" role="37mO4d">
-          <property role="gqqTZ" value="151.0" />
-          <property role="gqqTW" value="408.0" />
-          <property role="gqqTX" value="143.0" />
-          <property role="gqqTy" value="61.0" />
+          <property role="gqqTZ" value="138.0002983642578" />
+          <property role="gqqTW" value="430.4669203128303" />
+          <property role="gqqTX" value="112.0" />
+          <property role="gqqTy" value="40.0" />
           <property role="TgtnS" value="1.0;0.0;0.0;1.0;0.0;0.0" />
         </node>
       </node>
       <node concept="37mRIm" id="2ccN23oa9Bi" role="37mRID">
         <property role="37mO49" value="4266958635905731187" />
         <node concept="gqqVs" id="2ccN23oa9Bh" role="37mO4d">
-          <property role="gqqTZ" value="236.0" />
+          <property role="gqqTZ" value="256.0" />
           <property role="gqqTW" value="185.0" />
-          <property role="gqqTX" value="153.0" />
-          <property role="gqqTy" value="61.0" />
+          <property role="gqqTX" value="117.0" />
+          <property role="gqqTy" value="54.0" />
           <property role="TgtnS" value="1.0;0.0;0.0;1.0;0.0;0.0" />
         </node>
       </node>
       <node concept="37mRIm" id="2ccN23oa9Bk" role="37mRID">
         <property role="37mO49" value="4266958635906132579" />
         <node concept="gqqVs" id="2ccN23oa9Bj" role="37mO4d">
-          <property role="gqqTZ" value="389.0001" />
-          <property role="gqqTW" value="398.0" />
-          <property role="gqqTX" value="145.0" />
-          <property role="gqqTy" value="63.0" />
+          <property role="gqqTZ" value="388.5001" />
+          <property role="gqqTW" value="456.6660049810225" />
+          <property role="gqqTX" value="119.0" />
+          <property role="gqqTy" value="54.0" />
           <property role="TgtnS" value="1.0;0.0;0.0;1.0;0.0;0.0" />
         </node>
       </node>
@@ -560,10 +570,130 @@
       <node concept="37mRIm" id="336$aoTD0wQ" role="37mRID">
         <property role="37mO49" value="3514655602815273001" />
         <node concept="gqqVs" id="336$aoTD0wP" role="37mO4d">
-          <property role="gqqTZ" value="196.0" />
-          <property role="gqqTW" value="-11.0" />
-          <property role="gqqTX" value="227.0" />
+          <property role="gqqTZ" value="522.8675698795182" />
+          <property role="gqqTW" value="53.0" />
+          <property role="gqqTX" value="207.0" />
           <property role="gqqTy" value="68.0" />
+          <property role="TgtnS" value="1.0;0.0;0.0;1.0;0.0;0.0" />
+        </node>
+      </node>
+      <node concept="37mRIm" id="4_xuXPCH94G" role="37mRID">
+        <property role="37mO49" value="5287643628384325376" />
+        <node concept="gqqVs" id="4_xuXPCH94F" role="37mO4d">
+          <property role="gqqTZ" value="15.000100000000003" />
+          <property role="gqqTW" value="6.0" />
+          <property role="gqqTX" value="1134.0" />
+          <property role="gqqTy" value="805.0" />
+          <property role="TgtnS" value="1.0;0.0;0.0;1.0;0.0;0.0" />
+        </node>
+      </node>
+      <node concept="37mRIm" id="4_xuXPCLkNI" role="37mRID">
+        <property role="37mO49" value="5287643628385270908" />
+        <node concept="gqqVs" id="4_xuXPCLkNH" role="37mO4d">
+          <property role="gqqTZ" value="103.0" />
+          <property role="gqqTW" value="457.0" />
+          <property role="gqqTX" value="26.0" />
+          <property role="gqqTy" value="239.0" />
+          <property role="TgtnS" value="1.0;0.0;0.0;1.0;0.0;0.0" />
+        </node>
+      </node>
+      <node concept="37mRIm" id="4_xuXPCMF52" role="37mRID">
+        <property role="37mO49" value="5287643628385775200" />
+        <node concept="gqqVs" id="4_xuXPCMF51" role="37mO4d">
+          <property role="gqqTZ" value="0.0" />
+          <property role="gqqTW" value="0.0" />
+          <property role="gqqTX" value="30.0" />
+          <property role="gqqTy" value="28.0" />
+          <property role="TgtnS" value="1.0;0.0;0.0;1.0;0.0;0.0" />
+        </node>
+      </node>
+      <node concept="37mRIm" id="4_xuXPCOwvZ" role="37mRID">
+        <property role="37mO49" value="5287643628385972699" />
+        <node concept="gqqVs" id="4_xuXPCOwvY" role="37mO4d">
+          <property role="gqqTZ" value="0.0" />
+          <property role="gqqTW" value="0.0" />
+          <property role="gqqTX" value="30.0" />
+          <property role="gqqTy" value="28.0" />
+          <property role="TgtnS" value="1.0;0.0;0.0;1.0;0.0;0.0" />
+        </node>
+      </node>
+      <node concept="37mRIm" id="4_xuXPCPgj9" role="37mRID">
+        <property role="37mO49" value="5287643628386452124" />
+        <node concept="gqqVs" id="4_xuXPCPgj8" role="37mO4d">
+          <property role="gqqTZ" value="0.0" />
+          <property role="gqqTW" value="0.0" />
+          <property role="gqqTX" value="14.0" />
+          <property role="gqqTy" value="26.0" />
+          <property role="TgtnS" value="1.0;0.0;0.0;1.0;0.0;0.0" />
+        </node>
+      </node>
+      <node concept="37mRIm" id="4_xuXPCV73I" role="37mRID">
+        <property role="37mO49" value="5287643628387986955" />
+        <node concept="gqqVs" id="4_xuXPCV73H" role="37mO4d">
+          <property role="gqqTZ" value="9.0" />
+          <property role="gqqTW" value="6.0" />
+          <property role="gqqTX" value="34.0" />
+          <property role="gqqTy" value="45.0" />
+          <property role="TgtnS" value="1.0;0.0;0.0;1.0;0.0;0.0" />
+        </node>
+      </node>
+      <node concept="37mRIm" id="4_xuXPCV73K" role="37mRID">
+        <property role="37mO49" value="5287643628387986956" />
+        <node concept="gqqVs" id="4_xuXPCV73J" role="37mO4d">
+          <property role="gqqTZ" value="775.0001" />
+          <property role="gqqTW" value="361.0" />
+          <property role="gqqTX" value="62.0" />
+          <property role="gqqTy" value="62.0" />
+          <property role="TgtnS" value="1.0;0.0;0.0;1.0;0.0;0.0" />
+        </node>
+      </node>
+      <node concept="37mRIm" id="4_xuXPCZR9I" role="37mRID">
+        <property role="37mO49" value="5287643628389232338" />
+        <node concept="gqqVs" id="4_xuXPCZR9H" role="37mO4d">
+          <property role="gqqTZ" value="0.0" />
+          <property role="gqqTW" value="0.0" />
+          <property role="gqqTX" value="30.0" />
+          <property role="gqqTy" value="26.0" />
+          <property role="TgtnS" value="1.0;0.0;0.0;1.0;0.0;0.0" />
+        </node>
+      </node>
+      <node concept="37mRIm" id="4_xuXPCZR9K" role="37mRID">
+        <property role="37mO49" value="5287643628389232339" />
+        <node concept="gqqVs" id="4_xuXPCZR9J" role="37mO4d">
+          <property role="gqqTZ" value="1310.4820277108433" />
+          <property role="gqqTW" value="896.1961254629502" />
+          <property role="gqqTX" value="30.0" />
+          <property role="gqqTy" value="26.0" />
+          <property role="TgtnS" value="1.0;0.0;0.0;1.0;0.0;0.0" />
+        </node>
+      </node>
+      <node concept="37mRIm" id="4yjTpwGVANW" role="37mRID">
+        <property role="37mO49" value="PAGE_SETTING_BOTTOM_RIGHT" />
+        <node concept="gqqVs" id="4yjTpwGVANV" role="37mO4d">
+          <property role="gqqTX" value="75.0" />
+          <property role="gqqTy" value="35.0" />
+          <property role="gqqTZ" value="793" />
+          <property role="gqqTW" value="1122" />
+          <property role="TgtnS" value="1.0;0.0;0.0;1.0;0.0;0.0" />
+        </node>
+      </node>
+      <node concept="37mRIm" id="4yjTpwGVAOT" role="37mRID">
+        <property role="37mO49" value="5229776034058890542" />
+        <node concept="gqqVs" id="4yjTpwGVAOS" role="37mO4d">
+          <property role="gqqTZ" value="0.0" />
+          <property role="gqqTW" value="0.0" />
+          <property role="gqqTX" value="30.0" />
+          <property role="gqqTy" value="26.0" />
+          <property role="TgtnS" value="1.0;0.0;0.0;1.0;0.0;0.0" />
+        </node>
+      </node>
+      <node concept="37mRIm" id="4yjTpwGVAQ5" role="37mRID">
+        <property role="37mO49" value="5229776034058890607" />
+        <node concept="gqqVs" id="4yjTpwGVAQ4" role="37mO4d">
+          <property role="gqqTZ" value="0.0" />
+          <property role="gqqTW" value="0.0" />
+          <property role="gqqTX" value="30.0" />
+          <property role="gqqTy" value="26.0" />
           <property role="TgtnS" value="1.0;0.0;0.0;1.0;0.0;0.0" />
         </node>
       </node>
@@ -652,6 +782,10 @@
         <node concept="1SLyFQ" id="7QzWuw5pvzM" role="19SJt6" />
         <node concept="19SUe$" id="7QzWuw5pvzN" role="19SJt6" />
       </node>
+    </node>
+    <node concept="xZRyP" id="4yjTpwGVAPI" role="xZDQj">
+      <node concept="xHMzG" id="4yjTpwGVAPJ" role="xHLN1" />
+      <node concept="xHMrU" id="4yjTpwGVAPK" role="xHLsg" />
     </node>
   </node>
   <node concept="2vn7XN" id="7TjUbLQa$K1">

--- a/code/languages/com.mpsbasics/languages/com.mpsbasics.plaintext.yaml.dsl.base/models/com.mpsbasics.plaintext.yaml.dsl.base.utils.importer.mps
+++ b/code/languages/com.mpsbasics/languages/com.mpsbasics.plaintext.yaml.dsl.base/models/com.mpsbasics.plaintext.yaml.dsl.base.utils.importer.mps
@@ -1013,13 +1013,25 @@
                           </node>
                         </node>
                       </node>
-                      <node concept="2OqwBi" id="4v4hk0aj4Kq" role="3clFbw">
-                        <node concept="2GrUjf" id="4v4hk0aiIFy" role="2Oq$k0">
-                          <ref role="2Gs0qQ" node="49jqi8rQAky" resolve="scalarNodeChild" />
+                      <node concept="22lmx$" id="1P450_2rgwE" role="3clFbw">
+                        <node concept="2OqwBi" id="4v4hk0aj4Kq" role="3uHU7B">
+                          <node concept="2GrUjf" id="4v4hk0aiIFy" role="2Oq$k0">
+                            <ref role="2Gs0qQ" node="49jqi8rQAky" resolve="scalarNodeChild" />
+                          </node>
+                          <node concept="1mIQ4w" id="4v4hk0aj7_F" role="2OqNvi">
+                            <node concept="chp4Y" id="4v4hk0aj8i3" role="cj9EA">
+                              <ref role="cht4Q" to="bpzl:5jnWVpEAvcn" resolve="IWhitespaceLike" />
+                            </node>
+                          </node>
                         </node>
-                        <node concept="1mIQ4w" id="4v4hk0aj7_F" role="2OqNvi">
-                          <node concept="chp4Y" id="4v4hk0aj8i3" role="cj9EA">
-                            <ref role="cht4Q" to="bpzl:21lHZzX1IBU" resolve="Space" />
+                        <node concept="2OqwBi" id="1P450_2rnhx" role="3uHU7w">
+                          <node concept="2GrUjf" id="1P450_2rijI" role="2Oq$k0">
+                            <ref role="2Gs0qQ" node="49jqi8rQAky" resolve="scalarNodeChild" />
+                          </node>
+                          <node concept="1mIQ4w" id="1P450_2rqmW" role="2OqNvi">
+                            <node concept="chp4Y" id="1P450_2rqZz" role="cj9EA">
+                              <ref role="cht4Q" to="bpzl:3gvcLqnVlJf" resolve="IPunctuationLike" />
+                            </node>
                           </node>
                         </node>
                       </node>

--- a/code/tutorial-safety/solutions/com.mbeddr.formal.safety.tutorial/models/_010_features._050_structured_assurance_cases/_010_plain_text_gsn.mpsr
+++ b/code/tutorial-safety/solutions/com.mbeddr.formal.safety.tutorial/models/_010_features._050_structured_assurance_cases/_010_plain_text_gsn.mpsr
@@ -52,6 +52,16 @@
       </concept>
     </language>
     <language id="83ed2dfe-f724-46cc-852a-dce086daee3f" name="com.mbeddr.formal.base">
+      <concept id="5287643628390203696" name="com.mbeddr.formal.base.structure.A5PageLandscape" flags="ng" index="wrNFH" />
+      <concept id="5287643628386540839" name="com.mbeddr.formal.base.structure.PageSettingsBottomRight" flags="ng" index="xHMrU" />
+      <concept id="5287643628386538289" name="com.mbeddr.formal.base.structure.PageSettingsTopLeft" flags="ng" index="xHMzG" />
+      <concept id="5287643628382845845" name="com.mbeddr.formal.base.structure.PageSettingBase" flags="ng" index="xZ818">
+        <child id="5287643628386544845" name="bottomRight" index="xHLsg" />
+        <child id="5287643628386543388" name="topLeft" index="xHLN1" />
+      </concept>
+      <concept id="5287643628382841294" name="com.mbeddr.formal.base.structure.IDiagramWithPageSettingContainer" flags="ngI" index="xZ98j">
+        <child id="5287643628382971470" name="pageSetting" index="xZDQj" />
+      </concept>
       <concept id="7402587364850275469" name="com.mbeddr.formal.base.structure.IAttributeContainer" flags="ngI" index="2U2l5L">
         <child id="7402587364850275470" name="attributes" index="2U2l5M" />
       </concept>
@@ -101,8 +111,8 @@
       <node concept="37mRIm" id="7L33HENdux3" role="37mRID">
         <property role="37mO49" value="8954016816614991919" />
         <node concept="gqqVs" id="7L33HENdux1" role="37mO4d">
-          <property role="gqqTZ" value="206.0" />
-          <property role="gqqTW" value="118.0" />
+          <property role="gqqTZ" value="246.0" />
+          <property role="gqqTW" value="148.0" />
           <property role="gqqTX" value="208.0" />
           <property role="gqqTy" value="60.0" />
           <property role="TgtnS" value="1.0;0.0;0.0;1.0;0.0;0.0" />
@@ -111,8 +121,8 @@
       <node concept="37mRIm" id="7L33HENduxA" role="37mRID">
         <property role="37mO49" value="8954016816614991952" />
         <node concept="gqqVs" id="7L33HENdux_" role="37mO4d">
-          <property role="gqqTZ" value="213.0" />
-          <property role="gqqTW" value="236.0" />
+          <property role="gqqTZ" value="253.0" />
+          <property role="gqqTW" value="266.0" />
           <property role="gqqTX" value="194.0" />
           <property role="gqqTy" value="44.0" />
           <property role="TgtnS" value="1.0;0.0;0.0;1.0;0.0;0.0" />
@@ -121,8 +131,8 @@
       <node concept="37mRIm" id="7L33HENduyp" role="37mRID">
         <property role="37mO49" value="8954016816614992000" />
         <node concept="gqqVs" id="7L33HENduyo" role="37mO4d">
-          <property role="gqqTZ" value="164.0" />
-          <property role="gqqTW" value="338.0" />
+          <property role="gqqTZ" value="204.0" />
+          <property role="gqqTW" value="368.0" />
           <property role="gqqTX" value="119.0" />
           <property role="gqqTy" value="60.0" />
           <property role="TgtnS" value="1.0;0.0;0.0;1.0;0.0;0.0" />
@@ -132,12 +142,12 @@
         <property role="37mO49" value="8954016816614991992" />
         <node concept="2VclpC" id="7L33HENduyq" role="37mO4d">
           <node concept="2VclrF" id="2FavYGw1Zk_" role="2Vcluh">
-            <property role="2Vclpx" value="309.0" />
-            <property role="2Vclpz" value="206.0" />
+            <property role="2Vclpx" value="349.0" />
+            <property role="2Vclpz" value="236.0" />
           </node>
           <node concept="2VclrF" id="2FavYGw1ZkA" role="2Vcluh">
-            <property role="2Vclpx" value="309.0" />
-            <property role="2Vclpz" value="206.0" />
+            <property role="2Vclpx" value="349.0" />
+            <property role="2Vclpz" value="236.0" />
           </node>
           <node concept="3ul5H1" id="2FavYGw1ZkB" role="3ul5Gx">
             <node concept="3wpmZ1" id="2FavYGw1ZkC" role="3ul5Gz">
@@ -157,12 +167,12 @@
         <property role="37mO49" value="8954016816614992071" />
         <node concept="2VclpC" id="7L33HENduzg" role="37mO4d">
           <node concept="2VclrF" id="2FavYGw1ZkF" role="2Vcluh">
-            <property role="2Vclpx" value="309.0" />
-            <property role="2Vclpz" value="308.0" />
+            <property role="2Vclpx" value="349.0" />
+            <property role="2Vclpz" value="338.0" />
           </node>
           <node concept="2VclrF" id="2FavYGw1ZkG" role="2Vcluh">
-            <property role="2Vclpx" value="222.0" />
-            <property role="2Vclpz" value="308.0" />
+            <property role="2Vclpx" value="262.0" />
+            <property role="2Vclpz" value="338.0" />
           </node>
           <node concept="3ul5H1" id="2FavYGw1ZkH" role="3ul5Gx">
             <node concept="3wpmZ1" id="2FavYGw1ZkI" role="3ul5Gz">
@@ -181,8 +191,8 @@
       <node concept="37mRIm" id="3jaLROLvqyK" role="37mRID">
         <property role="37mO49" value="3804072175782963270" />
         <node concept="gqqVs" id="3jaLROLvqyJ" role="37mO4d">
-          <property role="gqqTZ" value="346.0" />
-          <property role="gqqTW" value="338.0" />
+          <property role="gqqTZ" value="386.0" />
+          <property role="gqqTW" value="368.0" />
           <property role="gqqTX" value="110.0" />
           <property role="gqqTy" value="60.0" />
           <property role="TgtnS" value="1.0;0.0;0.0;1.0;0.0;0.0" />
@@ -192,12 +202,12 @@
         <property role="37mO49" value="3804072175782963490" />
         <node concept="2VclpC" id="3jaLROLvq_j" role="37mO4d">
           <node concept="2VclrF" id="2FavYGw1ZkL" role="2Vcluh">
-            <property role="2Vclpx" value="309.0" />
-            <property role="2Vclpz" value="308.0" />
+            <property role="2Vclpx" value="349.0" />
+            <property role="2Vclpz" value="338.0" />
           </node>
           <node concept="2VclrF" id="2FavYGw1ZkM" role="2Vcluh">
-            <property role="2Vclpx" value="400.0" />
-            <property role="2Vclpz" value="308.0" />
+            <property role="2Vclpx" value="440.0" />
+            <property role="2Vclpz" value="338.0" />
           </node>
           <node concept="3ul5H1" id="2FavYGw1ZkN" role="3ul5Gx">
             <node concept="3wpmZ1" id="2FavYGw1ZkO" role="3ul5Gz">
@@ -310,8 +320,8 @@
       <node concept="37mRIm" id="2hB9zGID8DR" role="37mRID">
         <property role="37mO49" value="2623107343594064426" />
         <node concept="gqqVs" id="2hB9zGID8DQ" role="37mO4d">
-          <property role="gqqTZ" value="50.0" />
-          <property role="gqqTW" value="118.0" />
+          <property role="gqqTZ" value="90.0" />
+          <property role="gqqTW" value="148.0" />
           <property role="gqqTX" value="98.0" />
           <property role="gqqTy" value="60.0" />
           <property role="TgtnS" value="1.0;0.0;0.0;1.0;0.0;0.0" />
@@ -321,12 +331,12 @@
         <property role="37mO49" value="2623107343594064619" />
         <node concept="2VclpC" id="2hB9zGID8GE" role="37mO4d">
           <node concept="2VclrF" id="2FavYGw1ZkX" role="2Vcluh">
-            <property role="2Vclpx" value="206.0" />
-            <property role="2Vclpz" value="147.0" />
+            <property role="2Vclpx" value="246.0" />
+            <property role="2Vclpz" value="177.0" />
           </node>
           <node concept="2VclrF" id="2FavYGw1ZkY" role="2Vcluh">
-            <property role="2Vclpx" value="156.0" />
-            <property role="2Vclpz" value="147.0" />
+            <property role="2Vclpx" value="196.0" />
+            <property role="2Vclpz" value="177.0" />
           </node>
           <node concept="3ul5H1" id="2FavYGw1ZkZ" role="3ul5Gx">
             <node concept="3wpmZ1" id="2FavYGw1Zl0" role="3ul5Gz">
@@ -345,8 +355,8 @@
       <node concept="37mRIm" id="2hB9zGID8QN" role="37mRID">
         <property role="37mO49" value="2623107343594065251" />
         <node concept="gqqVs" id="2hB9zGID8QM" role="37mO4d">
-          <property role="gqqTZ" value="455.0" />
-          <property role="gqqTW" value="236.0" />
+          <property role="gqqTZ" value="495.0" />
+          <property role="gqqTW" value="266.0" />
           <property role="gqqTX" value="194.0" />
           <property role="gqqTy" value="60.0" />
           <property role="TgtnS" value="1.0;0.0;0.0;1.0;0.0;0.0" />
@@ -356,12 +366,12 @@
         <property role="37mO49" value="2623107343594065572" />
         <node concept="2VclpC" id="2hB9zGID8V$" role="37mO4d">
           <node concept="2VclrF" id="2FavYGw1Zl3" role="2Vcluh">
-            <property role="2Vclpx" value="405.0" />
-            <property role="2Vclpz" value="257.0" />
+            <property role="2Vclpx" value="445.0" />
+            <property role="2Vclpz" value="287.0" />
           </node>
           <node concept="2VclrF" id="2FavYGw1Zl4" role="2Vcluh">
-            <property role="2Vclpx" value="455.0" />
-            <property role="2Vclpz" value="265.0" />
+            <property role="2Vclpx" value="495.0" />
+            <property role="2Vclpz" value="295.0" />
           </node>
           <node concept="3ul5H1" id="2FavYGw1Zl5" role="3ul5Gx">
             <node concept="3wpmZ1" id="2FavYGw1Zl6" role="3ul5Gz">
@@ -380,8 +390,8 @@
       <node concept="37mRIm" id="2hB9zGID932" role="37mRID">
         <property role="37mO49" value="2623107343594066031" />
         <node concept="gqqVs" id="2hB9zGID931" role="37mO4d">
-          <property role="gqqTZ" value="311.0" />
-          <property role="gqqTW" value="456.0" />
+          <property role="gqqTZ" value="351.0" />
+          <property role="gqqTW" value="476.0" />
           <property role="gqqTX" value="180.0" />
           <property role="gqqTy" value="44.0" />
           <property role="TgtnS" value="1.0;0.0;0.0;1.0;0.0;0.0" />
@@ -391,12 +401,12 @@
         <property role="37mO49" value="2623107343594066248" />
         <node concept="2VclpC" id="2hB9zGID969" role="37mO4d">
           <node concept="2VclrF" id="2FavYGw1ZkR" role="2Vcluh">
-            <property role="2Vclpx" value="400.0" />
-            <property role="2Vclpz" value="426.0" />
+            <property role="2Vclpx" value="440.0" />
+            <property role="2Vclpz" value="456.0" />
           </node>
           <node concept="2VclrF" id="2FavYGw1ZkS" role="2Vcluh">
-            <property role="2Vclpx" value="400.0" />
-            <property role="2Vclpz" value="426.0" />
+            <property role="2Vclpx" value="440.0" />
+            <property role="2Vclpz" value="456.0" />
           </node>
           <node concept="3ul5H1" id="2FavYGw1ZkT" role="3ul5Gx">
             <node concept="3wpmZ1" id="2FavYGw1ZkU" role="3ul5Gz">
@@ -415,8 +425,8 @@
       <node concept="37mRIm" id="2hB9zGID9bQ" role="37mRID">
         <property role="37mO49" value="2623107343594066592" />
         <node concept="gqqVs" id="2hB9zGID9bP" role="37mO4d">
-          <property role="gqqTZ" value="462.0" />
-          <property role="gqqTW" value="118.0" />
+          <property role="gqqTZ" value="502.0" />
+          <property role="gqqTW" value="148.0" />
           <property role="gqqTX" value="194.0" />
           <property role="gqqTy" value="60.0" />
           <property role="TgtnS" value="1.0;0.0;0.0;1.0;0.0;0.0" />
@@ -426,12 +436,12 @@
         <property role="37mO49" value="2623107343594066820" />
         <node concept="2VclpC" id="2hB9zGID9f6" role="37mO4d">
           <node concept="2VclrF" id="2FavYGw1Zl9" role="2Vcluh">
-            <property role="2Vclpx" value="412.0" />
-            <property role="2Vclpz" value="147.0" />
+            <property role="2Vclpx" value="452.0" />
+            <property role="2Vclpz" value="177.0" />
           </node>
           <node concept="2VclrF" id="2FavYGw1Zla" role="2Vcluh">
-            <property role="2Vclpx" value="462.0" />
-            <property role="2Vclpz" value="147.0" />
+            <property role="2Vclpx" value="502.0" />
+            <property role="2Vclpz" value="177.0" />
           </node>
           <node concept="3ul5H1" id="2FavYGw1Zlb" role="3ul5Gx">
             <node concept="3wpmZ1" id="2FavYGw1Zlc" role="3ul5Gz">
@@ -460,10 +470,40 @@
       <node concept="37mRIm" id="336$aoTKiLa" role="37mRID">
         <property role="37mO49" value="3514655602817182745" />
         <node concept="gqqVs" id="336$aoTKiL9" role="37mO4d">
-          <property role="gqqTZ" value="196.0" />
-          <property role="gqqTW" value="20.000100000000003" />
+          <property role="gqqTZ" value="236.0" />
+          <property role="gqqTW" value="50.0001" />
           <property role="gqqTX" value="224.0" />
           <property role="gqqTy" value="60.0" />
+          <property role="TgtnS" value="1.0;0.0;0.0;1.0;0.0;0.0" />
+        </node>
+      </node>
+      <node concept="37mRIm" id="1P450_2$BcN" role="37mRID">
+        <property role="37mO49" value="PAGE_SETTING_BOTTOM_RIGHT" />
+        <node concept="gqqVs" id="1P450_2$BcM" role="37mO4d">
+          <property role="gqqTX" value="75.0" />
+          <property role="gqqTy" value="35.0" />
+          <property role="gqqTZ" value="793" />
+          <property role="gqqTW" value="555" />
+          <property role="TgtnS" value="1.0;0.0;0.0;1.0;0.0;0.0" />
+        </node>
+      </node>
+      <node concept="37mRIm" id="1P450_2$Bmk" role="37mRID">
+        <property role="37mO49" value="2108832555520389928" />
+        <node concept="gqqVs" id="1P450_2$Bmj" role="37mO4d">
+          <property role="gqqTZ" value="0.0" />
+          <property role="gqqTW" value="0.0" />
+          <property role="gqqTX" value="30.0" />
+          <property role="gqqTy" value="26.0" />
+          <property role="TgtnS" value="1.0;0.0;0.0;1.0;0.0;0.0" />
+        </node>
+      </node>
+      <node concept="37mRIm" id="1P450_2$Bv$" role="37mRID">
+        <property role="37mO49" value="2108832555520391000" />
+        <node concept="gqqVs" id="1P450_2$Bvz" role="37mO4d">
+          <property role="gqqTZ" value="0.0" />
+          <property role="gqqTW" value="0.0" />
+          <property role="gqqTX" value="30.0" />
+          <property role="gqqTy" value="26.0" />
           <property role="TgtnS" value="1.0;0.0;0.0;1.0;0.0;0.0" />
         </node>
       </node>
@@ -571,6 +611,10 @@
           <property role="19SUeA" value="Basic example of a text-based &#10;structured assurance case part&#10;of the FASTEN-Safe tutorial." />
         </node>
       </node>
+    </node>
+    <node concept="wrNFH" id="1P450_2$Btn" role="xZDQj">
+      <node concept="xHMzG" id="1P450_2$Bto" role="xHLN1" />
+      <node concept="xHMrU" id="1P450_2$Btp" role="xHLsg" />
     </node>
   </node>
 </model>

--- a/code/tutorial-safety/solutions/com.mbeddr.formal.safety.tutorial/models/_010_features._050_structured_assurance_cases/_020_patterns_instantiated_from_library.mpsr
+++ b/code/tutorial-safety/solutions/com.mbeddr.formal.safety.tutorial/models/_010_features._050_structured_assurance_cases/_020_patterns_instantiated_from_library.mpsr
@@ -67,6 +67,16 @@
       </concept>
     </language>
     <language id="83ed2dfe-f724-46cc-852a-dce086daee3f" name="com.mbeddr.formal.base">
+      <concept id="5287643628386540839" name="com.mbeddr.formal.base.structure.PageSettingsBottomRight" flags="ng" index="xHMrU" />
+      <concept id="5287643628386538289" name="com.mbeddr.formal.base.structure.PageSettingsTopLeft" flags="ng" index="xHMzG" />
+      <concept id="5287643628382845845" name="com.mbeddr.formal.base.structure.PageSettingBase" flags="ng" index="xZ818">
+        <child id="5287643628386544845" name="bottomRight" index="xHLsg" />
+        <child id="5287643628386543388" name="topLeft" index="xHLN1" />
+      </concept>
+      <concept id="5287643628382841294" name="com.mbeddr.formal.base.structure.IDiagramWithPageSettingContainer" flags="ngI" index="xZ98j">
+        <child id="5287643628382971470" name="pageSetting" index="xZDQj" />
+      </concept>
+      <concept id="5287643628382847848" name="com.mbeddr.formal.base.structure.A4PagePortrait" flags="ng" index="xZRyP" />
       <concept id="7402587364850275469" name="com.mbeddr.formal.base.structure.IAttributeContainer" flags="ngI" index="2U2l5L">
         <child id="7402587364850275470" name="attributes" index="2U2l5M" />
       </concept>
@@ -371,6 +381,15 @@
           </node>
         </node>
       </node>
+      <node concept="37mRIm" id="1P450_2$BiK" role="37mRID">
+        <property role="37mO49" value="PAGE_SETTING_BOTTOM_RIGHT" />
+        <node concept="gqqVs" id="1P450_2$BiJ" role="37mO4d">
+          <property role="gqqTX" value="75" />
+          <property role="gqqTy" value="35" />
+          <property role="gqqTZ" value="793" />
+          <property role="gqqTW" value="1122" />
+        </node>
+      </node>
     </node>
     <node concept="1VB52A" id="WKGDODSTiW" role="2vn1q5">
       <ref role="AygKy" to="6r4f:3jaLROLvqLi" resolve="Argument Over Hazards" />
@@ -611,6 +630,10 @@
     </node>
     <node concept="26s6xy" id="3ALtb$im2a9" role="2WHcHu">
       <property role="2Wzj7u" value="6312041527983384237" />
+    </node>
+    <node concept="xZRyP" id="1P450_2$BhU" role="xZDQj">
+      <node concept="xHMzG" id="1P450_2$BhV" role="xHLN1" />
+      <node concept="xHMrU" id="1P450_2$BhW" role="xHLsg" />
     </node>
   </node>
 </model>


### PR DESCRIPTION
- enhance diagrams with hints about the page sizes (A0, A1, A2, A3, A4, A5)
- mini fix of the DslImporter for plain-text yaml
- mini fix of the attributes base concept for goal structure entities