### PR TITLE
[breaking] Finalize upgrade to docx4j 11.5

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,7 @@ plugins {
     id("download-jbr") version mpsGradlePluginVersion
     id("de.itemis.mps.gradle.common") version mpsGradlePluginVersion
 
-    id("org.cyclonedx.bom") version "2.2.0"
+    id("org.cyclonedx.bom") version "3.2.4"
 }
 
 val jbrVers = "21.0.6-b895.109"
@@ -499,7 +499,7 @@ tasks {
     }
 
     val package_formal by registering(Zip::class) {
-        dependsOn(build_formal_languages, cyclonedxBom)
+        dependsOn(build_formal_languages, cyclonedxDirectBom)
         archiveBaseName.set("com.mbeddr.formal")
         from(artifactsDir) {
             include("com.mbeddr.formal.languages/**")
@@ -517,7 +517,7 @@ tasks {
     }
 
     val package_assurance by registering(Zip::class) {
-        dependsOn(build_assurance_languages, cyclonedxBom)
+        dependsOn(build_assurance_languages, cyclonedxDirectBom)
         archiveBaseName.set("fasten.assurance")
         from(artifactsDir) {
             include("fasten.assurance.languages/**")
@@ -606,24 +606,23 @@ tasks {
         delete(fileTree(projectDir) { include("**/classes_gen/**", "**/source_gen/**", "**/source_gen.caches/**", "tmp/**") })
     }
 
-cyclonedxBom {
-    destination = layout.buildDirectory.dir("reports").get().asFile
-    outputName = "sbom"
-    outputFormat = "json"
-    includeLicenseText = false
-    includeConfigs = listOf(
-        "languageLibs",
-        "docx4j",
-	"langchain4j",
-        "plantUML",
-        "sat4j",
-        "jfreechart",
-        "nusmv",
-        "z3",
-        "jira",
-        "pdfbox"
-    )
-}
+    cyclonedxDirectBom {
+        jsonOutput = layout.buildDirectory.file("reports/sbom.json")
+        xmlOutput.unsetConvention()
+        includeLicenseText = false
+        includeConfigs = listOf(
+            "languageLibs",
+            "docx4j",
+            "langchain4j",
+            "plantUML",
+            "sat4j",
+            "jfreechart",
+            "nusmv",
+            "z3",
+            "jira",
+            "pdfbox"
+        )
+    }
 
     //clean { dependsOn(cleanMps) }
     val rebuild by registering { dependsOn(clean, build_formal_languages) }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -372,8 +372,18 @@ tasks {
         script = scriptFile("build_all_scripts.xml")
     }
 
-    val build_formal_languages by registering(BuildLanguages::class) {
+    val build_mpsbasics_languages by registering(BuildLanguages::class) {
         dependsOn(build_allScripts)
+        script = scriptFile("build-mpsbasics-languages.xml")
+    }
+
+    val run_mpsbasics_tests by registering(TestLanguages::class) {
+        dependsOn(build_mpsbasics_languages)
+        script = scriptFile("test-mpsbasics-languages.xml")
+    }
+
+    val build_formal_languages by registering(BuildLanguages::class) {
+        dependsOn(build_mpsbasics_languages)
         script = scriptFile("build-formal-languages.xml")
     }
 
@@ -419,7 +429,7 @@ tasks {
     }
 
     val run_all_tests by registering(TestLanguages::class) {
-        dependsOn(configureJava)
+        dependsOn(configureJava, build_formal_languages)
         description = "Will execute all tests from command line"
         script = scriptFile("build-all-tests.xml")
         doLast {
@@ -466,7 +476,8 @@ tasks {
                 listOf(
                     "dependencies/com.mbeddr.platform",
                     "dependencies/org.mpsqa.allInOne",
-                    "artifacts/com.mbeddr.formal.languages").map { buildDir.dir(it) }
+                    "artifacts/com.mbeddr.formal.languages",
+                    "artifacts/com.mpsbasics").map { buildDir.dir(it) }
             })
 
         maxHeapSize = "3G"
@@ -493,10 +504,6 @@ tasks {
         dependsOn(withType<MpsCheck>())
     }
 
-    check {
-        dependsOn(run_all_tests, checkModels)
-    }
-
     val package_formal by registering(Zip::class) {
         dependsOn(build_formal_languages, cyclonedxDirectBom)
         archiveBaseName.set("com.mbeddr.formal")
@@ -511,7 +518,7 @@ tasks {
     }
 
     val build_assurance_languages by registering(BuildLanguages::class) {
-        dependsOn(build_allScripts)
+        dependsOn(build_mpsbasics_languages)
         script = scriptFile("build-assurance-languages.xml")
     }
 
@@ -597,6 +604,14 @@ tasks {
 	// as of 01.2025, all languages built by 'build_assurance_languages' are also built by 'build_formal_languages'
 	// commented out to avoid multiple building of the same languages
         dependsOn(/*build_assurance_languages,*/ build_formal_languages)
+    }
+
+    test {
+        dependsOn(run_all_tests, run_mpsbasics_tests)
+    }
+
+    check {
+        dependsOn(checkModels)
     }
 
     assemble { dependsOn(package_formal, package_assurance) }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -458,6 +458,7 @@ tasks {
                 listOf(
                     "dependencies/com.mbeddr.platform",
                     "dependencies/org.mpsqa.allInOne",
+                    "artifacts/com.mpsbasics",
                     "artifacts/com.mbeddr.formal.languages").map { buildDir.dir(it) }
             })
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -229,8 +229,6 @@ val defaultScriptArgs = mapOf(
         "build.dir" to layout.buildDirectory.get(),
         "version" to version,
         "build.date" to Date(),
-        //incremental build support
-        "mps.generator.skipUnmodifiedModels" to true,
         "jdk.nio.zipfs.allowDotZipEntry" to true,
         "jdk.util.zip.disableZip64ExtraFieldValidation" to true,
         "build.jna.library.path" to mpsHomeDir.resolve("lib/jna/$jnaArch")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -170,19 +170,20 @@ dependencyLocking { lockAllConfigurations() }
 
 repositories {
     mavenCentral()
-    val dependencyRepositories = listOf("https://artifacts.itemis.cloud/repository/maven-mps",
-            "https://maven.pkg.github.com/mbeddr/*","https://packages.atlassian.com/mvn/maven-external")
+    maven("https://artifacts.itemis.cloud/repository/maven-mps")
 
-    for (repoUrl in dependencyRepositories) {
-        maven {
-            url = uri(repoUrl)
+    maven("https://maven.pkg.github.com/mbeddr/*") {
+        credentials {
+            username = project.property("gpr.user") as String
+            password = project.property("gpr.token") as String
+        }
+    }
 
-            if (repoUrl.startsWith("https://maven.pkg.github.com/")) {
-                credentials {
-                    username = project.property("gpr.user") as String
-                    password = project.property("gpr.token") as String
-                }
-            }
+    // Atlassian stuff is only in the Atlassian repo, tell Gradle to not look for it anywhere else.
+    exclusiveContent {
+        forRepositories(maven("https://packages.atlassian.com/mvn/maven-external"))
+        filter {
+            includeGroupByRegex("com\\.atlassian.*")
         }
     }
 }

--- a/build/scripts/build_all_scripts.xml
+++ b/build/scripts/build_all_scripts.xml
@@ -157,6 +157,7 @@
     </echoxml>
     <jar destfile="${build.layout}/com.mpsbasics.build.jar" duplicate="preserve">
       <fileset dir="${build.tmp}/java/out/com.mpsbasics.build" />
+      <fileset dir="${mbeddr.formal.home}/code/languages/com.mpsbasics/solutions/com.mpsbasics.build" includes="icons/**, resources/**" />
       <fileset dir="${mbeddr.formal.home}/code/languages/com.mpsbasics/solutions/com.mpsbasics.build/source_gen" includes="**/trace.info, **/exports, **/*.mps, **/checkpoints" />
       <fileset dir="${build.tmp}/default/com.mpsbasics.build.jar" />
     </jar>
@@ -194,6 +195,7 @@
     </echoxml>
     <jar destfile="${build.layout}/com.mpsbasics.tests.build.jar" duplicate="preserve">
       <fileset dir="${build.tmp}/java/out/com.mpsbasics.tests.build" />
+      <fileset dir="${mbeddr.formal.home}/code/languages/com.mpsbasics/solutions/com.mpsbasics.tests.build" includes="icons/**, resources/**" />
       <fileset dir="${mbeddr.formal.home}/code/languages/com.mpsbasics/solutions/com.mpsbasics.tests.build/source_gen" includes="**/trace.info, **/exports, **/*.mps, **/checkpoints" />
       <fileset dir="${build.tmp}/default/com.mpsbasics.tests.build.jar" />
     </jar>

--- a/build/scripts/build_all_scripts.xml
+++ b/build/scripts/build_all_scripts.xml
@@ -62,6 +62,7 @@
       <module namespace="com.mbeddr.formal.safety.build" type="solution" uuid="b4bbc0a5-248e-4db2-9ddc-4901a463c66c">
         <dependencies>
           <module ref="3ae9cfda-f938-4524-b4ca-fbcba3b0525b(com.mbeddr.platform)" kind="cl" />
+          <module ref="ff2a102e-f030-4756-a6c9-02da709c686f(com.mpsbasics.build)" kind="cl" />
           <module ref="f1fb7b1c-ce0d-423c-9369-4a661d600029(de.itemis.mps.extensions.build)" kind="cl" />
           <module ref="5e8cea6b-997f-49b1-a8d8-dc2a7a6fa657(org.mpsqa.base.build)" kind="cl" />
           <module ref="11d4368a-a7e8-4dd9-bfc6-c2de268d1994(org.mpsqa.build)" kind="cl" />
@@ -103,6 +104,7 @@
       <module namespace="com.fasten.assurance.build" type="solution" uuid="7301161d-854c-45d9-b0d7-121b4fb52625">
         <dependencies>
           <module ref="3ae9cfda-f938-4524-b4ca-fbcba3b0525b(com.mbeddr.platform)" kind="cl" />
+          <module ref="ff2a102e-f030-4756-a6c9-02da709c686f(com.mpsbasics.build)" kind="cl" />
           <module ref="f1fb7b1c-ce0d-423c-9369-4a661d600029(de.itemis.mps.extensions.build)" kind="cl" />
           <module ref="5e8cea6b-997f-49b1-a8d8-dc2a7a6fa657(org.mpsqa.base.build)" kind="cl" />
         </dependencies>
@@ -135,6 +137,79 @@
       <zipfileset file="${mbeddr.formal.safety.code}/solutions/com.fasten.assurance.build/com.fasten.assurance.build.msd" prefix="module" />
       <zipfileset dir="${build.tmp}/customProcessors/copyModels/solutions-com.fasten.assurance.build-models" prefix="module/models" />
     </jar>
+    <mkdir dir="${build.tmp}/default/com.mpsbasics.build.jar" />
+    <mkdir dir="${build.tmp}/default/com.mpsbasics.build.jar/META-INF" />
+    <echoxml file="${build.tmp}/default/com.mpsbasics.build.jar/META-INF/module.xml">
+      <module namespace="com.mpsbasics.build" type="solution" uuid="ff2a102e-f030-4756-a6c9-02da709c686f">
+        <dependencies>
+          <module ref="3ae9cfda-f938-4524-b4ca-fbcba3b0525b(com.mbeddr.platform)" kind="cl" />
+          <module ref="f1fb7b1c-ce0d-423c-9369-4a661d600029(de.itemis.mps.extensions.build)" kind="cl" />
+        </dependencies>
+        <uses>
+          <language id="l:798100da-4f0a-421a-b991-71f8c50ce5d2:jetbrains.mps.build" />
+          <language id="l:0cf935df-4699-4e9c-a132-fa109541cba3:jetbrains.mps.build.mps" />
+        </uses>
+        <classpath>
+          <entry path="." />
+        </classpath>
+        <sources jar="com.mpsbasics.build-src.jar" descriptor="com.mpsbasics.build.msd" />
+      </module>
+    </echoxml>
+    <jar destfile="${build.layout}/com.mpsbasics.build.jar" duplicate="preserve">
+      <fileset dir="${build.tmp}/java/out/com.mpsbasics.build" />
+      <fileset dir="${mbeddr.formal.home}/code/languages/com.mpsbasics/solutions/com.mpsbasics.build/source_gen" includes="**/trace.info, **/exports, **/*.mps, **/checkpoints" />
+      <fileset dir="${build.tmp}/default/com.mpsbasics.build.jar" />
+    </jar>
+    <copyModels todir="${build.tmp}/customProcessors/copyModels/code-languages-com.mpsbasics-solutions-com.mpsbasics.build-models">
+      <fileset dir="${mbeddr.formal.home}/code/languages/com.mpsbasics/solutions/com.mpsbasics.build/models" includes="**/*.mps, **/*.mpsr, **/.model" />
+    </copyModels>
+    <jar destfile="${build.layout}/com.mpsbasics.build-src.jar" duplicate="preserve">
+      <fileset dir="${mbeddr.formal.home}/code/languages/com.mpsbasics/solutions/com.mpsbasics.build/source_gen">
+        <exclude name="**/trace.info" />
+        <exclude name="**/exports" />
+        <exclude name="**/checkpoints" />
+        <exclude name="**/*.mps" />
+      </fileset>
+      <zipfileset file="${mbeddr.formal.home}/code/languages/com.mpsbasics/solutions/com.mpsbasics.build/com.mpsbasics.build.msd" prefix="module" />
+      <zipfileset dir="${build.tmp}/customProcessors/copyModels/code-languages-com.mpsbasics-solutions-com.mpsbasics.build-models" prefix="module/models" />
+    </jar>
+    <mkdir dir="${build.tmp}/default/com.mpsbasics.tests.build.jar" />
+    <mkdir dir="${build.tmp}/default/com.mpsbasics.tests.build.jar/META-INF" />
+    <echoxml file="${build.tmp}/default/com.mpsbasics.tests.build.jar/META-INF/module.xml">
+      <module namespace="com.mpsbasics.tests.build" type="solution" uuid="501fd540-aef3-4d7b-b289-4bdbc8b5a74a">
+        <dependencies>
+          <module ref="3ae9cfda-f938-4524-b4ca-fbcba3b0525b(com.mbeddr.platform)" kind="cl" />
+          <module ref="ff2a102e-f030-4756-a6c9-02da709c686f(com.mpsbasics.build)" kind="cl" />
+        </dependencies>
+        <uses>
+          <language id="l:798100da-4f0a-421a-b991-71f8c50ce5d2:jetbrains.mps.build" />
+          <language id="l:0cf935df-4699-4e9c-a132-fa109541cba3:jetbrains.mps.build.mps" />
+          <language id="l:3600cb0a-44dd-4a5b-9968-22924406419e:jetbrains.mps.build.mps.tests" />
+        </uses>
+        <classpath>
+          <entry path="." />
+        </classpath>
+        <sources jar="com.mpsbasics.tests.build-src.jar" descriptor="com.mpsbasics.tests.build.msd" />
+      </module>
+    </echoxml>
+    <jar destfile="${build.layout}/com.mpsbasics.tests.build.jar" duplicate="preserve">
+      <fileset dir="${build.tmp}/java/out/com.mpsbasics.tests.build" />
+      <fileset dir="${mbeddr.formal.home}/code/languages/com.mpsbasics/solutions/com.mpsbasics.tests.build/source_gen" includes="**/trace.info, **/exports, **/*.mps, **/checkpoints" />
+      <fileset dir="${build.tmp}/default/com.mpsbasics.tests.build.jar" />
+    </jar>
+    <copyModels todir="${build.tmp}/customProcessors/copyModels/code-languages-com.mpsbasics-solutions-com.mpsbasics.tests.build-models">
+      <fileset dir="${mbeddr.formal.home}/code/languages/com.mpsbasics/solutions/com.mpsbasics.tests.build/models" includes="**/*.mps, **/*.mpsr, **/.model" />
+    </copyModels>
+    <jar destfile="${build.layout}/com.mpsbasics.tests.build-src.jar" duplicate="preserve">
+      <fileset dir="${mbeddr.formal.home}/code/languages/com.mpsbasics/solutions/com.mpsbasics.tests.build/source_gen">
+        <exclude name="**/trace.info" />
+        <exclude name="**/exports" />
+        <exclude name="**/checkpoints" />
+        <exclude name="**/*.mps" />
+      </fileset>
+      <zipfileset file="${mbeddr.formal.home}/code/languages/com.mpsbasics/solutions/com.mpsbasics.tests.build/com.mpsbasics.tests.build.msd" prefix="module" />
+      <zipfileset dir="${build.tmp}/customProcessors/copyModels/code-languages-com.mpsbasics-solutions-com.mpsbasics.tests.build-models" prefix="module/models" />
+    </jar>
     <echo file="${build.layout}/build.properties">mps.build.number=${mps.build.number}${line.separator}mps.date=${mps.date}${line.separator}mps.build.vcs.number=${mps.build.vcs.number}${line.separator}mps.teamcity.buildConfName=${mps.teamcity.buildConfName}${line.separator}mps.idea.platform.build.number=${mps.idea.platform.build.number}${line.separator}mps.mps.build.counter=${mps.mps.build.counter}${line.separator}mps.runtimeBuild=${mps.runtimeBuild}${line.separator}mpsBootstrapCore.version.major=${mpsBootstrapCore.version.major}${line.separator}mpsBootstrapCore.version.minor=${mpsBootstrapCore.version.minor}${line.separator}mpsBootstrapCore.version.bugfixNr=${mpsBootstrapCore.version.bugfixNr}${line.separator}mpsBootstrapCore.version.eap=${mpsBootstrapCore.version.eap}${line.separator}mpsBootstrapCore.version=${mpsBootstrapCore.version}${line.separator}com.mbeddr.platform.major.version=${com.mbeddr.platform.major.version}${line.separator}com.mbeddr.platform.minor.version=${com.mbeddr.platform.minor.version}${line.separator}com.mbeddr.platform.build=${com.mbeddr.platform.build}${line.separator}com.mbeddr.platform.mbeddr.version=${com.mbeddr.platform.mbeddr.version}${line.separator}de.itemis.mps.extensions.version=${de.itemis.mps.extensions.version}${line.separator}com.mbeddr.mpsutil.actionsfilter.major.version=${com.mbeddr.mpsutil.actionsfilter.major.version}${line.separator}com.mbeddr.mpsutil.actionsfilter.minor.version=${com.mbeddr.mpsutil.actionsfilter.minor.version}${line.separator}com.mbeddr.mpsutil.actionsfilter.build=${com.mbeddr.mpsutil.actionsfilter.build}${line.separator}com.mbeddr.mpsutil.actionsfilter.mbeddr.version=${com.mbeddr.mpsutil.actionsfilter.mbeddr.version}</echo>
   </target>
   
@@ -149,7 +224,7 @@
     <delete dir="${build.layout}" />
   </target>
   
-  <target name="compileJava" depends="java.compile.com.mbeddr.formal.safety.build, java.compile.com.fasten.assurance.build" />
+  <target name="compileJava" depends="java.compile.com.mbeddr.formal.safety.build, java.compile.com.fasten.assurance.build, java.compile.com.mpsbasics.build, java.compile.com.mpsbasics.tests.build" />
   
   <target name="processResources" />
   
@@ -175,6 +250,8 @@
       <chunk>
         <module file="${mbeddr.formal.safety.code}/solutions/com.fasten.assurance.build/com.fasten.assurance.build.msd" />
         <module file="${mbeddr.formal.safety.code}/solutions/com.mbeddr.formal.safety.build/com.mbeddr.formal.safety.build.msd" />
+        <module file="${mbeddr.formal.home}/code/languages/com.mpsbasics/solutions/com.mpsbasics.build/com.mpsbasics.build.msd" />
+        <module file="${mbeddr.formal.home}/code/languages/com.mpsbasics/solutions/com.mpsbasics.tests.build/com.mpsbasics.tests.build.msd" />
       </chunk>
       <jvmargs>
         <arg value="-ea" />
@@ -195,7 +272,7 @@
   
   <target name="makeDependents" />
   
-  <target name="java.compile.com.mbeddr.formal.safety.build">
+  <target name="java.compile.com.mbeddr.formal.safety.build" depends="java.compile.com.mpsbasics.build">
     <mkdir dir="${mbeddr.formal.safety.code}/solutions/com.mbeddr.formal.safety.build/source_gen" />
     <mkdir dir="${build.tmp}/java/out/com.mbeddr.formal.safety.build" />
     <javac destdir="${build.tmp}/java/out/com.mbeddr.formal.safety.build" fork="true" encoding="utf8" includeantruntime="false" debug="true">
@@ -204,6 +281,7 @@
         <path location="${mbeddr.formal.safety.code}/solutions/com.mbeddr.formal.safety.build/source_gen" />
       </src>
       <classpath>
+        <pathelement path="${build.tmp}/java/out/com.mpsbasics.build" />
         <fileset file="${artifacts.com.mbeddr.platform}/com.mbeddr.platform.jar" />
         <fileset file="${artifacts.com.mbeddr.platform}/de.itemis.mps.extensions.build/languages/de.itemis.mps.extensions.build/de.itemis.mps.extensions.build.jar" />
         <fileset file="${artifacts.org.mpsqa.base}/org.mpsqa.base.build/languages/build/org.mpsqa.base.build.jar" />
@@ -215,7 +293,7 @@
     </copy>
   </target>
   
-  <target name="java.compile.com.fasten.assurance.build">
+  <target name="java.compile.com.fasten.assurance.build" depends="java.compile.com.mpsbasics.build">
     <mkdir dir="${mbeddr.formal.safety.code}/solutions/com.fasten.assurance.build/source_gen" />
     <mkdir dir="${build.tmp}/java/out/com.fasten.assurance.build" />
     <javac destdir="${build.tmp}/java/out/com.fasten.assurance.build" fork="true" encoding="utf8" includeantruntime="false" debug="true">
@@ -224,6 +302,7 @@
         <path location="${mbeddr.formal.safety.code}/solutions/com.fasten.assurance.build/source_gen" />
       </src>
       <classpath>
+        <pathelement path="${build.tmp}/java/out/com.mpsbasics.build" />
         <fileset file="${artifacts.com.mbeddr.platform}/com.mbeddr.platform.jar" />
         <fileset file="${artifacts.com.mbeddr.platform}/de.itemis.mps.extensions.build/languages/de.itemis.mps.extensions.build/de.itemis.mps.extensions.build.jar" />
         <fileset file="${artifacts.org.mpsqa.base}/org.mpsqa.base.build/languages/build/org.mpsqa.base.build.jar" />
@@ -234,8 +313,46 @@
     </copy>
   </target>
   
+  <target name="java.compile.com.mpsbasics.build">
+    <mkdir dir="${mbeddr.formal.home}/code/languages/com.mpsbasics/solutions/com.mpsbasics.build/source_gen" />
+    <mkdir dir="${build.tmp}/java/out/com.mpsbasics.build" />
+    <javac destdir="${build.tmp}/java/out/com.mpsbasics.build" fork="true" encoding="utf8" includeantruntime="false" debug="true">
+      <compilerarg value="-Xlint:none" />
+      <src>
+        <path location="${mbeddr.formal.home}/code/languages/com.mpsbasics/solutions/com.mpsbasics.build/source_gen" />
+      </src>
+      <classpath>
+        <fileset file="${artifacts.com.mbeddr.platform}/com.mbeddr.platform.jar" />
+        <fileset file="${artifacts.com.mbeddr.platform}/de.itemis.mps.extensions.build/languages/de.itemis.mps.extensions.build/de.itemis.mps.extensions.build.jar" />
+      </classpath>
+    </javac>
+    <copy todir="${build.tmp}/java/out/com.mpsbasics.build">
+      <fileset dir="${mbeddr.formal.home}/code/languages/com.mpsbasics/solutions/com.mpsbasics.build/source_gen" excludes="**/*.java" />
+    </copy>
+  </target>
+  
+  <target name="java.compile.com.mpsbasics.tests.build" depends="java.compile.com.mpsbasics.build">
+    <mkdir dir="${mbeddr.formal.home}/code/languages/com.mpsbasics/solutions/com.mpsbasics.tests.build/source_gen" />
+    <mkdir dir="${build.tmp}/java/out/com.mpsbasics.tests.build" />
+    <javac destdir="${build.tmp}/java/out/com.mpsbasics.tests.build" fork="true" encoding="utf8" includeantruntime="false" debug="true">
+      <compilerarg value="-Xlint:none" />
+      <src>
+        <path location="${mbeddr.formal.home}/code/languages/com.mpsbasics/solutions/com.mpsbasics.tests.build/source_gen" />
+      </src>
+      <classpath>
+        <pathelement path="${build.tmp}/java/out/com.mpsbasics.build" />
+        <fileset file="${artifacts.com.mbeddr.platform}/com.mbeddr.platform.jar" />
+      </classpath>
+    </javac>
+    <copy todir="${build.tmp}/java/out/com.mpsbasics.tests.build">
+      <fileset dir="${mbeddr.formal.home}/code/languages/com.mpsbasics/solutions/com.mpsbasics.tests.build/source_gen" excludes="**/*.java" />
+    </copy>
+  </target>
+  
   <target name="cleanSources">
     <delete dir="${mbeddr.formal.safety.code}/solutions/com.fasten.assurance.build/source_gen" />
     <delete dir="${mbeddr.formal.safety.code}/solutions/com.mbeddr.formal.safety.build/source_gen" />
+    <delete dir="${mbeddr.formal.home}/code/languages/com.mpsbasics/solutions/com.mpsbasics.build/source_gen" />
+    <delete dir="${mbeddr.formal.home}/code/languages/com.mpsbasics/solutions/com.mpsbasics.tests.build/source_gen" />
   </target>
 </project>

--- a/code/languages/com.mbeddr.formal.safety/.mps/modules.xml
+++ b/code/languages/com.mbeddr.formal.safety/.mps/modules.xml
@@ -59,7 +59,7 @@
       <modulePath path="$PROJECT_DIR$/languages/com.mbeddr.formal.safety.req/com.mbeddr.formal.safety.req.mpl" folder="req" />
       <modulePath path="$PROJECT_DIR$/languages/com.mbeddr.formal.safety.stamp.ext/com.mbeddr.formal.safety.stamp.ext.mpl" folder="hara.stamp" />
       <modulePath path="$PROJECT_DIR$/languages/com.mbeddr.formal.safety.stamp/com.mbeddr.formal.safety.stamp.mpl" folder="hara.stamp" />
-      <modulePath path="$PROJECT_DIR$/solutions/com.fasten.assurance.build/com.fasten.assurance.build.msd" folder="build" />
+      <modulePath path="$PROJECT_DIR$/solutions/com.fasten.assurance.build/com.fasten.assurance.build.msd" folder="_001_build" />
       <modulePath path="$PROJECT_DIR$/solutions/com.fasten.process.review.sandbox/com.fasten.process.review.sandbox.msd" folder="process" />
       <modulePath path="$PROJECT_DIR$/solutions/com.fasten.safety.bayesian_network.pluginSolution/com.fasten.safety.bayesian_network.pluginSolution.msd" folder="bayesian" />
       <modulePath path="$PROJECT_DIR$/solutions/com.fasten.safety.bayesian_network.sandbox/com.fasten.safety.bayesian_network.sandbox.msd" folder="bayesian" />
@@ -80,7 +80,7 @@
       <modulePath path="$PROJECT_DIR$/solutions/com.mbeddr.formal.safety.argument.runtime.pluginSolution/com.mbeddr.formal.safety.argument.runtime.pluginSolution.msd" folder="gsn._060_runtime" />
       <modulePath path="$PROJECT_DIR$/solutions/com.mbeddr.formal.safety.argument.runtime.sandbox/com.mbeddr.formal.safety.argument.runtime.sandbox.msd" folder="gsn._060_runtime" />
       <modulePath path="$PROJECT_DIR$/solutions/com.mbeddr.formal.safety.argument.spi.sandbox/com.mbeddr.formal.safety.argument.spi.sandbox.msd" folder="gsn._060_runtime" />
-      <modulePath path="$PROJECT_DIR$/solutions/com.mbeddr.formal.safety.build/com.mbeddr.formal.safety.build.msd" folder="build" />
+      <modulePath path="$PROJECT_DIR$/solutions/com.mbeddr.formal.safety.build/com.mbeddr.formal.safety.build.msd" folder="_001_build" />
       <modulePath path="$PROJECT_DIR$/solutions/com.mbeddr.formal.safety.cae.sandbox/com.mbeddr.formal.safety.cae.sandbox.msd" folder="gsn._010_base" />
       <modulePath path="$PROJECT_DIR$/solutions/com.mbeddr.formal.safety.gsn.patterns.lib/com.mbeddr.formal.safety.gsn.patterns.lib.msd" folder="gsn._100_checkable_patterns" />
       <modulePath path="$PROJECT_DIR$/solutions/com.mbeddr.formal.safety.gsn.pluginSolution/com.mbeddr.formal.safety.gsn.pluginSolution.msd" folder="gsn._010_base" />

--- a/code/languages/com.mbeddr.formal.safety/solutions/com.fasten.assurance.build/models/com.fasten.assurance.build.mps
+++ b/code/languages/com.mbeddr.formal.safety/solutions/com.fasten.assurance.build/models/com.fasten.assurance.build.mps
@@ -439,7 +439,7 @@
       <node concept="aVJcg" id="6hyv0iVPlEz" role="aVJcv">
         <node concept="NbPM2" id="6hyv0iVPlGV" role="aVJcq">
           <node concept="3Mxwew" id="6hyv0iVPlUa" role="3MwsjC">
-            <property role="3MwjfP" value="2023-01-08" />
+            <property role="3MwjfP" value="2026-05-11" />
           </node>
         </node>
       </node>
@@ -7081,7 +7081,7 @@
     <node concept="2kB4xC" id="6hyv0iVPmt7" role="1l3spd">
       <property role="TrG5h" value="build.date" />
       <node concept="hHN3E" id="6hyv0iVPmtt" role="aVJcv">
-        <property role="hHN3Y" value="20230108" />
+        <property role="hHN3Y" value="20260511" />
       </node>
     </node>
     <node concept="2kB4xC" id="6hyv0iVPmt8" role="1l3spd">
@@ -7089,7 +7089,7 @@
       <node concept="aVJcg" id="6hyv0iVPmtu" role="aVJcv">
         <node concept="NbPM2" id="6hyv0iVPmtY" role="aVJcq">
           <node concept="3Mxwew" id="6hyv0iVPmuy" role="3MwsjC">
-            <property role="3MwjfP" value="com.fasten-201.2023.1" />
+            <property role="3MwjfP" value="com.fasten-201.2025.1" />
           </node>
         </node>
       </node>
@@ -7212,7 +7212,7 @@
       <node concept="aVJcg" id="6hyv0iVPmtC" role="aVJcv">
         <node concept="NbPM2" id="6hyv0iVPmu7" role="aVJcq">
           <node concept="3Mxwew" id="6hyv0iVPmuD" role="3MwsjC">
-            <property role="3MwjfP" value="2023-01-08" />
+            <property role="3MwjfP" value="2026-05-11" />
           </node>
         </node>
       </node>

--- a/code/languages/com.mbeddr.formal.safety/solutions/com.fasten.assurance.build/models/com.fasten.assurance.build.mps
+++ b/code/languages/com.mbeddr.formal.safety/solutions/com.fasten.assurance.build/models/com.fasten.assurance.build.mps
@@ -11,6 +11,7 @@
     <import index="ffeo" ref="r:874d959d-e3b4-4d04-b931-ca849af130dd(jetbrains.mps.ide.build)" />
     <import index="90a9" ref="r:fb24ac52-5985-4947-bba9-25be6fd32c1a(de.itemis.mps.extensions.build)" />
     <import index="2tou" ref="r:18bebd8f-6332-4ffd-b628-cc9dad4ef421(org.mpsqa.base.build)" />
+    <import index="k3fp" ref="r:ef07c49a-32d8-46ff-a533-57b4dbca7bb4(com.mpsbasics.build.build)" />
   </imports>
   <registry>
     <language id="798100da-4f0a-421a-b991-71f8c50ce5d2" name="jetbrains.mps.build">
@@ -283,6 +284,20 @@
         <ref role="398BVh" node="jPgKPEIpnE" resolve="dependencies.mpsqa" />
       </node>
     </node>
+    <node concept="2sgV4H" id="5gFsbf33P71" role="1l3spa">
+      <ref role="1l3spb" to="k3fp:42jqVeFkUtb" resolve="com.mpsbasics" />
+      <node concept="55IIr" id="5gFsbf33PmU" role="2JcizS">
+        <node concept="2Ry0Ak" id="5gFsbf33PAN" role="iGT6I">
+          <property role="2Ry0Am" value=".." />
+          <node concept="2Ry0Ak" id="5gFsbf33PAU" role="2Ry0An">
+            <property role="2Ry0Am" value="artifacts" />
+            <node concept="2Ry0Ak" id="5gFsbf33PAW" role="2Ry0An">
+              <property role="2Ry0Am" value="com.mpsbasics" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
     <node concept="10PD9b" id="6hyv0iVPlDP" role="10PD9s" />
     <node concept="3b7kt6" id="6hyv0iVPlDQ" role="10PD9s" />
     <node concept="398rNT" id="6hyv0iVPlDR" role="1l3spd">
@@ -436,76 +451,18 @@
       </node>
     </node>
     <node concept="1l3spV" id="6hyv0iVPlE1" role="1l3spN">
+      <node concept="3_I8Xc" id="5gFsbf3479Z" role="39821P">
+        <ref role="3_I8Xa" to="k3fp:6hyv0iVPlE_" resolve="com.mpsbasics" />
+      </node>
+      <node concept="3_I8Xc" id="5gFsbf347d5" role="39821P">
+        <ref role="3_I8Xa" to="k3fp:5gFsbf345XQ" resolve="com.mpsbasics.build" />
+      </node>
+      <node concept="3_I8Xc" id="5gFsbf347fa" role="39821P">
+        <ref role="3_I8Xa" to="k3fp:2MrvZqtGPu8" resolve="com.mpsbasics.testutils" />
+      </node>
       <node concept="m$_wl" id="ybq6lf$p0P" role="39821P">
         <ref role="m_rDy" node="1FlxJGBMqg9" resolve="fasten.assurance.build" />
         <node concept="pUk6x" id="ybq6lf$pgU" role="pUk7w" />
-      </node>
-      <node concept="m$_wl" id="6hyv0iVPlE_" role="39821P">
-        <ref role="m_rDy" node="6hyv0iVPlE4" resolve="com.mpsbasics" />
-        <node concept="398223" id="6hyv0iVPlGW" role="39821P">
-          <node concept="3_J27D" id="6hyv0iVPlUb" role="Nbhlr">
-            <node concept="3Mxwew" id="6hyv0iVPm70" role="3MwsjC">
-              <property role="3MwjfP" value="lib" />
-            </node>
-          </node>
-          <node concept="2HvfSZ" id="7mFgjcXq$$3" role="39821P">
-            <node concept="398BVA" id="7mFgjcXq$Je" role="2HvfZ0">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="7mFgjcXq$Jf" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="7mFgjcXq$Jg" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="7mFgjcXq$Jh" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="2HvfSZ" id="1hVhF3lkf3q" role="39821P">
-            <node concept="398BVA" id="1hVhF3lkfdq" role="2HvfZ0">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="1hVhF3lkfmQ" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="1hVhF3lkfoZ" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.pdfbox" />
-                  <node concept="2Ry0Ak" id="1hVhF3lkfqk" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="2HvfSZ" id="2wSfKqy9mOe" role="39821P">
-            <node concept="398BVA" id="2wSfKqy9n1s" role="2HvfZ0">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2wSfKqy9ne6" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2wSfKqy9ngd" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
-                  <node concept="2Ry0Ak" id="2wSfKqy9ngE" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="2HvfSZ" id="36zCbqqqdlR" role="39821P">
-            <node concept="398BVA" id="36zCbqqqdEw" role="2HvfZ0">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="36zCbqqqdZ9" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="36zCbqqqe9S" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.langchain4j" />
-                  <node concept="2Ry0Ak" id="36zCbqqqekB" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="pUk6x" id="6hyv0iVPlGX" role="pUk7w" />
       </node>
       <node concept="m$_wl" id="7a7$evTWEAK" role="39821P">
         <ref role="m_rDy" node="7a7$evTWB8g" resolve="fasten.symo" />
@@ -531,10 +488,6 @@
           </node>
         </node>
         <node concept="pUk6x" id="7a7$evTWEB3" role="pUk7w" />
-      </node>
-      <node concept="m$_wl" id="2MrvZqtGPu8" role="39821P">
-        <ref role="m_rDy" node="2MrvZqtGPGn" resolve="com.mpsbasics.testutils" />
-        <node concept="pUk6x" id="2MrvZqtGPuh" role="pUk7w" />
       </node>
       <node concept="m$_wl" id="6hyv0iVPlEA" role="39821P">
         <ref role="m_rDy" node="6hyv0iVPlE5" resolve="fasten.base" />
@@ -589,57 +542,6 @@
       <property role="1wOHq$" value="true" />
       <property role="3Ej$Sc" value="true" />
     </node>
-    <node concept="m$_wf" id="6hyv0iVPlE4" role="3989C9">
-      <property role="m$_wk" value="com.mpsbasics" />
-      <node concept="3_J27D" id="6hyv0iVPlEG" role="m$_yQ">
-        <node concept="3Mxwew" id="6hyv0iVPlH5" role="3MwsjC">
-          <property role="3MwjfP" value="com.mpsbasics" />
-        </node>
-      </node>
-      <node concept="3_J27D" id="6hyv0iVPlEH" role="m_cZH">
-        <node concept="3Mxwew" id="6hyv0iVPlH6" role="3MwsjC">
-          <property role="3MwjfP" value="com.mpsbasics" />
-        </node>
-      </node>
-      <node concept="3_J27D" id="6hyv0iVPlEI" role="m$_w8">
-        <node concept="3Mxwey" id="6hyv0iVPlH7" role="3MwsjC">
-          <ref role="3Mxwex" node="6hyv0iVPlDZ" resolve="version" />
-        </node>
-      </node>
-      <node concept="m$f5U" id="6hyv0iVPlEJ" role="m$_yh">
-        <ref role="m$f5T" node="6hyv0iVPlEb" resolve="com.mpsbasics" />
-      </node>
-      <node concept="m$_yC" id="6hyv0iVPlEK" role="m$_yJ">
-        <ref role="m$_y1" to="ffeo:4k71ibbKLe8" resolve="jetbrains.mps.core" />
-      </node>
-      <node concept="m$_yC" id="6hyv0iVPlEL" role="m$_yJ">
-        <ref role="m$_y1" to="90a9:4p3FRivDLPy" resolve="org.apache.commons" />
-      </node>
-      <node concept="m$_yC" id="2u7UHDCnTyY" role="m$_yJ">
-        <ref role="m$_y1" to="al5i:64SK4bcJmGP" resolve="com.mbeddr.mpsutil.plantuml" />
-      </node>
-      <node concept="m$_yC" id="36zCbqqqepY" role="m$_yJ">
-        <ref role="m$_y1" to="al5i:NMVW79y25x" resolve="com.mbeddr.mpsutil.json" />
-      </node>
-      <node concept="m$_yC" id="3TNxfDZ8qPv" role="m$_yJ">
-        <ref role="m$_y1" to="al5i:Vtr7jyB0oM" resolve="com.mbeddr.mpsutil.filepicker" />
-      </node>
-      <node concept="m$_yC" id="hKYaKNdjV$" role="m$_yJ">
-        <ref role="m$_y1" to="90a9:3$A0JaN5ezp" resolve="MPS.ThirdParty" />
-      </node>
-      <node concept="m$_yC" id="5Gu43O52lhT" role="m$_yJ">
-        <ref role="m$_y1" to="90a9:6SVXTgIe8wD" resolve="de.itemis.mps.celllayout" />
-      </node>
-      <node concept="m$_yC" id="6FJpOMBt7hW" role="m$_yJ">
-        <ref role="m$_y1" to="90a9:1sO539bGQvt" resolve="de.slisson.mps.richtext" />
-      </node>
-      <node concept="m$_yC" id="5mv1DnKbokD" role="m$_yJ">
-        <ref role="m$_y1" to="ffeo:4O0hKJpmtq1" resolve="jetbrains.mps.trove" />
-      </node>
-      <node concept="m$_yC" id="5xR2VPu2qTq" role="m$_yJ">
-        <ref role="m$_y1" to="ffeo:6Hpa5co69BH" resolve="jetbrains.mps.editor.tooltips" />
-      </node>
-    </node>
     <node concept="m$_wf" id="7a7$evTWB8g" role="3989C9">
       <property role="m$_wk" value="fasten.symo" />
       <node concept="3_J27D" id="7a7$evTWB8h" role="m$_yQ">
@@ -661,34 +563,10 @@
         <ref role="m$f5T" node="7a7$evTWl$t" resolve="fasten.symo" />
       </node>
       <node concept="m$_yC" id="7a7$evTWCDI" role="m$_yJ">
-        <ref role="m$_y1" node="6hyv0iVPlE4" resolve="com.mpsbasics" />
+        <ref role="m$_y1" to="k3fp:6hyv0iVPlE4" resolve="com.mpsbasics" />
       </node>
       <node concept="m$_yC" id="7a7$evTWI7Z" role="m$_yJ">
         <ref role="m$_y1" to="90a9:F1NWDqr5lJ" resolve="de.itemis.mps.grammarcells" />
-      </node>
-    </node>
-    <node concept="m$_wf" id="2MrvZqtGPGn" role="3989C9">
-      <property role="m$_wk" value="com.mpsbasics.testutils" />
-      <node concept="3_J27D" id="2MrvZqtGPGo" role="m$_yQ">
-        <node concept="3Mxwew" id="2MrvZqtGPGp" role="3MwsjC">
-          <property role="3MwjfP" value="com.mpsbasics.testutils" />
-        </node>
-      </node>
-      <node concept="3_J27D" id="2MrvZqtGPGq" role="m_cZH">
-        <node concept="3Mxwew" id="2MrvZqtGPGr" role="3MwsjC">
-          <property role="3MwjfP" value="com.mpsbasics.testutils" />
-        </node>
-      </node>
-      <node concept="3_J27D" id="2MrvZqtGPGs" role="m$_w8">
-        <node concept="3Mxwey" id="2MrvZqtGPGt" role="3MwsjC">
-          <ref role="3Mxwex" node="6hyv0iVPlDZ" resolve="version" />
-        </node>
-      </node>
-      <node concept="m$f5U" id="2MrvZqtGPGu" role="m$_yh">
-        <ref role="m$f5T" node="2MrvZqtGQDM" resolve="com.mpsbasics.testutils" />
-      </node>
-      <node concept="m$_yC" id="2MrvZqtGSm8" role="m$_yJ">
-        <ref role="m$_y1" node="6hyv0iVPlE4" resolve="com.mpsbasics" />
       </node>
     </node>
     <node concept="m$_wf" id="6hyv0iVPlE5" role="3989C9">
@@ -718,7 +596,7 @@
         <ref role="m$_y1" to="ffeo:RJsmGEieyQ" resolve="jetbrains.mps.vcs" />
       </node>
       <node concept="m$_yC" id="5t37uj6Yhku" role="m$_yJ">
-        <ref role="m$_y1" node="6hyv0iVPlE4" resolve="com.mpsbasics" />
+        <ref role="m$_y1" to="k3fp:6hyv0iVPlE4" resolve="com.mpsbasics" />
       </node>
       <node concept="m$_yC" id="5FTX57fNo4l" role="m$_yJ">
         <ref role="m$_y1" to="al5i:$bJ0jguQdg" resolve="com.mbeddr.platform" />
@@ -770,9 +648,6 @@
       </node>
       <node concept="m$_yC" id="67Nhy_DXSAz" role="m$_yJ">
         <ref role="m$_y1" node="6hyv0iVPlE5" resolve="fasten.base" />
-      </node>
-      <node concept="m$_yC" id="6hyv0iVPlF3" role="m$_yJ">
-        <ref role="m$_y1" node="6hyv0iVPlE4" resolve="com.mpsbasics" />
       </node>
       <node concept="m$_yC" id="84ljAGzJlV" role="m$_yJ">
         <ref role="m$_y1" to="90a9:1Rj3F434oop" resolve="com.mbeddr.mpsutil.treenotations" />
@@ -939,6 +814,9 @@
       <node concept="m$_yC" id="jPgKPEIr3h" role="m$_yJ">
         <ref role="m$_y1" to="2tou:32O483pJLpG" resolve="org.mpsqa.base.build" />
       </node>
+      <node concept="m$_yC" id="5gFsbf342pI" role="m$_yJ">
+        <ref role="m$_y1" to="k3fp:5gFsbf342Kk" resolve="com.mpsbasics.build" />
+      </node>
     </node>
     <node concept="2G$12M" id="1FlxJGBMsrc" role="3989C9">
       <property role="TrG5h" value="fasten.assurance.build" />
@@ -1016,2596 +894,9 @@
             <ref role="3bR37D" to="2tou:32O483pJL16" resolve="org.mpsqa.base.build" />
           </node>
         </node>
-      </node>
-    </node>
-    <node concept="2G$12M" id="6hyv0iVPlEb" role="3989C9">
-      <property role="TrG5h" value="com.mpsbasics" />
-      <node concept="1E1JtA" id="6hyv0iVPlFH" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="com.mpsbasics.docx4j.core" />
-        <property role="3LESm3" value="fdd69818-de3d-4ebf-9ec6-17ea152db151" />
-        <node concept="398BVA" id="6hyv0iVPlHq" role="3LF7KH">
-          <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-          <node concept="2Ry0Ak" id="6hyv0iVPlUg" role="iGT6I">
-            <property role="2Ry0Am" value="solutions" />
-            <node concept="2Ry0Ak" id="6hyv0iVPm75" role="2Ry0An">
-              <property role="2Ry0Am" value="com.mpsbasics.docx4j.core" />
-              <node concept="2Ry0Ak" id="6hyv0iVPme5" role="2Ry0An">
-                <property role="2Ry0Am" value="com.mpsbasics.docx4j.core.msd" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="6hyv0iVPlHr" role="3bR37C">
-          <node concept="3bR9La" id="6hyv0iVPlUh" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1H905DlDUSw" resolve="MPS.OpenAPI" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="6hyv0iVPlHs" role="3bR37C">
-          <node concept="3bR9La" id="6hyv0iVPlUi" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="6hyv0iVPlHt" role="3bR37C">
-          <node concept="3bR9La" id="6hyv0iVPlUj" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:44LXwdzyvTi" resolve="Annotations" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="6hyv0iVPlHu" role="3bR37C">
-          <node concept="3bR9La" id="6hyv0iVPlUk" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1ia2VB5guYy" resolve="MPS.IDEA" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="6hyv0iVPlHv" role="3bR37C">
-          <node concept="3bR9La" id="6hyv0iVPlUl" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:7Kfy9QB6L4X" resolve="jetbrains.mps.lang.editor" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="6hyv0iVPlHw" role="3bR37C">
-          <node concept="3bR9La" id="6hyv0iVPlUm" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1TaHNgiIbIZ" resolve="MPS.Editor" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="6hyv0iVPlHx" role="3bR37C">
-          <node concept="3bR9La" id="6hyv0iVPlUn" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1TaHNgiIbIQ" resolve="MPS.Core" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="6hyv0iVPlHy" role="3bR37C">
-          <node concept="3bR9La" id="6hyv0iVPlUo" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:7Kfy9QB6LaO" resolve="jetbrains.mps.lang.structure" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="6hyv0iVPlHz" role="3bR37C">
-          <node concept="3bR9La" id="6hyv0iVPlUp" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:3MI1gu0QouH" resolve="jetbrains.mps.editor.runtime" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="6hyv0iVPlH$" role="3bR37C">
-          <node concept="3bR9La" id="6hyv0iVPlUq" role="1SiIV1">
-            <ref role="3bR37D" node="6hyv0iVPlFI" resolve="com.mpsbasics.docx4j.lib" />
-          </node>
-        </node>
-        <node concept="1BupzO" id="6hyv0iVPlH_" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="6hyv0iVPlUr" role="1HemKq">
-            <node concept="398BVA" id="6hyv0iVPm76" role="3LXTmr">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="6hyv0iVPme6" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="6hyv0iVPmiT" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.core" />
-                  <node concept="2Ry0Ak" id="6hyv0iVPmm4" role="2Ry0An">
-                    <property role="2Ry0Am" value="models" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="6hyv0iVPm77" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-        <node concept="3rtmxn" id="6hyv0iVPlHA" role="3bR31x">
-          <node concept="3LXTmp" id="6hyv0iVPlUs" role="3rtmxm">
-            <node concept="3qWCbU" id="6hyv0iVPm78" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="6hyv0iVPm79" role="3LXTmr">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="6hyv0iVPme7" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="6hyv0iVPmiU" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.core" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="4ziKDEng_E7" role="3bR37C">
-          <node concept="3bR9La" id="4ziKDEng_E8" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1TaHNgiIbJb" resolve="MPS.Platform" />
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtA" id="6hyv0iVPlFI" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="com.mpsbasics.docx4j.lib" />
-        <property role="3LESm3" value="71bb25aa-20fa-4c18-8954-1b176576f52d" />
-        <node concept="398BVA" id="6hyv0iVPlHB" role="3LF7KH">
-          <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-          <node concept="2Ry0Ak" id="6hyv0iVPlUt" role="iGT6I">
-            <property role="2Ry0Am" value="solutions" />
-            <node concept="2Ry0Ak" id="6hyv0iVPm7a" role="2Ry0An">
-              <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-              <node concept="2Ry0Ak" id="6hyv0iVPme8" role="2Ry0An">
-                <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib.msd" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="6hyv0iVPlHC" role="3bR37C">
-          <node concept="3bR9La" id="6hyv0iVPlUu" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
-          </node>
-        </node>
-        <node concept="3rtmxn" id="6hyv0iVPlIc" role="3bR31x">
-          <node concept="3LXTmp" id="6hyv0iVPlV2" role="3rtmxm">
-            <node concept="3qWCbU" id="6hyv0iVPm7H" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="6hyv0iVPm7I" role="3LXTmr">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="6hyv0iVPmeF" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="6hyv0iVPmjt" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rF4o" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rF4p" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rF4b" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rF4c" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rF4d" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rF4e" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rF4f" role="2Ry0An">
-                      <property role="2Ry0Am" value="antlr-runtime.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rF4B" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rF4C" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rF4q" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rF4r" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rF4s" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rF4t" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rF4u" role="2Ry0An">
-                      <property role="2Ry0Am" value="antlr.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rF4Q" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rF4R" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rF4D" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rF4E" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rF4F" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rF4G" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rF4H" role="2Ry0An">
-                      <property role="2Ry0Am" value="checker-qual.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rF55" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rF56" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rF4S" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rF4T" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rF4U" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rF4V" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rF4W" role="2Ry0An">
-                      <property role="2Ry0Am" value="commons-codec.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rF5k" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rF5l" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rF57" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rF58" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rF59" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rF5a" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rF5b" role="2Ry0An">
-                      <property role="2Ry0Am" value="commons-compress.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rF5z" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rF5$" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rF5m" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rF5n" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rF5o" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rF5p" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rF5q" role="2Ry0An">
-                      <property role="2Ry0Am" value="commons-io.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rF5M" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rF5N" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rF5_" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rF5A" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rF5B" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rF5C" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rF5D" role="2Ry0An">
-                      <property role="2Ry0Am" value="commons-lang3.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rF61" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rF62" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rF5O" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rF5P" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rF5Q" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rF5R" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rF5S" role="2Ry0An">
-                      <property role="2Ry0Am" value="docx4j-core.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rF6g" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rF6h" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rF63" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rF64" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rF65" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rF66" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rF67" role="2Ry0An">
-                      <property role="2Ry0Am" value="docx4j-JAXB-MOXy.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rF6v" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rF6w" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rF6i" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rF6j" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rF6k" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rF6l" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rF6m" role="2Ry0An">
-                      <property role="2Ry0Am" value="docx4j-openxml-objects-pml.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rF6I" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rF6J" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rF6x" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rF6y" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rF6z" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rF6$" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rF6_" role="2Ry0An">
-                      <property role="2Ry0Am" value="docx4j-openxml-objects-sml.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rF6X" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rF6Y" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rF6K" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rF6L" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rF6M" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rF6N" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rF6O" role="2Ry0An">
-                      <property role="2Ry0Am" value="docx4j-openxml-objects.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rF7c" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rF7d" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rF6Z" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rF70" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rF71" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rF72" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rF73" role="2Ry0An">
-                      <property role="2Ry0Am" value="error_prone_annotations.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rF7r" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rF7s" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rF7e" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rF7f" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rF7g" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rF7h" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rF7i" role="2Ry0An">
-                      <property role="2Ry0Am" value="fontbox.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rF7E" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rF7F" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rF7t" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rF7u" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rF7v" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rF7w" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rF7x" role="2Ry0An">
-                      <property role="2Ry0Am" value="jakarta.activation-api.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rF88" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rF89" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rF7V" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rF7W" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rF7X" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rF7Y" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rF7Z" role="2Ry0An">
-                      <property role="2Ry0Am" value="jakarta.mail-api.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rF8A" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rF8B" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rF8p" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rF8q" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rF8r" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rF8s" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rF8t" role="2Ry0An">
-                      <property role="2Ry0Am" value="jakarta.xml.bind-api.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rF8P" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rF8Q" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rF8C" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rF8D" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rF8E" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rF8F" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rF8G" role="2Ry0An">
-                      <property role="2Ry0Am" value="jaxb-svg11.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rF94" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rF95" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rF8R" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rF8S" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rF8T" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rF8U" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rF8V" role="2Ry0An">
-                      <property role="2Ry0Am" value="jcl-over-slf4j.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rF9j" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rF9k" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rF96" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rF97" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rF98" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rF99" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rF9a" role="2Ry0An">
-                      <property role="2Ry0Am" value="mbassador.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rF9y" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rF9z" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rF9l" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rF9m" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rF9n" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rF9o" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rF9p" role="2Ry0An">
-                      <property role="2Ry0Am" value="org.eclipse.persistence.asm.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rF9L" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rF9M" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rF9$" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rF9_" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rF9A" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rF9B" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rF9C" role="2Ry0An">
-                      <property role="2Ry0Am" value="org.eclipse.persistence.core.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rFa0" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rFa1" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rF9N" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rF9O" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rF9P" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rF9Q" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rF9R" role="2Ry0An">
-                      <property role="2Ry0Am" value="org.eclipse.persistence.moxy.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rFaf" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rFag" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rFa2" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rFa3" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rFa4" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rFa5" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rFa6" role="2Ry0An">
-                      <property role="2Ry0Am" value="qdox.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rFaH" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rFaI" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rFaw" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rFax" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rFay" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rFaz" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rFa$" role="2Ry0An">
-                      <property role="2Ry0Am" value="stringtemplate.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rFaW" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rFaX" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rFaJ" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rFaK" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rFaL" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rFaM" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rFaN" role="2Ry0An">
-                      <property role="2Ry0Am" value="wmf2svg.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rFbb" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rFbc" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rFaY" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rFaZ" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rFb0" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rFb1" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rFb2" role="2Ry0An">
-                      <property role="2Ry0Am" value="xalan-interpretive.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rFbq" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rFbr" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rFbd" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rFbe" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rFbf" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rFbg" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rFbh" role="2Ry0An">
-                      <property role="2Ry0Am" value="xalan-serializer.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rFbD" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rFbE" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rFbs" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rFbt" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rFbu" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rFbv" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rFbw" role="2Ry0An">
-                      <property role="2Ry0Am" value="xmlgraphics-commons.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="6CRJe3tfEFm" role="3bR37C">
-          <node concept="1BurEX" id="6CRJe3tfEFn" role="1SiIV1">
-            <node concept="398BVA" id="6CRJe3tfEF9" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="6CRJe3tfEFa" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="6CRJe3tfEFb" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="6CRJe3tfEFc" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="6CRJe3tfEFd" role="2Ry0An">
-                      <property role="2Ry0Am" value="angus-activation.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="6CRJe3tfEF_" role="3bR37C">
-          <node concept="1BurEX" id="6CRJe3tfEFA" role="1SiIV1">
-            <node concept="398BVA" id="6CRJe3tfEFo" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="6CRJe3tfEFp" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="6CRJe3tfEFq" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="6CRJe3tfEFr" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="6CRJe3tfEFs" role="2Ry0An">
-                      <property role="2Ry0Am" value="angus-mail.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="6CRJe3tfEGC" role="3bR37C">
-          <node concept="1BurEX" id="6CRJe3tfEGD" role="1SiIV1">
-            <node concept="398BVA" id="6CRJe3tfEGr" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="6CRJe3tfEGs" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="6CRJe3tfEGt" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="6CRJe3tfEGu" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="6CRJe3tfEGv" role="2Ry0An">
-                      <property role="2Ry0Am" value="commons-collections4.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="6CRJe3tfEHu" role="3bR37C">
-          <node concept="1BurEX" id="6CRJe3tfEHv" role="1SiIV1">
-            <node concept="398BVA" id="6CRJe3tfEHh" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="6CRJe3tfEHi" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="6CRJe3tfEHj" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="6CRJe3tfEHk" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="6CRJe3tfEHl" role="2Ry0An">
-                      <property role="2Ry0Am" value="commons-logging.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="6CRJe3tfEJY" role="3bR37C">
-          <node concept="1BurEX" id="6CRJe3tfEJZ" role="1SiIV1">
-            <node concept="398BVA" id="6CRJe3tfEJL" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="6CRJe3tfEJM" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="6CRJe3tfEJN" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="6CRJe3tfEJO" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="6CRJe3tfEJP" role="2Ry0An">
-                      <property role="2Ry0Am" value="jaxb-core.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="6CRJe3tfEKD" role="3bR37C">
-          <node concept="1BurEX" id="6CRJe3tfEKE" role="1SiIV1">
-            <node concept="398BVA" id="6CRJe3tfEKs" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="6CRJe3tfEKt" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="6CRJe3tfEKu" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="6CRJe3tfEKv" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="6CRJe3tfEKw" role="2Ry0An">
-                      <property role="2Ry0Am" value="jaxb-xjc.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="6CRJe3tfELT" role="3bR37C">
-          <node concept="1BurEX" id="6CRJe3tfELU" role="1SiIV1">
-            <node concept="398BVA" id="6CRJe3tfELG" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="6CRJe3tfELH" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="6CRJe3tfELI" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="6CRJe3tfELJ" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="6CRJe3tfELK" role="2Ry0An">
-                      <property role="2Ry0Am" value="pdfbox-io.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="6CRJe3tfEMl" role="3bR37C">
-          <node concept="1BurEX" id="6CRJe3tfEMm" role="1SiIV1">
-            <node concept="398BVA" id="6CRJe3tfEM8" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="6CRJe3tfEM9" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="6CRJe3tfEMa" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="6CRJe3tfEMb" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="6CRJe3tfEMc" role="2Ry0An">
-                      <property role="2Ry0Am" value="SparseBitSet.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtA" id="6hyv0iVPlFJ" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="com.mpsbasics.snode.utils" />
-        <property role="3LESm3" value="8da51702-0e05-44c8-96db-8f11d1457c0c" />
-        <node concept="398BVA" id="6hyv0iVPlId" role="3LF7KH">
-          <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-          <node concept="2Ry0Ak" id="6hyv0iVPlV3" role="iGT6I">
-            <property role="2Ry0Am" value="solutions" />
-            <node concept="2Ry0Ak" id="6hyv0iVPm7J" role="2Ry0An">
-              <property role="2Ry0Am" value="com.mpsbasics.snode.utils" />
-              <node concept="2Ry0Ak" id="6hyv0iVPmeG" role="2Ry0An">
-                <property role="2Ry0Am" value="com.mpsbasics.snode.utils.msd" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="6hyv0iVPlIe" role="3bR37C">
-          <node concept="3bR9La" id="6hyv0iVPlV4" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="6hyv0iVPlIf" role="3bR37C">
-          <node concept="3bR9La" id="6hyv0iVPlV5" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1H905DlDUSw" resolve="MPS.OpenAPI" />
-          </node>
-        </node>
-        <node concept="1BupzO" id="6hyv0iVPlIi" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="6hyv0iVPlV8" role="1HemKq">
-            <node concept="398BVA" id="6hyv0iVPm7K" role="3LXTmr">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="6hyv0iVPmeH" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="6hyv0iVPmju" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.snode.utils" />
-                  <node concept="2Ry0Ak" id="6hyv0iVPmmB" role="2Ry0An">
-                    <property role="2Ry0Am" value="models" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="6hyv0iVPm7L" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-        <node concept="3rtmxn" id="6hyv0iVPlIj" role="3bR31x">
-          <node concept="3LXTmp" id="6hyv0iVPlV9" role="3rtmxm">
-            <node concept="3qWCbU" id="6hyv0iVPm7M" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="6hyv0iVPm7N" role="3LXTmr">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="6hyv0iVPmeI" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="6hyv0iVPmjv" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.snode.utils" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtA" id="2u7UHDCnPLY" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="com.mpsbasics.project.utils" />
-        <property role="3LESm3" value="1f4710e9-f074-4732-a0bd-6fa896d282b7" />
-        <node concept="398BVA" id="2u7UHDCnPZq" role="3LF7KH">
-          <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-          <node concept="2Ry0Ak" id="2u7UHDCnQeS" role="iGT6I">
-            <property role="2Ry0Am" value="solutions" />
-            <node concept="2Ry0Ak" id="2u7UHDCnQul" role="2Ry0An">
-              <property role="2Ry0Am" value="com.mpsbasics.project.utils" />
-              <node concept="2Ry0Ak" id="2u7UHDCnQHM" role="2Ry0An">
-                <property role="2Ry0Am" value="com.mpsbasics.project.utils.msd" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2u7UHDCnQWT" role="3bR37C">
-          <node concept="3bR9La" id="2u7UHDCnQWU" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2u7UHDCnQWV" role="3bR37C">
-          <node concept="3bR9La" id="2u7UHDCnQWW" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1ia2VB5guYy" resolve="MPS.IDEA" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2u7UHDCnQWX" role="3bR37C">
-          <node concept="3bR9La" id="2u7UHDCnQWY" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1TaHNgiIbJb" resolve="MPS.Platform" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2u7UHDCnQWZ" role="3bR37C">
-          <node concept="3bR9La" id="2u7UHDCnQX0" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1TaHNgiIbIQ" resolve="MPS.Core" />
-          </node>
-        </node>
-        <node concept="1BupzO" id="2u7UHDCnQXc" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="2u7UHDCnQXd" role="1HemKq">
-            <node concept="398BVA" id="2u7UHDCnQX1" role="3LXTmr">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2u7UHDCnQX2" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2u7UHDCnQX3" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.project.utils" />
-                  <node concept="2Ry0Ak" id="2u7UHDCnQX4" role="2Ry0An">
-                    <property role="2Ry0Am" value="models" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="2u7UHDCnQXe" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-        <node concept="3rtmxn" id="4euqtkrusDt" role="3bR31x">
-          <node concept="3LXTmp" id="4euqtkrusDu" role="3rtmxm">
-            <node concept="3qWCbU" id="4euqtkrusDv" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="4euqtkrusDw" role="3LXTmr">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="4euqtkrusDx" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="4euqtkrusDy" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.project.utils" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtA" id="2u7UHDCnRuK" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="com.mpsbasics.editor.utils" />
-        <property role="3LESm3" value="6b84fb9e-5f09-4a61-bf31-3bfdc54820e3" />
-        <node concept="398BVA" id="2u7UHDCnRGu" role="3LF7KH">
-          <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-          <node concept="2Ry0Ak" id="2u7UHDCnRVW" role="iGT6I">
-            <property role="2Ry0Am" value="solutions" />
-            <node concept="2Ry0Ak" id="2u7UHDCnSj5" role="2Ry0An">
-              <property role="2Ry0Am" value="com.mpsbasics.editor.utils" />
-              <node concept="2Ry0Ak" id="2u7UHDCnSyy" role="2Ry0An">
-                <property role="2Ry0Am" value="com.mpsbasics.editor.utils.msd" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2u7UHDCnSLO" role="3bR37C">
-          <node concept="3bR9La" id="2u7UHDCnSLP" role="1SiIV1">
-            <ref role="3bR37D" node="2u7UHDCnPLY" resolve="com.mpsbasics.project.utils" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2u7UHDCnSLQ" role="3bR37C">
-          <node concept="3bR9La" id="2u7UHDCnSLR" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1ia2VB5guYy" resolve="MPS.IDEA" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2u7UHDCnSLU" role="3bR37C">
-          <node concept="3bR9La" id="2u7UHDCnSLV" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:3MI1gu0QouH" resolve="jetbrains.mps.editor.runtime" />
-          </node>
-        </node>
-        <node concept="1BupzO" id="2u7UHDCnSM7" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="2u7UHDCnSM8" role="1HemKq">
-            <node concept="398BVA" id="2u7UHDCnSLW" role="3LXTmr">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2u7UHDCnSLX" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2u7UHDCnSLY" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.editor.utils" />
-                  <node concept="2Ry0Ak" id="2u7UHDCnSLZ" role="2Ry0An">
-                    <property role="2Ry0Am" value="models" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="2u7UHDCnSM9" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-        <node concept="3rtmxn" id="4euqtkrusD$" role="3bR31x">
-          <node concept="3LXTmp" id="4euqtkrusD_" role="3rtmxm">
-            <node concept="3qWCbU" id="4euqtkrusDA" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="4euqtkrusDB" role="3LXTmr">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="4euqtkrusDC" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="4euqtkrusDD" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.editor.utils" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="YXkTXVNg_7" role="3bR37C">
-          <node concept="3bR9La" id="YXkTXVNg_8" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="YXkTXVNg_9" role="3bR37C">
-          <node concept="3bR9La" id="YXkTXVNg_a" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1TaHNgiIbIZ" resolve="MPS.Editor" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2i2e8U1mEgx" role="3bR37C">
-          <node concept="3bR9La" id="2i2e8U1mEgy" role="1SiIV1">
-            <ref role="3bR37D" to="90a9:6bkzxtWPDx1" resolve="de.itemis.stubs.batik" />
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtA" id="2u7UHDC1RNf" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="com.mpsbasics.pdfbox" />
-        <property role="3LESm3" value="bc7d0863-298c-41cf-984f-a0421e757da5" />
-        <node concept="398BVA" id="2u7UHDC1S2a" role="3LF7KH">
-          <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-          <node concept="2Ry0Ak" id="2u7UHDC1Sye" role="iGT6I">
-            <property role="2Ry0Am" value="solutions" />
-            <node concept="2Ry0Ak" id="2u7UHDC1SOx" role="2Ry0An">
-              <property role="2Ry0Am" value="com.mpsbasics.pdfbox" />
-              <node concept="2Ry0Ak" id="2u7UHDC1T5A" role="2Ry0An">
-                <property role="2Ry0Am" value="com.mpsbasics.pdfbox.msd" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2u7UHDC1Tlm" role="3bR37C">
-          <node concept="3bR9La" id="2u7UHDC1Tln" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2u7UHDC1VSB" role="3bR37C">
-          <node concept="3bR9La" id="2u7UHDC1VSC" role="1SiIV1">
-            <ref role="3bR37D" node="2u7UHDC1TKp" resolve="com.mpsbasics.pdfexporter" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2u7UHDCnTe3" role="3bR37C">
-          <node concept="3bR9La" id="2u7UHDCnTe4" role="1SiIV1">
-            <ref role="3bR37D" node="2u7UHDCnRuK" resolve="com.mpsbasics.editor.utils" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="3TNxfDZ5bWu" role="3bR37C">
-          <node concept="3bR9La" id="3TNxfDZ5bWv" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1ia2VB5guYy" resolve="MPS.IDEA" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="3TNxfDZ5bWy" role="3bR37C">
-          <node concept="3bR9La" id="3TNxfDZ5bWz" role="1SiIV1">
-            <ref role="3bR37D" to="al5i:Vtr7jyAKU4" resolve="com.mbeddr.mpsutil.filepicker" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rFcp" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rFcq" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rFcc" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rFcd" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rFce" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.pdfbox" />
-                  <node concept="2Ry0Ak" id="2fGryx5rFcf" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rFcg" role="2Ry0An">
-                      <property role="2Ry0Am" value="graphics2d.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3rtmxn" id="4euqtkrusDF" role="3bR31x">
-          <node concept="3LXTmp" id="4euqtkrusDG" role="3rtmxm">
-            <node concept="3qWCbU" id="4euqtkrusDH" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="4euqtkrusDI" role="3LXTmr">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="4euqtkrusDJ" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="4euqtkrusDK" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.pdfbox" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rFcC" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rFcD" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rFcr" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rFcs" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rFct" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.pdfbox" />
-                  <node concept="2Ry0Ak" id="2fGryx5rFcu" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rFcv" role="2Ry0An">
-                      <property role="2Ry0Am" value="openhtmltopdf-core.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rFcR" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rFcS" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rFcE" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rFcF" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rFcG" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.pdfbox" />
-                  <node concept="2Ry0Ak" id="2fGryx5rFcH" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rFcI" role="2Ry0An">
-                      <property role="2Ry0Am" value="openhtmltopdf-pdfbox.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rFd6" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rFd7" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rFcT" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rFcU" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rFcV" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.pdfbox" />
-                  <node concept="2Ry0Ak" id="2fGryx5rFcW" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rFcX" role="2Ry0An">
-                      <property role="2Ry0Am" value="pdfbox-app.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1BupzO" id="2_t3nDPzUj0" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="2_t3nDPzUj1" role="1HemKq">
-            <node concept="398BVA" id="2_t3nDPzUiP" role="3LXTmr">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2_t3nDPzUiQ" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2_t3nDPzUiR" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.pdfbox" />
-                  <node concept="2Ry0Ak" id="2_t3nDPzUiS" role="2Ry0An">
-                    <property role="2Ry0Am" value="models" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="2_t3nDPzUj2" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rFdl" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rFdm" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rFd8" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rFd9" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rFda" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.pdfbox" />
-                  <node concept="2Ry0Ak" id="2fGryx5rFdb" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rFdc" role="2Ry0An">
-                      <property role="2Ry0Am" value="xmpbox.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtD" id="2u7UHDC1TKp" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="com.mpsbasics.pdfexporter" />
-        <property role="3LESm3" value="ece26728-2885-4b26-9f61-67d2821fc361" />
-        <node concept="398BVA" id="2u7UHDC1Ug2" role="3LF7KH">
-          <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-          <node concept="2Ry0Ak" id="2u7UHDC1UCq" role="iGT6I">
-            <property role="2Ry0Am" value="languages" />
-            <node concept="2Ry0Ak" id="2u7UHDC1UTv" role="2Ry0An">
-              <property role="2Ry0Am" value="com.mpsbasics.pdfexporter" />
-              <node concept="2Ry0Ak" id="2u7UHDC1Vaa" role="2Ry0An">
-                <property role="2Ry0Am" value="com.mpsbasics.pdfexporter.mpl" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2u7UHDC1Vqt" role="3bR37C">
-          <node concept="3bR9La" id="2u7UHDC1Vqu" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1TaHNgiIbIZ" resolve="MPS.Editor" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2u7UHDC1Vqv" role="3bR37C">
-          <node concept="3bR9La" id="2u7UHDC1Vqw" role="1SiIV1">
-            <ref role="3bR37D" node="2u7UHDC1RNf" resolve="com.mpsbasics.pdfbox" />
-          </node>
-        </node>
-        <node concept="1BupzO" id="2u7UHDC1VqG" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="2u7UHDC1VqH" role="1HemKq">
-            <node concept="398BVA" id="2u7UHDC1Vqx" role="3LXTmr">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2u7UHDC1Vqy" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="2u7UHDC1Vqz" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.pdfexporter" />
-                  <node concept="2Ry0Ak" id="2u7UHDC1Vq$" role="2Ry0An">
-                    <property role="2Ry0Am" value="models" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="2u7UHDC1VqI" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="3TNxfDZ5bWW" role="3bR37C">
-          <node concept="3bR9La" id="3TNxfDZ5bWX" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:3HV74$ebibC" resolve="jetbrains.mps.lang.text" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="3TNxfDZ5bWY" role="3bR37C">
-          <node concept="3bR9La" id="3TNxfDZ5bWZ" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="3TNxfDZ5bX0" role="3bR37C">
-          <node concept="3bR9La" id="3TNxfDZ5bX1" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:7Kfy9QB6LfQ" resolve="jetbrains.mps.kernel" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="3TNxfDZ5bX2" role="3bR37C">
-          <node concept="3bR9La" id="3TNxfDZ5bX3" role="1SiIV1">
-            <ref role="3bR37D" to="al5i:Vtr7jyAKU4" resolve="com.mbeddr.mpsutil.filepicker" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="3TNxfDZ5bX4" role="3bR37C">
-          <node concept="3bR9La" id="3TNxfDZ5bX5" role="1SiIV1">
-            <ref role="3bR37D" node="2u7UHDCnRuK" resolve="com.mpsbasics.editor.utils" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2ZPTSaoSrhy" role="3bR37C">
-          <node concept="3bR9La" id="2ZPTSaoSrhz" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1H905DlDUSw" resolve="MPS.OpenAPI" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2ZPTSaoSrh$" role="3bR37C">
-          <node concept="3bR9La" id="2ZPTSaoSrh_" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:3MI1gu0QouH" resolve="jetbrains.mps.editor.runtime" />
-          </node>
-        </node>
-        <node concept="3rtmxn" id="4euqtkrusLZ" role="3bR31x">
-          <node concept="3LXTmp" id="4euqtkrusM0" role="3rtmxm">
-            <node concept="3qWCbU" id="4euqtkrusM1" role="3LXTna">
-              <property role="3qWCbO" value="com/mpsbasics/pdfexporter/structure/*.png" />
-            </node>
-            <node concept="398BVA" id="4euqtkrusM2" role="3LXTmr">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="4euqtkrusM3" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="4euqtkrusM4" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.pdfexporter" />
-                  <node concept="2Ry0Ak" id="2oWhy0w_F$j" role="2Ry0An">
-                    <property role="2Ry0Am" value="source_gen" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtA" id="2wSfKqy9hC9" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="com.mpsbasics.jira.pluginSolution" />
-        <property role="3LESm3" value="47b4ca2d-4ed7-41a6-b64f-df36b50a3c95" />
-        <node concept="398BVA" id="2wSfKqy9hTU" role="3LF7KH">
-          <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-          <node concept="2Ry0Ak" id="2wSfKqy9ibO" role="iGT6I">
-            <property role="2Ry0Am" value="solutions" />
-            <node concept="2Ry0Ak" id="2wSfKqy9iuV" role="2Ry0An">
-              <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
-              <node concept="2Ry0Ak" id="2wSfKqy9iK0" role="2Ry0An">
-                <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution.msd" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2wSfKqy9j1e" role="3bR37C">
-          <node concept="3bR9La" id="2wSfKqy9j1f" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
-          </node>
-        </node>
-        <node concept="3rtmxn" id="2bBfLTGrYGA" role="3bR31x">
-          <node concept="3LXTmp" id="2bBfLTGrYGB" role="3rtmxm">
-            <node concept="3qWCbU" id="2bBfLTGrYGC" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="2bBfLTGrYGD" role="3LXTmr">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2bBfLTGrYGE" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2bBfLTGrYGF" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rFdJ" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rFdK" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rFdy" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rFdz" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rFd$" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
-                  <node concept="2Ry0Ak" id="2fGryx5rFd_" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rFdA" role="2Ry0An">
-                      <property role="2Ry0Am" value="atlassian-event.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rFdY" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rFdZ" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rFdL" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rFdM" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rFdN" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
-                  <node concept="2Ry0Ak" id="2fGryx5rFdO" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rFdP" role="2Ry0An">
-                      <property role="2Ry0Am" value="atlassian-httpclient-api.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rFed" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rFee" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rFe0" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rFe1" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rFe2" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
-                  <node concept="2Ry0Ak" id="2fGryx5rFe3" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rFe4" role="2Ry0An">
-                      <property role="2Ry0Am" value="atlassian-util-concurrent.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rFeF" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rFeG" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rFeu" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rFev" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rFew" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
-                  <node concept="2Ry0Ak" id="2fGryx5rFex" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rFey" role="2Ry0An">
-                      <property role="2Ry0Am" value="commons-logging.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rFeU" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rFeV" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rFeH" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rFeI" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rFeJ" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
-                  <node concept="2Ry0Ak" id="2fGryx5rFeK" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rFeL" role="2Ry0An">
-                      <property role="2Ry0Am" value="guava.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rFf9" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rFfa" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rFeW" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rFeX" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rFeY" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
-                  <node concept="2Ry0Ak" id="2fGryx5rFeZ" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rFf0" role="2Ry0An">
-                      <property role="2Ry0Am" value="httpasyncclient-cache.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rFfo" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rFfp" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rFfb" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rFfc" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rFfd" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
-                  <node concept="2Ry0Ak" id="2fGryx5rFfe" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rFff" role="2Ry0An">
-                      <property role="2Ry0Am" value="httpasyncclient.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rFfB" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rFfC" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rFfq" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rFfr" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rFfs" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
-                  <node concept="2Ry0Ak" id="2fGryx5rFft" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rFfu" role="2Ry0An">
-                      <property role="2Ry0Am" value="httpclient-cache.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rFfQ" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rFfR" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rFfD" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rFfE" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rFfF" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
-                  <node concept="2Ry0Ak" id="2fGryx5rFfG" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rFfH" role="2Ry0An">
-                      <property role="2Ry0Am" value="httpclient.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rFg5" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rFg6" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rFfS" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rFfT" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rFfU" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
-                  <node concept="2Ry0Ak" id="2fGryx5rFfV" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rFfW" role="2Ry0An">
-                      <property role="2Ry0Am" value="httpcore-nio.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rFgk" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rFgl" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rFg7" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rFg8" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rFg9" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
-                  <node concept="2Ry0Ak" id="2fGryx5rFga" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rFgb" role="2Ry0An">
-                      <property role="2Ry0Am" value="httpcore.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rFgz" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rFg$" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rFgm" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rFgn" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rFgo" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
-                  <node concept="2Ry0Ak" id="2fGryx5rFgp" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rFgq" role="2Ry0An">
-                      <property role="2Ry0Am" value="httpmime.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rFic" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rFid" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rFhZ" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rFi0" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rFi1" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
-                  <node concept="2Ry0Ak" id="2fGryx5rFi2" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rFi3" role="2Ry0An">
-                      <property role="2Ry0Am" value="jersey-client.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rFiT" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rFiU" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rFiG" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rFiH" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rFiI" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
-                  <node concept="2Ry0Ak" id="2fGryx5rFiJ" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rFiK" role="2Ry0An">
-                      <property role="2Ry0Am" value="jettison.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rFj8" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rFj9" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rFiV" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rFiW" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rFiX" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
-                  <node concept="2Ry0Ak" id="2fGryx5rFiY" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rFiZ" role="2Ry0An">
-                      <property role="2Ry0Am" value="jira-rest-java-client-api.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rFjn" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rFjo" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rFja" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rFjb" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rFjc" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
-                  <node concept="2Ry0Ak" id="2fGryx5rFjd" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rFje" role="2Ry0An">
-                      <property role="2Ry0Am" value="jira-rest-java-client-core.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rFjA" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rFjB" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rFjp" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rFjq" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rFjr" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
-                  <node concept="2Ry0Ak" id="2fGryx5rFjs" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rFjt" role="2Ry0An">
-                      <property role="2Ry0Am" value="joda-time.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rFjP" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rFjQ" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rFjC" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rFjD" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rFjE" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
-                  <node concept="2Ry0Ak" id="2fGryx5rFjF" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rFjG" role="2Ry0An">
-                      <property role="2Ry0Am" value="jsr305.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rFkj" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rFkk" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rFk6" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rFk7" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rFk8" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
-                  <node concept="2Ry0Ak" id="2fGryx5rFk9" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rFka" role="2Ry0An">
-                      <property role="2Ry0Am" value="spring-beans.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rFky" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rFkz" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rFkl" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rFkm" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rFkn" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
-                  <node concept="2Ry0Ak" id="2fGryx5rFko" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rFkp" role="2Ry0An">
-                      <property role="2Ry0Am" value="spring-core.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1BupzO" id="2_t3nDPzUpG" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="2_t3nDPzUpH" role="1HemKq">
-            <node concept="398BVA" id="2_t3nDPzUpx" role="3LXTmr">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2_t3nDPzUpy" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2_t3nDPzUpz" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
-                  <node concept="2Ry0Ak" id="2_t3nDPzUp$" role="2Ry0An">
-                    <property role="2Ry0Am" value="models" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="2_t3nDPzUpI" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtD" id="2wSfKqy9jAQ" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="com.mpsbasics.jira" />
-        <property role="3LESm3" value="fde86f49-830f-414f-9c22-2a9e300eaba6" />
-        <node concept="398BVA" id="2wSfKqy9jXx" role="3LF7KH">
-          <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-          <node concept="2Ry0Ak" id="2wSfKqy9kkH" role="iGT6I">
-            <property role="2Ry0Am" value="languages" />
-            <node concept="2Ry0Ak" id="2wSfKqy9kGG" role="2Ry0An">
-              <property role="2Ry0Am" value="com.mpsbasics.jira" />
-              <node concept="2Ry0Ak" id="2wSfKqy9l4F" role="2Ry0An">
-                <property role="2Ry0Am" value="com.mpsbasics.jira.mpl" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2wSfKqy9lsa" role="3bR37C">
-          <node concept="3bR9La" id="2wSfKqy9lsb" role="1SiIV1">
-            <ref role="3bR37D" node="2wSfKqy9hC9" resolve="com.mpsbasics.jira.pluginSolution" />
-          </node>
-        </node>
-        <node concept="1BupzO" id="2wSfKqy9lsn" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="2wSfKqy9lso" role="1HemKq">
-            <node concept="398BVA" id="2wSfKqy9lsc" role="3LXTmr">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2wSfKqy9lsd" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="2wSfKqy9lse" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.jira" />
-                  <node concept="2Ry0Ak" id="2wSfKqy9lsf" role="2Ry0An">
-                    <property role="2Ry0Am" value="models" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="2wSfKqy9lsp" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-        <node concept="3rtmxn" id="2oWhy0wGLxN" role="3bR31x">
-          <node concept="3LXTmp" id="2oWhy0wGLxO" role="3rtmxm">
-            <node concept="398BVA" id="2oWhy0wGLxP" role="3LXTmr">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2oWhy0wGLxQ" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="2oWhy0wGLxR" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.jira" />
-                  <node concept="2Ry0Ak" id="2oWhy0wGITY" role="2Ry0An">
-                    <property role="2Ry0Am" value="source_gen" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="2oWhy0wGLxS" role="3LXTna">
-              <property role="3qWCbO" value="com/mpsbasics/jira/structure/*.png" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtD" id="4lJSf3LkfPw" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="com.mpsbasics.core" />
-        <property role="3LESm3" value="792be022-0a7a-4b28-bfd8-b1b2d347b772" />
-        <node concept="398BVA" id="4lJSf3Lkg39" role="3LF7KH">
-          <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-          <node concept="2Ry0Ak" id="4lJSf3LkggM" role="iGT6I">
-            <property role="2Ry0Am" value="languages" />
-            <node concept="2Ry0Ak" id="4lJSf3LkgFZ" role="2Ry0An">
-              <property role="2Ry0Am" value="com.mpsbasics.core" />
-              <node concept="2Ry0Ak" id="4lJSf3Lkh7c" role="2Ry0An">
-                <property role="2Ry0Am" value="com.mpsbasics.core.mpl" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="4lJSf3Lkhx6" role="3bR37C">
-          <node concept="3bR9La" id="4lJSf3Lkhx7" role="1SiIV1">
-            <ref role="3bR37D" to="90a9:6SVXTgIejl1" resolve="de.itemis.mps.editor.celllayout.runtime" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="4lJSf3Lkhx8" role="3bR37C">
-          <node concept="3bR9La" id="4lJSf3Lkhx9" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1TaHNgiIbJt" resolve="jetbrains.mps.ide.platform" />
-          </node>
-        </node>
-        <node concept="1BupzO" id="4lJSf3Lkhxl" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="4lJSf3Lkhxm" role="1HemKq">
-            <node concept="398BVA" id="4lJSf3Lkhxa" role="3LXTmr">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="4lJSf3Lkhxb" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="4lJSf3Lkhxc" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.core" />
-                  <node concept="2Ry0Ak" id="4lJSf3Lkhxd" role="2Ry0An">
-                    <property role="2Ry0Am" value="models" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="4lJSf3Lkhxn" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-        <node concept="3rtmxn" id="4lJSf3LkibE" role="3bR31x">
-          <node concept="3LXTmp" id="4lJSf3LkibF" role="3rtmxm">
-            <node concept="398BVA" id="4lJSf3LkibG" role="3LXTmr">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="4lJSf3LkibH" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="4lJSf3LkibI" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.core" />
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="4lJSf3LkibK" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="vYco6EFYgp" role="3bR37C">
-          <node concept="3bR9La" id="vYco6EFYgq" role="1SiIV1">
-            <ref role="3bR37D" node="2u7UHDCnRuK" resolve="com.mpsbasics.editor.utils" />
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtD" id="6FJpOMBsZUh" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="com.mpsbasics.words.generic" />
-        <property role="3LESm3" value="e4b230e7-8e1a-4a05-8148-8713530572c1" />
-        <node concept="398BVA" id="6FJpOMBt05F" role="3LF7KH">
-          <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-          <node concept="2Ry0Ak" id="6FJpOMBt1vp" role="iGT6I">
-            <property role="2Ry0Am" value="languages" />
-            <node concept="2Ry0Ak" id="6FJpOMBt2cO" role="2Ry0An">
-              <property role="2Ry0Am" value="com.mpsbasics.words.generic" />
-              <node concept="2Ry0Ak" id="6FJpOMBt2zz" role="2Ry0An">
-                <property role="2Ry0Am" value="com.mpsbasics.words.generic.mpl" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="6FJpOMBt2V$" role="3bR37C">
-          <node concept="3bR9La" id="6FJpOMBt2V_" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:7Kfy9QB6LfQ" resolve="jetbrains.mps.kernel" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="6FJpOMBt2VA" role="3bR37C">
-          <node concept="3bR9La" id="6FJpOMBt2VB" role="1SiIV1">
-            <ref role="3bR37D" node="4lJSf3LkfPw" resolve="com.mpsbasics.core" />
-          </node>
-        </node>
-        <node concept="1BupzO" id="6FJpOMBt2VN" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="6FJpOMBt2VO" role="1HemKq">
-            <node concept="398BVA" id="6FJpOMBt2VC" role="3LXTmr">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="6FJpOMBt2VD" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="6FJpOMBt2VE" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.words.generic" />
-                  <node concept="2Ry0Ak" id="6FJpOMBt2VF" role="2Ry0An">
-                    <property role="2Ry0Am" value="models" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="6FJpOMBt2VP" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="6FJpOMBt2VQ" role="3bR37C">
-          <node concept="1Busua" id="6FJpOMBt2VR" role="1SiIV1">
-            <ref role="1Busuk" to="90a9:1sO539bGQvB" resolve="de.slisson.mps.richtext" />
-          </node>
-        </node>
-        <node concept="3rtmxn" id="6FJpOMBt3Sx" role="3bR31x">
-          <node concept="3LXTmp" id="6FJpOMBt3Sy" role="3rtmxm">
-            <node concept="398BVA" id="6FJpOMBt3Sz" role="3LXTmr">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="6FJpOMBt3S$" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="6FJpOMBt3S_" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.words.generic" />
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="6FJpOMBt3SB" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtD" id="4m8f5php_QJ" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="com.mpsbasics.plaintext.yaml" />
-        <property role="3LESm3" value="4556fd77-6edd-4716-8b05-e35fd684d04d" />
-        <node concept="398BVA" id="4m8f5php_QK" role="3LF7KH">
-          <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-          <node concept="2Ry0Ak" id="4m8f5php_QL" role="iGT6I">
-            <property role="2Ry0Am" value="languages" />
-            <node concept="2Ry0Ak" id="4m8f5php_QM" role="2Ry0An">
-              <property role="2Ry0Am" value="com.mpsbasics.plaintext.yaml" />
-              <node concept="2Ry0Ak" id="4m8f5phpAua" role="2Ry0An">
-                <property role="2Ry0Am" value="com.mpsbasics.plaintext.yaml.mpl" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1BupzO" id="4m8f5php_QS" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="4m8f5phpAR3" role="1HemKq">
-            <node concept="398BVA" id="4m8f5phpAQS" role="3LXTmr">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="4m8f5phpAQT" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="4m8f5phpAQU" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.plaintext.yaml" />
-                  <node concept="2Ry0Ak" id="4m8f5phpAQV" role="2Ry0An">
-                    <property role="2Ry0Am" value="models" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="4m8f5phpAR4" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-        <node concept="3rtmxn" id="4m8f5php_R1" role="3bR31x">
-          <node concept="3LXTmp" id="4m8f5php_R2" role="3rtmxm">
-            <node concept="398BVA" id="4m8f5php_R3" role="3LXTmr">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="4m8f5php_R4" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="4m8f5phpBR3" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.plaintext.yaml" />
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="4m8f5php_R6" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="4m8f5phpAQK" role="3bR37C">
-          <node concept="3bR9La" id="4m8f5phpAQL" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="4m8f5phpAQM" role="3bR37C">
-          <node concept="3bR9La" id="4m8f5phpAQN" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1TaHNgiIbIZ" resolve="MPS.Editor" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="4m8f5phpAQO" role="3bR37C">
-          <node concept="3bR9La" id="4m8f5phpAQP" role="1SiIV1">
-            <ref role="3bR37D" to="90a9:3$A0JaN5bpX" resolve="MPS.ThirdParty" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="4m8f5phpAQQ" role="3bR37C">
-          <node concept="3bR9La" id="4m8f5phpAQR" role="1SiIV1">
-            <ref role="3bR37D" to="90a9:PE3B26QCrP" resolve="org.apache.commons" />
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtD" id="5C1tqSGWeiw" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="com.mpsbasics.plaintext.yaml.dsl.base" />
-        <property role="3LESm3" value="91ea57f8-7d6f-44b2-9328-d39a2e01a88b" />
-        <node concept="398BVA" id="5C1tqSGWew_" role="3LF7KH">
-          <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-          <node concept="2Ry0Ak" id="5C1tqSGWeIE" role="iGT6I">
-            <property role="2Ry0Am" value="languages" />
-            <node concept="2Ry0Ak" id="5C1tqSGWfoK" role="2Ry0An">
-              <property role="2Ry0Am" value="com.mpsbasics.plaintext.yaml.dsl.base" />
-              <node concept="2Ry0Ak" id="5C1tqSGWfOP" role="2Ry0An">
-                <property role="2Ry0Am" value="com.mpsbasics.plaintext.yaml.dsl.base.mpl" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="5C1tqSGWgiJ" role="3bR37C">
-          <node concept="3bR9La" id="5C1tqSGWgiK" role="1SiIV1">
-            <ref role="3bR37D" node="4m8f5php_QJ" resolve="com.mpsbasics.plaintext.yaml" />
-          </node>
-        </node>
-        <node concept="1BupzO" id="5C1tqSGWgiW" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="5C1tqSGWgiX" role="1HemKq">
-            <node concept="398BVA" id="5C1tqSGWgiL" role="3LXTmr">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="5C1tqSGWgiM" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="5C1tqSGWgiN" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.plaintext.yaml.dsl.base" />
-                  <node concept="2Ry0Ak" id="5C1tqSGWgiO" role="2Ry0An">
-                    <property role="2Ry0Am" value="models" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="5C1tqSGWgiY" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="5C1tqSGWgiZ" role="3bR37C">
-          <node concept="1Busua" id="5C1tqSGWgj0" role="1SiIV1">
-            <ref role="1Busuk" node="4m8f5php_QJ" resolve="com.mpsbasics.plaintext.yaml" />
-          </node>
-        </node>
-        <node concept="3rtmxn" id="5C1tqSGWgGk" role="3bR31x">
-          <node concept="3LXTmp" id="5C1tqSGWgGl" role="3rtmxm">
-            <node concept="398BVA" id="5C1tqSGWgGm" role="3LXTmr">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="5C1tqSGWgGn" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="5C1tqSGWgGo" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.plaintext.yaml.dsl.base" />
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="5C1tqSGWgGq" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtA" id="36zCbqqq9fZ" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="com.mpsbasics.langchain4j" />
-        <property role="3LESm3" value="033ccb15-c42a-4e5a-82f2-5fe5cdc5fd43" />
-        <node concept="398BVA" id="36zCbqqq9yc" role="3LF7KH">
-          <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-          <node concept="2Ry0Ak" id="36zCbqqqa1c" role="iGT6I">
-            <property role="2Ry0Am" value="solutions" />
-            <node concept="2Ry0Ak" id="36zCbqqqa_x" role="2Ry0An">
-              <property role="2Ry0Am" value="com.mpsbasics.langchain4j" />
-              <node concept="2Ry0Ak" id="36zCbqqqb4w" role="2Ry0An">
-                <property role="2Ry0Am" value="com.mpsbasics.langchain4j.msd" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="36zCbqqqb$F" role="3bR37C">
-          <node concept="3bR9La" id="36zCbqqqb$G" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="36zCbqqqb$H" role="3bR37C">
-          <node concept="3bR9La" id="36zCbqqqb$I" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:3HV74$ebibC" resolve="jetbrains.mps.lang.text" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="36zCbqqqb$J" role="3bR37C">
-          <node concept="3bR9La" id="36zCbqqqb$K" role="1SiIV1">
-            <ref role="3bR37D" node="36zCbqqq6a9" resolve="com.mpsbasics.genai" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="36zCbqqqb$L" role="3bR37C">
-          <node concept="3bR9La" id="36zCbqqqb$M" role="1SiIV1">
-            <ref role="3bR37D" node="2u7UHDC1RNf" resolve="com.mpsbasics.pdfbox" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="36zCbqqqb$N" role="3bR37C">
-          <node concept="3bR9La" id="36zCbqqqb$O" role="1SiIV1">
-            <ref role="3bR37D" to="al5i:6o5cjw5gEyi" resolve="com.mbeddr.mpsutil.json" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="36zCbqqqb_2" role="3bR37C">
-          <node concept="1BurEX" id="36zCbqqqb_3" role="1SiIV1">
-            <node concept="398BVA" id="36zCbqqqb$P" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="36zCbqqqb$Q" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="36zCbqqqb$R" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.langchain4j" />
-                  <node concept="2Ry0Ak" id="36zCbqqqb$S" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="36zCbqqqb$T" role="2Ry0An">
-                      <property role="2Ry0Am" value="langchain4j.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="36zCbqqqb_h" role="3bR37C">
-          <node concept="1BurEX" id="36zCbqqqb_i" role="1SiIV1">
-            <node concept="398BVA" id="36zCbqqqb_4" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="36zCbqqqb_5" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="36zCbqqqb_6" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.langchain4j" />
-                  <node concept="2Ry0Ak" id="36zCbqqqb_7" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="36zCbqqqb_8" role="2Ry0An">
-                      <property role="2Ry0Am" value="opennlp-tools.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="36zCbqqqb_w" role="3bR37C">
-          <node concept="1BurEX" id="36zCbqqqb_x" role="1SiIV1">
-            <node concept="398BVA" id="36zCbqqqb_j" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="36zCbqqqb_k" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="36zCbqqqb_l" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.langchain4j" />
-                  <node concept="2Ry0Ak" id="36zCbqqqb_m" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="36zCbqqqb_n" role="2Ry0An">
-                      <property role="2Ry0Am" value="jackson-annotations.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="36zCbqqqb_J" role="3bR37C">
-          <node concept="1BurEX" id="36zCbqqqb_K" role="1SiIV1">
-            <node concept="398BVA" id="36zCbqqqb_y" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="36zCbqqqb_z" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="36zCbqqqb_$" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.langchain4j" />
-                  <node concept="2Ry0Ak" id="36zCbqqqb__" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="36zCbqqqb_A" role="2Ry0An">
-                      <property role="2Ry0Am" value="jackson-core.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="36zCbqqqb_Y" role="3bR37C">
-          <node concept="1BurEX" id="36zCbqqqb_Z" role="1SiIV1">
-            <node concept="398BVA" id="36zCbqqqb_L" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="36zCbqqqb_M" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="36zCbqqqb_N" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.langchain4j" />
-                  <node concept="2Ry0Ak" id="36zCbqqqb_O" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="36zCbqqqb_P" role="2Ry0An">
-                      <property role="2Ry0Am" value="jackson-databind.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="36zCbqqqbAd" role="3bR37C">
-          <node concept="1BurEX" id="36zCbqqqbAe" role="1SiIV1">
-            <node concept="398BVA" id="36zCbqqqbA0" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="36zCbqqqbA1" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="36zCbqqqbA2" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.langchain4j" />
-                  <node concept="2Ry0Ak" id="36zCbqqqbA3" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="36zCbqqqbA4" role="2Ry0An">
-                      <property role="2Ry0Am" value="jspecify.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="36zCbqqqbAs" role="3bR37C">
-          <node concept="1BurEX" id="36zCbqqqbAt" role="1SiIV1">
-            <node concept="398BVA" id="36zCbqqqbAf" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="36zCbqqqbAg" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="36zCbqqqbAh" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.langchain4j" />
-                  <node concept="2Ry0Ak" id="36zCbqqqbAi" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="36zCbqqqbAj" role="2Ry0An">
-                      <property role="2Ry0Am" value="jtokkit.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="36zCbqqqbAF" role="3bR37C">
-          <node concept="1BurEX" id="36zCbqqqbAG" role="1SiIV1">
-            <node concept="398BVA" id="36zCbqqqbAu" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="36zCbqqqbAv" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="36zCbqqqbAw" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.langchain4j" />
-                  <node concept="2Ry0Ak" id="36zCbqqqbAx" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="36zCbqqqbAy" role="2Ry0An">
-                      <property role="2Ry0Am" value="langchain4j-core.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="36zCbqqqbAU" role="3bR37C">
-          <node concept="1BurEX" id="36zCbqqqbAV" role="1SiIV1">
-            <node concept="398BVA" id="36zCbqqqbAH" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="36zCbqqqbAI" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="36zCbqqqbAJ" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.langchain4j" />
-                  <node concept="2Ry0Ak" id="36zCbqqqbAK" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="36zCbqqqbAL" role="2Ry0An">
-                      <property role="2Ry0Am" value="langchain4j-http-client-jdk.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="36zCbqqqbB9" role="3bR37C">
-          <node concept="1BurEX" id="36zCbqqqbBa" role="1SiIV1">
-            <node concept="398BVA" id="36zCbqqqbAW" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="36zCbqqqbAX" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="36zCbqqqbAY" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.langchain4j" />
-                  <node concept="2Ry0Ak" id="36zCbqqqbAZ" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="36zCbqqqbB0" role="2Ry0An">
-                      <property role="2Ry0Am" value="langchain4j-http-client.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="36zCbqqqbBo" role="3bR37C">
-          <node concept="1BurEX" id="36zCbqqqbBp" role="1SiIV1">
-            <node concept="398BVA" id="36zCbqqqbBb" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="36zCbqqqbBc" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="36zCbqqqbBd" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.langchain4j" />
-                  <node concept="2Ry0Ak" id="36zCbqqqbBe" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="36zCbqqqbBf" role="2Ry0An">
-                      <property role="2Ry0Am" value="langchain4j-open-ai.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1BupzO" id="36zCbqqqbBO" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="36zCbqqqbBP" role="1HemKq">
-            <node concept="398BVA" id="36zCbqqqbBD" role="3LXTmr">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="36zCbqqqbBE" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="36zCbqqqbBF" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.langchain4j" />
-                  <node concept="2Ry0Ak" id="36zCbqqqbBG" role="2Ry0An">
-                    <property role="2Ry0Am" value="models" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="36zCbqqqbBQ" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-        <node concept="3rtmxn" id="3d7CvMnNV2Q" role="3bR31x">
-          <node concept="3LXTmp" id="3d7CvMnNV2R" role="3rtmxm">
-            <node concept="3qWCbU" id="3d7CvMnNV2S" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="3d7CvMnNV2T" role="3LXTmr">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="3d7CvMnNV2U" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="3d7CvMnNV2V" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.langchain4j" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtD" id="36zCbqqq6a9" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="com.mpsbasics.genai" />
-        <property role="3LESm3" value="e49ae71b-b7a6-4321-84b6-ac9a82e13853" />
-        <node concept="398BVA" id="36zCbqqq6sm" role="3LF7KH">
-          <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-          <node concept="2Ry0Ak" id="36zCbqqq70G" role="iGT6I">
-            <property role="2Ry0Am" value="languages" />
-            <node concept="2Ry0Ak" id="36zCbqqq7vF" role="2Ry0An">
-              <property role="2Ry0Am" value="com.mpsbasics.genai" />
-              <node concept="2Ry0Ak" id="36zCbqqq840" role="2Ry0An">
-                <property role="2Ry0Am" value="com.mpsbasics.genai.mpl" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="36zCbqqq8uP" role="3bR37C">
-          <node concept="3bR9La" id="36zCbqqq8uQ" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:3HV74$ebibC" resolve="jetbrains.mps.lang.text" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="36zCbqqq8uR" role="3bR37C">
-          <node concept="3bR9La" id="36zCbqqq8uS" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:4SM2EuqHUPF" resolve="jetbrains.mps.lang.modelapi" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="36zCbqqq8uT" role="3bR37C">
-          <node concept="3bR9La" id="36zCbqqq8uU" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1TaHNgiIbIZ" resolve="MPS.Editor" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="36zCbqqq8uV" role="3bR37C">
-          <node concept="3bR9La" id="36zCbqqq8uW" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:7Kfy9QB6LfQ" resolve="jetbrains.mps.kernel" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="36zCbqqq8uX" role="3bR37C">
-          <node concept="3bR9La" id="36zCbqqq8uY" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:7Kfy9QB6L9O" resolve="jetbrains.mps.lang.smodel" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="36zCbqqq8uZ" role="3bR37C">
-          <node concept="3bR9La" id="36zCbqqq8v0" role="1SiIV1">
-            <ref role="3bR37D" to="al5i:6o5cjw5gEyi" resolve="com.mbeddr.mpsutil.json" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="36zCbqqq8v1" role="3bR37C">
-          <node concept="3bR9La" id="36zCbqqq8v2" role="1SiIV1">
-            <ref role="3bR37D" to="al5i:Vtr7jyAKU4" resolve="com.mbeddr.mpsutil.filepicker" />
-          </node>
-        </node>
-        <node concept="1BupzO" id="36zCbqqq8ve" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="36zCbqqq8vf" role="1HemKq">
-            <node concept="398BVA" id="36zCbqqq8v3" role="3LXTmr">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="36zCbqqq8v4" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="36zCbqqq8v5" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.genai" />
-                  <node concept="2Ry0Ak" id="36zCbqqq8v6" role="2Ry0An">
-                    <property role="2Ry0Am" value="models" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="36zCbqqq8vg" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="36zCbqqqcpD" role="3bR37C">
-          <node concept="3bR9La" id="36zCbqqqcpE" role="1SiIV1">
-            <ref role="3bR37D" node="36zCbqqq9fZ" resolve="com.mpsbasics.langchain4j" />
-          </node>
-        </node>
-        <node concept="3rtmxn" id="3d7CvMnNV2X" role="3bR31x">
-          <node concept="3LXTmp" id="3d7CvMnNV2Y" role="3rtmxm">
-            <node concept="3qWCbU" id="3d7CvMnNV2Z" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="3d7CvMnNV30" role="3LXTmr">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="3d7CvMnNV31" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="3d7CvMnNV32" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.genai" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="2G$12M" id="2MrvZqtGQDM" role="3989C9">
-      <property role="TrG5h" value="com.mpsbasics.testutils" />
-      <node concept="1E1JtA" id="2MrvZqtDizQ" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="com.mpsbasics.docx4j.testutils" />
-        <property role="3LESm3" value="5f04c496-eb21-4501-981b-4e5fc2ab46ec" />
-        <node concept="398BVA" id="2MrvZqtDiKJ" role="3LF7KH">
-          <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-          <node concept="2Ry0Ak" id="2MrvZqtDj3D" role="iGT6I">
-            <property role="2Ry0Am" value="solutions" />
-            <node concept="2Ry0Ak" id="2MrvZqtDjmW" role="2Ry0An">
-              <property role="2Ry0Am" value="com.mpsbasics.docx4j.testutils" />
-              <node concept="2Ry0Ak" id="2MrvZqtDjC7" role="2Ry0An">
-                <property role="2Ry0Am" value="com.mpsbasics.docx4j.testutils.msd" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2MrvZqtDjUI" role="3bR37C">
-          <node concept="3bR9La" id="2MrvZqtDjUJ" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2MrvZqtDjUK" role="3bR37C">
-          <node concept="3bR9La" id="2MrvZqtDjUL" role="1SiIV1">
-            <ref role="3bR37D" node="6hyv0iVPlFI" resolve="com.mpsbasics.docx4j.lib" />
-          </node>
-        </node>
-        <node concept="1BupzO" id="2MrvZqtDjUZ" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="2MrvZqtDjV0" role="1HemKq">
-            <node concept="398BVA" id="2MrvZqtDjUO" role="3LXTmr">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2MrvZqtDjUP" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2MrvZqtDjUQ" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.testutils" />
-                  <node concept="2Ry0Ak" id="2MrvZqtDjUR" role="2Ry0An">
-                    <property role="2Ry0Am" value="models" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="2MrvZqtDjV1" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-        <node concept="3rtmxn" id="4euqtkrusDT" role="3bR31x">
-          <node concept="3LXTmp" id="4euqtkrusDU" role="3rtmxm">
-            <node concept="3qWCbU" id="4euqtkrusDV" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="4euqtkrusDW" role="3LXTmr">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="4euqtkrusDX" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="4euqtkrusDY" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.testutils" />
-                </node>
-              </node>
-            </node>
+        <node concept="1SiIV0" id="5gFsbf342ch" role="3bR37C">
+          <node concept="3bR9La" id="5gFsbf342ci" role="1SiIV1">
+            <ref role="3bR37D" to="k3fp:5jdn85oHU1h" resolve="com.mpsbasics.build" />
           </node>
         </node>
       </node>
@@ -3819,7 +1110,7 @@
         </node>
         <node concept="1SiIV0" id="7a7$evTWqS9" role="3bR37C">
           <node concept="3bR9La" id="7a7$evTWqSa" role="1SiIV1">
-            <ref role="3bR37D" node="4lJSf3LkfPw" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
         <node concept="1BupzO" id="7a7$evTWqSo" role="3bR31x">
@@ -3916,7 +1207,7 @@
         </node>
         <node concept="1SiIV0" id="7a7$evTWu1e" role="3bR37C">
           <node concept="1Busua" id="7a7$evTWu1f" role="1SiIV1">
-            <ref role="1Busuk" node="4lJSf3LkfPw" resolve="com.mpsbasics.core" />
+            <ref role="1Busuk" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
         <node concept="1SiIV0" id="7a7$evTWu1g" role="3bR37C">
@@ -3962,12 +1253,12 @@
         </node>
         <node concept="1SiIV0" id="6hyv0iVPlIl" role="3bR37C">
           <node concept="3bR9La" id="6hyv0iVPlVb" role="1SiIV1">
-            <ref role="3bR37D" node="6hyv0iVPlFH" resolve="com.mpsbasics.docx4j.core" />
+            <ref role="3bR37D" to="k3fp:6hyv0iVPlFH" resolve="com.mpsbasics.docx4j.core" />
           </node>
         </node>
         <node concept="1SiIV0" id="6hyv0iVPlIm" role="3bR37C">
           <node concept="3bR9La" id="6hyv0iVPlVc" role="1SiIV1">
-            <ref role="3bR37D" node="6hyv0iVPlFI" resolve="com.mpsbasics.docx4j.lib" />
+            <ref role="3bR37D" to="k3fp:6hyv0iVPlFI" resolve="com.mpsbasics.docx4j.lib" />
           </node>
         </node>
         <node concept="1SiIV0" id="6hyv0iVPlIo" role="3bR37C">
@@ -4132,12 +1423,12 @@
         </node>
         <node concept="1SiIV0" id="5Gu43O52kV3" role="3bR37C">
           <node concept="3bR9La" id="5Gu43O52kV4" role="1SiIV1">
-            <ref role="3bR37D" node="4lJSf3LkfPw" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
         <node concept="1SiIV0" id="6FJpOMBt4h9" role="3bR37C">
           <node concept="3bR9La" id="6FJpOMBt4ha" role="1SiIV1">
-            <ref role="3bR37D" node="6FJpOMBsZUh" resolve="com.mpsbasics.words.generic" />
+            <ref role="3bR37D" to="k3fp:6FJpOMBsZUh" resolve="com.mpsbasics.words.generic" />
           </node>
         </node>
         <node concept="1SiIV0" id="5xecbsSrGxF" role="3bR37C">
@@ -4252,7 +1543,7 @@
         </node>
         <node concept="1SiIV0" id="5Gu43O52kVt" role="3bR37C">
           <node concept="3bR9La" id="5Gu43O52kVu" role="1SiIV1">
-            <ref role="3bR37D" node="4lJSf3LkfPw" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
       </node>
@@ -4457,7 +1748,7 @@
         </node>
         <node concept="1SiIV0" id="5Gu43O52kVP" role="3bR37C">
           <node concept="3bR9La" id="5Gu43O52kVQ" role="1SiIV1">
-            <ref role="3bR37D" node="4lJSf3LkfPw" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
       </node>
@@ -4560,7 +1851,7 @@
         </node>
         <node concept="1SiIV0" id="kjG6o7UaVH" role="3bR37C">
           <node concept="3bR9La" id="kjG6o7UaVI" role="1SiIV1">
-            <ref role="3bR37D" node="4lJSf3LkfPw" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
       </node>
@@ -4686,7 +1977,7 @@
         </node>
         <node concept="1SiIV0" id="5t37uj6YhHe" role="3bR37C">
           <node concept="3bR9La" id="5t37uj6YhHf" role="1SiIV1">
-            <ref role="3bR37D" node="6hyv0iVPlFJ" resolve="com.mpsbasics.snode.utils" />
+            <ref role="3bR37D" to="k3fp:6hyv0iVPlFJ" resolve="com.mpsbasics.snode.utils" />
           </node>
         </node>
         <node concept="1SiIV0" id="8xY_IhvzFT" role="3bR37C">
@@ -4701,12 +1992,12 @@
         </node>
         <node concept="1SiIV0" id="2u7UHDCnSOz" role="3bR37C">
           <node concept="3bR9La" id="2u7UHDCnSO$" role="1SiIV1">
-            <ref role="3bR37D" node="2u7UHDCnPLY" resolve="com.mpsbasics.project.utils" />
+            <ref role="3bR37D" to="k3fp:2u7UHDCnPLY" resolve="com.mpsbasics.project.utils" />
           </node>
         </node>
         <node concept="1SiIV0" id="5Gu43O52kWf" role="3bR37C">
           <node concept="3bR9La" id="5Gu43O52kWg" role="1SiIV1">
-            <ref role="3bR37D" node="4lJSf3LkfPw" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
         <node concept="1SiIV0" id="3aXq4CuhyUs" role="3bR37C">
@@ -4721,7 +2012,7 @@
         </node>
         <node concept="1SiIV0" id="6r9ErzLlH4f" role="3bR37C">
           <node concept="3bR9La" id="6r9ErzLlH4g" role="1SiIV1">
-            <ref role="3bR37D" node="2u7UHDCnRuK" resolve="com.mpsbasics.editor.utils" />
+            <ref role="3bR37D" to="k3fp:2u7UHDCnRuK" resolve="com.mpsbasics.editor.utils" />
           </node>
         </node>
       </node>
@@ -4869,7 +2160,7 @@
         </node>
         <node concept="1SiIV0" id="5Gu43O52kWB" role="3bR37C">
           <node concept="3bR9La" id="5Gu43O52kWC" role="1SiIV1">
-            <ref role="3bR37D" node="4lJSf3LkfPw" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
       </node>
@@ -4949,7 +2240,7 @@
         </node>
         <node concept="1SiIV0" id="5Gu43O52kWO" role="3bR37C">
           <node concept="3bR9La" id="5Gu43O52kWP" role="1SiIV1">
-            <ref role="3bR37D" node="4lJSf3LkfPw" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
       </node>
@@ -5370,7 +2661,7 @@
         </node>
         <node concept="1SiIV0" id="5Gu43O52kXW" role="3bR37C">
           <node concept="3bR9La" id="5Gu43O52kXX" role="1SiIV1">
-            <ref role="3bR37D" node="4lJSf3LkfPw" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
       </node>
@@ -5502,7 +2793,7 @@
         </node>
         <node concept="1SiIV0" id="5Gu43O52kYx" role="3bR37C">
           <node concept="3bR9La" id="5Gu43O52kYy" role="1SiIV1">
-            <ref role="3bR37D" node="4lJSf3LkfPw" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
       </node>
@@ -5657,7 +2948,7 @@
         </node>
         <node concept="1SiIV0" id="5Gu43O52kYT" role="3bR37C">
           <node concept="3bR9La" id="5Gu43O52kYU" role="1SiIV1">
-            <ref role="3bR37D" node="4lJSf3LkfPw" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
         <node concept="1SiIV0" id="1TpxQu7pSkD" role="3bR37C">
@@ -5788,7 +3079,7 @@
         </node>
         <node concept="1SiIV0" id="5t37uj6YhJM" role="3bR37C">
           <node concept="3bR9La" id="5t37uj6YhJN" role="1SiIV1">
-            <ref role="3bR37D" node="6hyv0iVPlFJ" resolve="com.mpsbasics.snode.utils" />
+            <ref role="3bR37D" to="k3fp:6hyv0iVPlFJ" resolve="com.mpsbasics.snode.utils" />
           </node>
         </node>
         <node concept="1SiIV0" id="1x1_rydrQuq" role="3bR37C">
@@ -5814,17 +3105,17 @@
         </node>
         <node concept="1SiIV0" id="2u7UHDCnTjb" role="3bR37C">
           <node concept="3bR9La" id="2u7UHDCnTjc" role="1SiIV1">
-            <ref role="3bR37D" node="2u7UHDCnRuK" resolve="com.mpsbasics.editor.utils" />
+            <ref role="3bR37D" to="k3fp:2u7UHDCnRuK" resolve="com.mpsbasics.editor.utils" />
           </node>
         </node>
         <node concept="1SiIV0" id="5Gu43O52kZ6" role="3bR37C">
           <node concept="3bR9La" id="5Gu43O52kZ7" role="1SiIV1">
-            <ref role="3bR37D" node="4lJSf3LkfPw" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
         <node concept="1SiIV0" id="2FavYGw22Mg" role="3bR37C">
           <node concept="1Busua" id="2FavYGw22Mh" role="1SiIV1">
-            <ref role="1Busuk" node="6FJpOMBsZUh" resolve="com.mpsbasics.words.generic" />
+            <ref role="1Busuk" to="k3fp:6FJpOMBsZUh" resolve="com.mpsbasics.words.generic" />
           </node>
         </node>
         <node concept="1SiIV0" id="5mBZ2gvf8EL" role="3bR37C">
@@ -5934,12 +3225,12 @@
         </node>
         <node concept="1SiIV0" id="YXkTXVNgI0" role="3bR37C">
           <node concept="3bR9La" id="YXkTXVNgI1" role="1SiIV1">
-            <ref role="3bR37D" node="2u7UHDCnRuK" resolve="com.mpsbasics.editor.utils" />
+            <ref role="3bR37D" to="k3fp:2u7UHDCnRuK" resolve="com.mpsbasics.editor.utils" />
           </node>
         </node>
         <node concept="1SiIV0" id="5Gu43O52kZj" role="3bR37C">
           <node concept="3bR9La" id="5Gu43O52kZk" role="1SiIV1">
-            <ref role="3bR37D" node="4lJSf3LkfPw" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
       </node>
@@ -6072,12 +3363,12 @@
         </node>
         <node concept="1SiIV0" id="5Gu43O52kZw" role="3bR37C">
           <node concept="3bR9La" id="5Gu43O52kZx" role="1SiIV1">
-            <ref role="3bR37D" node="4lJSf3LkfPw" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
         <node concept="1SiIV0" id="5U_9MCNd6MB" role="3bR37C">
           <node concept="3bR9La" id="5U_9MCNd6MC" role="1SiIV1">
-            <ref role="3bR37D" node="2u7UHDCnPLY" resolve="com.mpsbasics.project.utils" />
+            <ref role="3bR37D" to="k3fp:2u7UHDCnPLY" resolve="com.mpsbasics.project.utils" />
           </node>
         </node>
       </node>
@@ -6410,12 +3701,12 @@
         </node>
         <node concept="1SiIV0" id="1_HYGT7LTW8" role="3bR37C">
           <node concept="1Busua" id="1_HYGT7LTW9" role="1SiIV1">
-            <ref role="1Busuk" node="4lJSf3LkfPw" resolve="com.mpsbasics.core" />
+            <ref role="1Busuk" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
         <node concept="1SiIV0" id="2dsc7Gno1f" role="3bR37C">
           <node concept="3bR9La" id="2dsc7Gno1g" role="1SiIV1">
-            <ref role="3bR37D" node="4lJSf3LkfPw" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
       </node>
@@ -6518,12 +3809,12 @@
         </node>
         <node concept="1SiIV0" id="5Gu43O52l0r" role="3bR37C">
           <node concept="3bR9La" id="5Gu43O52l0s" role="1SiIV1">
-            <ref role="3bR37D" node="4lJSf3LkfPw" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
         <node concept="1SiIV0" id="6FJpOMBt4mm" role="3bR37C">
           <node concept="3bR9La" id="6FJpOMBt4mn" role="1SiIV1">
-            <ref role="3bR37D" node="6FJpOMBsZUh" resolve="com.mpsbasics.words.generic" />
+            <ref role="3bR37D" to="k3fp:6FJpOMBsZUh" resolve="com.mpsbasics.words.generic" />
           </node>
         </node>
       </node>
@@ -6671,7 +3962,7 @@
         </node>
         <node concept="1SiIV0" id="5Gu43O52l0C" role="3bR37C">
           <node concept="3bR9La" id="5Gu43O52l0D" role="1SiIV1">
-            <ref role="3bR37D" node="4lJSf3LkfPw" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
         <node concept="1SiIV0" id="2K8T9FD4pH5" role="3bR37C">
@@ -6718,7 +4009,7 @@
         </node>
         <node concept="1SiIV0" id="2K8T9FD4s2$" role="3bR37C">
           <node concept="3bR9La" id="2K8T9FD4s2_" role="1SiIV1">
-            <ref role="3bR37D" node="4lJSf3LkfPw" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
         <node concept="1SiIV0" id="2K8T9FD4s2A" role="3bR37C">
@@ -6869,7 +4160,7 @@
         </node>
         <node concept="1SiIV0" id="5Gu43O52l0P" role="3bR37C">
           <node concept="3bR9La" id="5Gu43O52l0Q" role="1SiIV1">
-            <ref role="3bR37D" node="4lJSf3LkfPw" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
       </node>
@@ -7008,7 +4299,7 @@
         </node>
         <node concept="1SiIV0" id="6FJpOMBt4mT" role="3bR37C">
           <node concept="3bR9La" id="6FJpOMBt4mU" role="1SiIV1">
-            <ref role="3bR37D" node="6FJpOMBsZUh" resolve="com.mpsbasics.words.generic" />
+            <ref role="3bR37D" to="k3fp:6FJpOMBsZUh" resolve="com.mpsbasics.words.generic" />
           </node>
         </node>
       </node>
@@ -7144,11 +4435,11 @@
           </node>
         </node>
         <node concept="1E0d5M" id="1hVhF3lqvV3" role="1E1XAP">
-          <ref role="1E0d5P" node="2u7UHDCnPLY" resolve="com.mpsbasics.project.utils" />
+          <ref role="1E0d5P" to="k3fp:2u7UHDCnPLY" resolve="com.mpsbasics.project.utils" />
         </node>
         <node concept="1SiIV0" id="5Gu43O52l1q" role="3bR37C">
           <node concept="3bR9La" id="5Gu43O52l1r" role="1SiIV1">
-            <ref role="3bR37D" node="4lJSf3LkfPw" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
         <node concept="1SiIV0" id="7OA8CsRhfWe" role="3bR37C">
@@ -7158,7 +4449,7 @@
         </node>
         <node concept="1SiIV0" id="2FavYGw2uea" role="3bR37C">
           <node concept="1Busua" id="2FavYGw2ueb" role="1SiIV1">
-            <ref role="1Busuk" node="6FJpOMBsZUh" resolve="com.mpsbasics.words.generic" />
+            <ref role="1Busuk" to="k3fp:6FJpOMBsZUh" resolve="com.mpsbasics.words.generic" />
           </node>
         </node>
       </node>
@@ -7442,12 +4733,12 @@
         </node>
         <node concept="1SiIV0" id="4ziKDEngCuV" role="3bR37C">
           <node concept="3bR9La" id="4ziKDEngCuW" role="1SiIV1">
-            <ref role="3bR37D" node="6hyv0iVPlFH" resolve="com.mpsbasics.docx4j.core" />
+            <ref role="3bR37D" to="k3fp:6hyv0iVPlFH" resolve="com.mpsbasics.docx4j.core" />
           </node>
         </node>
         <node concept="1SiIV0" id="4ziKDEngCuZ" role="3bR37C">
           <node concept="3bR9La" id="4ziKDEngCv0" role="1SiIV1">
-            <ref role="3bR37D" node="6hyv0iVPlFI" resolve="com.mpsbasics.docx4j.lib" />
+            <ref role="3bR37D" to="k3fp:6hyv0iVPlFI" resolve="com.mpsbasics.docx4j.lib" />
           </node>
         </node>
         <node concept="1SiIV0" id="4ziKDEngCv3" role="3bR37C">
@@ -7539,7 +4830,7 @@
         </node>
         <node concept="1SiIV0" id="2u7UHDCnTm$" role="3bR37C">
           <node concept="3bR9La" id="2u7UHDCnTm_" role="1SiIV1">
-            <ref role="3bR37D" node="2u7UHDCnRuK" resolve="com.mpsbasics.editor.utils" />
+            <ref role="3bR37D" to="k3fp:2u7UHDCnRuK" resolve="com.mpsbasics.editor.utils" />
           </node>
         </node>
       </node>
@@ -7566,7 +4857,7 @@
         </node>
         <node concept="1SiIV0" id="3TNxfDZ8qC_" role="3bR37C">
           <node concept="3bR9La" id="3TNxfDZ8qCA" role="1SiIV1">
-            <ref role="3bR37D" node="2u7UHDC1RNf" resolve="com.mpsbasics.pdfbox" />
+            <ref role="3bR37D" to="k3fp:2u7UHDC1RNf" resolve="com.mpsbasics.pdfbox" />
           </node>
         </node>
         <node concept="1BupzO" id="3TNxfDZ8qCM" role="3bR31x">
@@ -7593,7 +4884,7 @@
         </node>
         <node concept="1SiIV0" id="3TNxfDZ8qCP" role="3bR37C">
           <node concept="1Busua" id="3TNxfDZ8qCQ" role="1SiIV1">
-            <ref role="1Busuk" node="2u7UHDC1TKp" resolve="com.mpsbasics.pdfexporter" />
+            <ref role="1Busuk" to="k3fp:2u7UHDC1TKp" resolve="com.mpsbasics.pdfexporter" />
           </node>
         </node>
         <node concept="3rtmxn" id="jPgKPEJYey" role="3bR31x">
@@ -7614,7 +4905,7 @@
         </node>
         <node concept="1SiIV0" id="5Gu43O52l2S" role="3bR37C">
           <node concept="3bR9La" id="5Gu43O52l2T" role="1SiIV1">
-            <ref role="3bR37D" node="4lJSf3LkfPw" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
       </node>
@@ -7717,7 +5008,7 @@
         </node>
         <node concept="1SiIV0" id="5Gu43O52l35" role="3bR37C">
           <node concept="3bR9La" id="5Gu43O52l36" role="1SiIV1">
-            <ref role="3bR37D" node="4lJSf3LkfPw" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
       </node>
@@ -7759,7 +5050,7 @@
         </node>
         <node concept="1SiIV0" id="3h2IzuaJgHX" role="3bR37C">
           <node concept="3bR9La" id="3h2IzuaJgHY" role="1SiIV1">
-            <ref role="3bR37D" node="2wSfKqy9jAQ" resolve="com.mpsbasics.jira" />
+            <ref role="3bR37D" to="k3fp:2wSfKqy9jAQ" resolve="com.mpsbasics.jira" />
           </node>
         </node>
         <node concept="1SiIV0" id="3h2IzuaJgHZ" role="3bR37C">
@@ -7813,7 +5104,7 @@
         </node>
         <node concept="1SiIV0" id="5Gu43O52l3i" role="3bR37C">
           <node concept="3bR9La" id="5Gu43O52l3j" role="1SiIV1">
-            <ref role="3bR37D" node="4lJSf3LkfPw" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
       </node>
@@ -7922,7 +5213,7 @@
         </node>
         <node concept="1SiIV0" id="5Gu43O52l3v" role="3bR37C">
           <node concept="3bR9La" id="5Gu43O52l3w" role="1SiIV1">
-            <ref role="3bR37D" node="4lJSf3LkfPw" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
       </node>
@@ -8015,7 +5306,7 @@
         </node>
         <node concept="1SiIV0" id="5Gu43O52l3G" role="3bR37C">
           <node concept="3bR9La" id="5Gu43O52l3H" role="1SiIV1">
-            <ref role="3bR37D" node="4lJSf3LkfPw" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
         <node concept="1SiIV0" id="75npNYZO4hJ" role="3bR37C">
@@ -8079,7 +5370,7 @@
         </node>
         <node concept="1SiIV0" id="6FJpOMBt4pi" role="3bR37C">
           <node concept="3bR9La" id="6FJpOMBt4pj" role="1SiIV1">
-            <ref role="3bR37D" node="6FJpOMBsZUh" resolve="com.mpsbasics.words.generic" />
+            <ref role="3bR37D" to="k3fp:6FJpOMBsZUh" resolve="com.mpsbasics.words.generic" />
           </node>
         </node>
         <node concept="1SiIV0" id="5xecbsSrGDG" role="3bR37C">
@@ -8330,7 +5621,7 @@
         </node>
         <node concept="1SiIV0" id="5Gu43O52l4f" role="3bR37C">
           <node concept="3bR9La" id="5Gu43O52l4g" role="1SiIV1">
-            <ref role="3bR37D" node="4lJSf3LkfPw" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
       </node>
@@ -8405,7 +5696,7 @@
         </node>
         <node concept="1SiIV0" id="5Gu43O52l4s" role="3bR37C">
           <node concept="3bR9La" id="5Gu43O52l4t" role="1SiIV1">
-            <ref role="3bR37D" node="4lJSf3LkfPw" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
       </node>
@@ -8475,7 +5766,7 @@
         </node>
         <node concept="1SiIV0" id="5Gu43O52l4D" role="3bR37C">
           <node concept="3bR9La" id="5Gu43O52l4E" role="1SiIV1">
-            <ref role="3bR37D" node="4lJSf3LkfPw" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
       </node>
@@ -8578,12 +5869,12 @@
         </node>
         <node concept="1SiIV0" id="2u7UHDCnTnE" role="3bR37C">
           <node concept="3bR9La" id="2u7UHDCnTnF" role="1SiIV1">
-            <ref role="3bR37D" node="2u7UHDCnRuK" resolve="com.mpsbasics.editor.utils" />
+            <ref role="3bR37D" to="k3fp:2u7UHDCnRuK" resolve="com.mpsbasics.editor.utils" />
           </node>
         </node>
         <node concept="1SiIV0" id="5Gu43O52l4Q" role="3bR37C">
           <node concept="3bR9La" id="5Gu43O52l4R" role="1SiIV1">
-            <ref role="3bR37D" node="4lJSf3LkfPw" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
       </node>
@@ -8636,7 +5927,7 @@
         </node>
         <node concept="1SiIV0" id="5mBZ2gvfx3T" role="3bR37C">
           <node concept="3bR9La" id="5mBZ2gvfx3U" role="1SiIV1">
-            <ref role="3bR37D" node="4lJSf3LkfPw" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
         <node concept="1BupzO" id="5mBZ2gvfx48" role="3bR31x">
@@ -8885,12 +6176,12 @@
         </node>
         <node concept="1SiIV0" id="2u7UHDCnTo2" role="3bR37C">
           <node concept="3bR9La" id="2u7UHDCnTo3" role="1SiIV1">
-            <ref role="3bR37D" node="2u7UHDCnRuK" resolve="com.mpsbasics.editor.utils" />
+            <ref role="3bR37D" to="k3fp:2u7UHDCnRuK" resolve="com.mpsbasics.editor.utils" />
           </node>
         </node>
         <node concept="1SiIV0" id="5Gu43O52l5e" role="3bR37C">
           <node concept="3bR9La" id="5Gu43O52l5f" role="1SiIV1">
-            <ref role="3bR37D" node="4lJSf3LkfPw" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
         <node concept="1SiIV0" id="5uow0HSPFnG" role="3bR37C">
@@ -9174,7 +6465,7 @@
         </node>
         <node concept="1SiIV0" id="5Gu43O52l5Y" role="3bR37C">
           <node concept="3bR9La" id="5Gu43O52l5Z" role="1SiIV1">
-            <ref role="3bR37D" node="4lJSf3LkfPw" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
         <node concept="1SiIV0" id="1IqNToc8LCz" role="3bR37C">
@@ -9259,7 +6550,7 @@
         </node>
         <node concept="1SiIV0" id="5Gu43O52l6b" role="3bR37C">
           <node concept="3bR9La" id="5Gu43O52l6c" role="1SiIV1">
-            <ref role="3bR37D" node="4lJSf3LkfPw" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
       </node>
@@ -9548,7 +6839,7 @@
           <ref role="3LEDTV" node="jPgKPEIhOV" resolve="com.mbeddr.formal.safety.argument.visualisation" />
         </node>
         <node concept="3LEDTy" id="6FJpOMBt4sa" role="3LEDUa">
-          <ref role="3LEDTV" node="6FJpOMBsZUh" resolve="com.mpsbasics.words.generic" />
+          <ref role="3LEDTV" to="k3fp:6FJpOMBsZUh" resolve="com.mpsbasics.words.generic" />
         </node>
       </node>
     </node>
@@ -9641,7 +6932,7 @@
           <ref role="3LEDTV" node="5YWtEMPIdDz" resolve="com.mbeddr.formal.safety.argument.process.artefacts" />
         </node>
         <node concept="3LEDTy" id="3h2IzuaJgKK" role="3LEDUa">
-          <ref role="3LEDTV" node="2wSfKqy9jAQ" resolve="com.mpsbasics.jira" />
+          <ref role="3LEDTV" to="k3fp:2wSfKqy9jAQ" resolve="com.mpsbasics.jira" />
         </node>
         <node concept="3LEDTy" id="3h2IzuaJhwg" role="3LEDUa">
           <ref role="3LEDTV" node="3h2IzuaJeCO" resolve="com.mbeddr.formal.safety.argument.jira_integration" />
@@ -9679,7 +6970,7 @@
           <ref role="3LEz8N" to="al5i:7tNo_gxoK9_" resolve="com.mbeddr.documentation" />
         </node>
         <node concept="3LEDTy" id="3TNxfDZ8qFl" role="3LEDUa">
-          <ref role="3LEDTV" node="2u7UHDC1TKp" resolve="com.mpsbasics.pdfexporter" />
+          <ref role="3LEDTV" to="k3fp:2u7UHDC1TKp" resolve="com.mpsbasics.pdfexporter" />
         </node>
         <node concept="3LEDTy" id="3TNxfDZ8rrp" role="3LEDUa">
           <ref role="3LEDTV" node="3TNxfDZ8p0R" resolve="com.mbeddr.formal.safety.gsn.pdfexport" />
@@ -9778,7 +7069,7 @@
           <ref role="3LEz8N" to="al5i:7tNo_gxoK9_" resolve="com.mbeddr.documentation" />
         </node>
         <node concept="3LEDTy" id="9wBdtpG2j9" role="3LEDUa">
-          <ref role="3LEDTV" node="2u7UHDC1TKp" resolve="com.mpsbasics.pdfexporter" />
+          <ref role="3LEDTV" to="k3fp:2u7UHDC1TKp" resolve="com.mpsbasics.pdfexporter" />
         </node>
       </node>
     </node>
@@ -10234,6 +7525,20 @@
       <ref role="1l3spb" to="al5i:3AVJcIMlF8l" resolve="com.mbeddr.platform" />
       <node concept="398BVA" id="6hyv0iVPmtW" role="2JcizS">
         <ref role="398BVh" node="6hyv0iVPmth" resolve="dependencies.mbeddr.platform" />
+      </node>
+    </node>
+    <node concept="2sgV4H" id="5gFsbf39l9B" role="1l3spa">
+      <ref role="1l3spb" to="k3fp:42jqVeFkUtb" resolve="com.mpsbasics" />
+      <node concept="55IIr" id="3te$DfsQ8DG" role="2JcizS">
+        <node concept="2Ry0Ak" id="3te$DfsQ8DI" role="iGT6I">
+          <property role="2Ry0Am" value=".." />
+          <node concept="2Ry0Ak" id="3te$DfsQ8DL" role="2Ry0An">
+            <property role="2Ry0Am" value="artifacts" />
+            <node concept="2Ry0Ak" id="3te$DfsQ8DO" role="2Ry0An">
+              <property role="2Ry0Am" value="com.mpsbasics" />
+            </node>
+          </node>
+        </node>
       </node>
     </node>
     <node concept="2sgV4H" id="6hyv0iVPmtp" role="1l3spa">
@@ -10695,7 +8000,7 @@
               <ref role="3_I8Xa" to="ffeo:1nJh0raVyYj" resolve="modelchecker.jar" />
             </node>
             <node concept="3_I8Xc" id="6hyv0iVPmvP" role="39821P">
-              <ref role="3_I8Xa" node="6hyv0iVPlE_" resolve="com.mpsbasics" />
+              <ref role="3_I8Xa" to="k3fp:6hyv0iVPlE_" resolve="com.mpsbasics" />
             </node>
             <node concept="3_I8Xc" id="6hyv0iVPmvR" role="39821P">
               <ref role="3_I8Xa" node="6hyv0iVPlEA" resolve="fasten.base" />

--- a/code/languages/com.mbeddr.formal.safety/solutions/com.fasten.assurance.build/models/com.fasten.assurance.build.mps
+++ b/code/languages/com.mbeddr.formal.safety/solutions/com.fasten.assurance.build/models/com.fasten.assurance.build.mps
@@ -1452,25 +1452,6 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="2fGryx5rF7T" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rF7U" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rF7G" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rF7H" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rF7I" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rF7J" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rF7K" role="2Ry0An">
-                      <property role="2Ry0Am" value="jakarta.activation.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
         <node concept="1SiIV0" id="2fGryx5rF88" role="3bR37C">
           <node concept="1BurEX" id="2fGryx5rF89" role="1SiIV1">
             <node concept="398BVA" id="2fGryx5rF7V" role="1BurEY">
@@ -1483,25 +1464,6 @@
                     <property role="2Ry0Am" value="lib" />
                     <node concept="2Ry0Ak" id="2fGryx5rF7Z" role="2Ry0An">
                       <property role="2Ry0Am" value="jakarta.mail-api.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rF8n" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rF8o" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rF8a" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rF8b" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rF8c" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rF8d" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rF8e" role="2Ry0An">
-                      <property role="2Ry0Am" value="jakarta.mail.jar" />
                     </node>
                   </node>
                 </node>
@@ -1661,25 +1623,6 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="2fGryx5rFau" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rFav" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rFah" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rFai" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rFaj" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rFak" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rFal" role="2Ry0An">
-                      <property role="2Ry0Am" value="slf4j-api.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
         <node concept="1SiIV0" id="2fGryx5rFaH" role="3bR37C">
           <node concept="1BurEX" id="2fGryx5rFaI" role="1SiIV1">
             <node concept="398BVA" id="2fGryx5rFaw" role="1BurEY">
@@ -1768,6 +1711,158 @@
                     <property role="2Ry0Am" value="lib" />
                     <node concept="2Ry0Ak" id="2fGryx5rFbw" role="2Ry0An">
                       <property role="2Ry0Am" value="xmlgraphics-commons.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6CRJe3tfEFm" role="3bR37C">
+          <node concept="1BurEX" id="6CRJe3tfEFn" role="1SiIV1">
+            <node concept="398BVA" id="6CRJe3tfEF9" role="1BurEY">
+              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="6CRJe3tfEFa" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="6CRJe3tfEFb" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
+                  <node concept="2Ry0Ak" id="6CRJe3tfEFc" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="6CRJe3tfEFd" role="2Ry0An">
+                      <property role="2Ry0Am" value="angus-activation.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6CRJe3tfEF_" role="3bR37C">
+          <node concept="1BurEX" id="6CRJe3tfEFA" role="1SiIV1">
+            <node concept="398BVA" id="6CRJe3tfEFo" role="1BurEY">
+              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="6CRJe3tfEFp" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="6CRJe3tfEFq" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
+                  <node concept="2Ry0Ak" id="6CRJe3tfEFr" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="6CRJe3tfEFs" role="2Ry0An">
+                      <property role="2Ry0Am" value="angus-mail.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6CRJe3tfEGC" role="3bR37C">
+          <node concept="1BurEX" id="6CRJe3tfEGD" role="1SiIV1">
+            <node concept="398BVA" id="6CRJe3tfEGr" role="1BurEY">
+              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="6CRJe3tfEGs" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="6CRJe3tfEGt" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
+                  <node concept="2Ry0Ak" id="6CRJe3tfEGu" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="6CRJe3tfEGv" role="2Ry0An">
+                      <property role="2Ry0Am" value="commons-collections4.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6CRJe3tfEHu" role="3bR37C">
+          <node concept="1BurEX" id="6CRJe3tfEHv" role="1SiIV1">
+            <node concept="398BVA" id="6CRJe3tfEHh" role="1BurEY">
+              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="6CRJe3tfEHi" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="6CRJe3tfEHj" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
+                  <node concept="2Ry0Ak" id="6CRJe3tfEHk" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="6CRJe3tfEHl" role="2Ry0An">
+                      <property role="2Ry0Am" value="commons-logging.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6CRJe3tfEJY" role="3bR37C">
+          <node concept="1BurEX" id="6CRJe3tfEJZ" role="1SiIV1">
+            <node concept="398BVA" id="6CRJe3tfEJL" role="1BurEY">
+              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="6CRJe3tfEJM" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="6CRJe3tfEJN" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
+                  <node concept="2Ry0Ak" id="6CRJe3tfEJO" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="6CRJe3tfEJP" role="2Ry0An">
+                      <property role="2Ry0Am" value="jaxb-core.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6CRJe3tfEKD" role="3bR37C">
+          <node concept="1BurEX" id="6CRJe3tfEKE" role="1SiIV1">
+            <node concept="398BVA" id="6CRJe3tfEKs" role="1BurEY">
+              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="6CRJe3tfEKt" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="6CRJe3tfEKu" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
+                  <node concept="2Ry0Ak" id="6CRJe3tfEKv" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="6CRJe3tfEKw" role="2Ry0An">
+                      <property role="2Ry0Am" value="jaxb-xjc.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6CRJe3tfELT" role="3bR37C">
+          <node concept="1BurEX" id="6CRJe3tfELU" role="1SiIV1">
+            <node concept="398BVA" id="6CRJe3tfELG" role="1BurEY">
+              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="6CRJe3tfELH" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="6CRJe3tfELI" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
+                  <node concept="2Ry0Ak" id="6CRJe3tfELJ" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="6CRJe3tfELK" role="2Ry0An">
+                      <property role="2Ry0Am" value="pdfbox-io.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6CRJe3tfEMl" role="3bR37C">
+          <node concept="1BurEX" id="6CRJe3tfEMm" role="1SiIV1">
+            <node concept="398BVA" id="6CRJe3tfEM8" role="1BurEY">
+              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="6CRJe3tfEM9" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="6CRJe3tfEMa" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
+                  <node concept="2Ry0Ak" id="6CRJe3tfEMb" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="6CRJe3tfEMc" role="2Ry0An">
+                      <property role="2Ry0Am" value="SparseBitSet.jar" />
                     </node>
                   </node>
                 </node>
@@ -2658,25 +2753,6 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="2fGryx5rFk4" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rFk5" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rFjR" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rFjS" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rFjT" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
-                  <node concept="2Ry0Ak" id="2fGryx5rFjU" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rFjV" role="2Ry0An">
-                      <property role="2Ry0Am" value="slf4j-api.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
         <node concept="1SiIV0" id="2fGryx5rFkj" role="3bR37C">
           <node concept="1BurEX" id="2fGryx5rFkk" role="1SiIV1">
             <node concept="398BVA" id="2fGryx5rFk6" role="1BurEY">
@@ -3324,25 +3400,6 @@
                     <property role="2Ry0Am" value="lib" />
                     <node concept="2Ry0Ak" id="36zCbqqqbBf" role="2Ry0An">
                       <property role="2Ry0Am" value="langchain4j-open-ai.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="36zCbqqqbBB" role="3bR37C">
-          <node concept="1BurEX" id="36zCbqqqbBC" role="1SiIV1">
-            <node concept="398BVA" id="36zCbqqqbBq" role="1BurEY">
-              <ref role="398BVh" node="6hyv0iVPlDT" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="36zCbqqqbBr" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="36zCbqqqbBs" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.langchain4j" />
-                  <node concept="2Ry0Ak" id="36zCbqqqbBt" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="36zCbqqqbBu" role="2Ry0An">
-                      <property role="2Ry0Am" value="slf4j-api.jar" />
                     </node>
                   </node>
                 </node>

--- a/code/languages/com.mbeddr.formal.safety/solutions/com.mbeddr.formal.safety.build/com.mbeddr.formal.safety.build.msd
+++ b/code/languages/com.mbeddr.formal.safety/solutions/com.mbeddr.formal.safety.build/com.mbeddr.formal.safety.build.msd
@@ -16,6 +16,7 @@
     <dependency reexport="false">f1fb7b1c-ce0d-423c-9369-4a661d600029(de.itemis.mps.extensions.build)</dependency>
     <dependency reexport="false">5e8cea6b-997f-49b1-a8d8-dc2a7a6fa657(org.mpsqa.base.build)</dependency>
     <dependency reexport="false">11d4368a-a7e8-4dd9-bfc6-c2de268d1994(org.mpsqa.build)</dependency>
+    <dependency reexport="false">ff2a102e-f030-4756-a6c9-02da709c686f(com.mpsbasics.build)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:798100da-4f0a-421a-b991-71f8c50ce5d2:jetbrains.mps.build" version="0" />
@@ -27,6 +28,7 @@
   <dependencyVersions>
     <module reference="b4bbc0a5-248e-4db2-9ddc-4901a463c66c(com.mbeddr.formal.safety.build)" version="0" />
     <module reference="3ae9cfda-f938-4524-b4ca-fbcba3b0525b(com.mbeddr.platform)" version="0" />
+    <module reference="ff2a102e-f030-4756-a6c9-02da709c686f(com.mpsbasics.build)" version="0" />
     <module reference="f1fb7b1c-ce0d-423c-9369-4a661d600029(de.itemis.mps.extensions.build)" version="0" />
     <module reference="422c2909-59d6-41a9-b318-40e6256b250f(jetbrains.mps.ide.build)" version="0" />
     <module reference="5e8cea6b-997f-49b1-a8d8-dc2a7a6fa657(org.mpsqa.base.build)" version="0" />

--- a/code/languages/com.mbeddr.formal.safety/solutions/com.mbeddr.formal.safety.build/models/com.mbeddr.formal.safety.build.mps
+++ b/code/languages/com.mbeddr.formal.safety/solutions/com.mbeddr.formal.safety.build/models/com.mbeddr.formal.safety.build.mps
@@ -14443,6 +14443,31 @@
           <ref role="3bR37D" to="al5i:7Pr7tifzlku" resolve="com.mbeddr.platform" />
         </node>
       </node>
+      <node concept="3rtmxn" id="7VF2e44sjKl" role="3bR31x">
+        <node concept="3LXTmp" id="7VF2e44sjKm" role="3rtmxm">
+          <node concept="3qWCbU" id="7VF2e44sjKn" role="3LXTna">
+            <property role="3qWCbO" value="icons/**, resources/**" />
+          </node>
+          <node concept="398BVA" id="7VF2e44sjKo" role="3LXTmr">
+            <ref role="398BVh" node="3GDqItDloIT" resolve="mbeddr.formal.home" />
+            <node concept="2Ry0Ak" id="7VF2e44sjKp" role="iGT6I">
+              <property role="2Ry0Am" value="code" />
+              <node concept="2Ry0Ak" id="7VF2e44sjKq" role="2Ry0An">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="7VF2e44sjKr" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics" />
+                  <node concept="2Ry0Ak" id="7VF2e44sjKs" role="2Ry0An">
+                    <property role="2Ry0Am" value="solutions" />
+                    <node concept="2Ry0Ak" id="7VF2e44sjKt" role="2Ry0An">
+                      <property role="2Ry0Am" value="com.mpsbasics.build" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
     </node>
     <node concept="1E1JtA" id="5gFsbf33HVn" role="3989C9">
       <property role="BnDLt" value="true" />
@@ -14513,6 +14538,31 @@
       <node concept="1SiIV0" id="5gFsbf3gFw7" role="3bR37C">
         <node concept="3bR9La" id="5gFsbf3gFw8" role="1SiIV1">
           <ref role="3bR37D" to="al5i:7Pr7tifzlku" resolve="com.mbeddr.platform" />
+        </node>
+      </node>
+      <node concept="3rtmxn" id="7VF2e44sjKv" role="3bR31x">
+        <node concept="3LXTmp" id="7VF2e44sjKw" role="3rtmxm">
+          <node concept="3qWCbU" id="7VF2e44sjKx" role="3LXTna">
+            <property role="3qWCbO" value="icons/**, resources/**" />
+          </node>
+          <node concept="398BVA" id="7VF2e44sjKy" role="3LXTmr">
+            <ref role="398BVh" node="3GDqItDloIT" resolve="mbeddr.formal.home" />
+            <node concept="2Ry0Ak" id="7VF2e44sjKz" role="iGT6I">
+              <property role="2Ry0Am" value="code" />
+              <node concept="2Ry0Ak" id="7VF2e44sjK$" role="2Ry0An">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="7VF2e44sjK_" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics" />
+                  <node concept="2Ry0Ak" id="7VF2e44sjKA" role="2Ry0An">
+                    <property role="2Ry0Am" value="solutions" />
+                    <node concept="2Ry0Ak" id="7VF2e44sjKB" role="2Ry0An">
+                      <property role="2Ry0Am" value="com.mpsbasics.tests.build" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
         </node>
       </node>
     </node>

--- a/code/languages/com.mbeddr.formal.safety/solutions/com.mbeddr.formal.safety.build/models/com.mbeddr.formal.safety.build.mps
+++ b/code/languages/com.mbeddr.formal.safety/solutions/com.mbeddr.formal.safety.build/models/com.mbeddr.formal.safety.build.mps
@@ -13,6 +13,7 @@
     <import index="90a9" ref="r:fb24ac52-5985-4947-bba9-25be6fd32c1a(de.itemis.mps.extensions.build)" />
     <import index="2tou" ref="r:18bebd8f-6332-4ffd-b628-cc9dad4ef421(org.mpsqa.base.build)" />
     <import index="jrpl" ref="r:f9ac9a52-9b52-485f-a0e9-7c4ea505964a(org.mpsqa.build._100_allInOne_build)" />
+    <import index="k3fp" ref="r:ef07c49a-32d8-46ff-a533-57b4dbca7bb4(com.mpsbasics.build.build)" />
     <import index="390y" ref="r:7cf4c5c6-be6b-461a-9752-5a87d0b55129(org.mpsqa.build._080_lint_build)" implicit="true" />
   </imports>
   <registry>
@@ -569,78 +570,21 @@
         <ref role="398BVh" node="6odNb$o7gGe" resolve="dependencies.mpsqa" />
       </node>
     </node>
-    <node concept="1l3spV" id="42jqVeFkUvc" role="1l3spN">
-      <node concept="m$_wl" id="7he_lUumPyH" role="39821P">
-        <ref role="m_rDy" node="7he_lUumEw2" resolve="com.mpsbasics" />
-        <node concept="398223" id="7he_lUumPNI" role="39821P">
-          <node concept="3_J27D" id="7he_lUumPNJ" role="Nbhlr">
-            <node concept="3Mxwew" id="7he_lUumPW8" role="3MwsjC">
-              <property role="3MwjfP" value="lib" />
-            </node>
-          </node>
-          <node concept="2HvfSZ" id="7he_lUumPWa" role="39821P">
-            <node concept="398BVA" id="7he_lUumQ4$" role="2HvfZ0">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="7he_lUumQd0" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="7he_lUumQd5" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="7he_lUumQda" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="2HvfSZ" id="1hVhF3lkf3q" role="39821P">
-            <node concept="398BVA" id="1hVhF3lkfdq" role="2HvfZ0">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="1hVhF3lkfmQ" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="1hVhF3lkfoZ" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.pdfbox" />
-                  <node concept="2Ry0Ak" id="1hVhF3lkfqk" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="2HvfSZ" id="2wSfKqy9mOe" role="39821P">
-            <node concept="398BVA" id="2wSfKqy9n1s" role="2HvfZ0">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2wSfKqy9ne6" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2wSfKqy9ngd" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
-                  <node concept="2Ry0Ak" id="2wSfKqy9ngE" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="2HvfSZ" id="4$EmJHcVFvX" role="39821P">
-            <node concept="398BVA" id="4$EmJHcVFKS" role="2HvfZ0">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="4$EmJHcVG1N" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="4$EmJHcVG1Q" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.langchain4j" />
-                  <node concept="2Ry0Ak" id="4$EmJHcVG1T" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                  </node>
-                </node>
-              </node>
+    <node concept="2sgV4H" id="5gFsbf3gBUi" role="1l3spa">
+      <ref role="1l3spb" to="k3fp:42jqVeFkUtb" resolve="com.mpsbasics" />
+      <node concept="55IIr" id="3te$DfsQ8E3" role="2JcizS">
+        <node concept="2Ry0Ak" id="3te$DfsQ8E4" role="iGT6I">
+          <property role="2Ry0Am" value=".." />
+          <node concept="2Ry0Ak" id="3te$DfsQ8E5" role="2Ry0An">
+            <property role="2Ry0Am" value="artifacts" />
+            <node concept="2Ry0Ak" id="3te$DfsQ8E6" role="2Ry0An">
+              <property role="2Ry0Am" value="com.mpsbasics" />
             </node>
           </node>
         </node>
-        <node concept="pUk6x" id="7Jv9b4B9k9v" role="pUk7w" />
       </node>
-      <node concept="m$_wl" id="2MrvZqtKhxe" role="39821P">
-        <ref role="m_rDy" node="2MrvZqtDsQE" resolve="com.mpsbasics.testutils" />
-        <node concept="pUk6x" id="2MrvZqtKhxn" role="pUk7w" />
-      </node>
+    </node>
+    <node concept="1l3spV" id="42jqVeFkUvc" role="1l3spN">
       <node concept="m$_wl" id="1uyUeTt3MWg" role="39821P">
         <ref role="m_rDy" node="1uyUeTt3ODd" resolve="com.mbeddr.formal.base" />
         <node concept="pUk6x" id="1uyUeTt3S5o" role="pUk7w" />
@@ -787,81 +731,6 @@
       <property role="1wOHq$" value="true" />
       <property role="3Ej$Sc" value="true" />
     </node>
-    <node concept="m$_wf" id="7he_lUumEw2" role="3989C9">
-      <property role="m$_wk" value="com.mpsbasics" />
-      <node concept="3_J27D" id="7he_lUumEw4" role="m$_yQ">
-        <node concept="3Mxwew" id="7he_lUumFzi" role="3MwsjC">
-          <property role="3MwjfP" value="com.mpsbasics" />
-        </node>
-      </node>
-      <node concept="3_J27D" id="7he_lUumEw6" role="m_cZH">
-        <node concept="3Mxwew" id="7he_lUumFzk" role="3MwsjC">
-          <property role="3MwjfP" value="com.mpsbasics" />
-        </node>
-      </node>
-      <node concept="3_J27D" id="7he_lUumEw8" role="m$_w8">
-        <node concept="3Mxwey" id="7he_lUumFFG" role="3MwsjC">
-          <ref role="3Mxwex" node="4aeOpjlAy7f" resolve="version" />
-        </node>
-      </node>
-      <node concept="m$f5U" id="7he_lUumFO4" role="m$_yh">
-        <ref role="m$f5T" node="7he_lUumA35" resolve="com.mpsbasics" />
-      </node>
-      <node concept="m$_yC" id="7yAshxDrNUC" role="m$_yJ">
-        <ref role="m$_y1" to="ffeo:4k71ibbKLe8" resolve="jetbrains.mps.core" />
-      </node>
-      <node concept="m$_yC" id="7yAshxDrNok" role="m$_yJ">
-        <ref role="m$_y1" to="90a9:4p3FRivDLPy" resolve="org.apache.commons" />
-      </node>
-      <node concept="m$_yC" id="2u7UHDCnTyY" role="m$_yJ">
-        <ref role="m$_y1" to="al5i:64SK4bcJmGP" resolve="com.mbeddr.mpsutil.plantuml" />
-      </node>
-      <node concept="m$_yC" id="3TNxfDZ8qPv" role="m$_yJ">
-        <ref role="m$_y1" to="al5i:Vtr7jyB0oM" resolve="com.mbeddr.mpsutil.filepicker" />
-      </node>
-      <node concept="m$_yC" id="hKYaKNdlcG" role="m$_yJ">
-        <ref role="m$_y1" to="90a9:3$A0JaN5ezp" resolve="MPS.ThirdParty" />
-      </node>
-      <node concept="m$_yC" id="4lJSf3Lkjhx" role="m$_yJ">
-        <ref role="m$_y1" to="90a9:6SVXTgIe8wD" resolve="de.itemis.mps.celllayout" />
-      </node>
-      <node concept="m$_yC" id="6FJpOMBt8iA" role="m$_yJ">
-        <ref role="m$_y1" to="90a9:1sO539bGQvt" resolve="de.slisson.mps.richtext" />
-      </node>
-      <node concept="m$_yC" id="5mv1DnKdM70" role="m$_yJ">
-        <ref role="m$_y1" to="ffeo:4O0hKJpmtq1" resolve="jetbrains.mps.trove" />
-      </node>
-      <node concept="m$_yC" id="5xR2VPu4zij" role="m$_yJ">
-        <ref role="m$_y1" to="ffeo:6Hpa5co69BH" resolve="jetbrains.mps.editor.tooltips" />
-      </node>
-      <node concept="m$_yC" id="4$EmJHcVT8v" role="m$_yJ">
-        <ref role="m$_y1" to="al5i:NMVW79y25x" resolve="com.mbeddr.mpsutil.json" />
-      </node>
-    </node>
-    <node concept="m$_wf" id="2MrvZqtDsQE" role="3989C9">
-      <property role="m$_wk" value="com.mpsbasics.testutils" />
-      <node concept="3_J27D" id="2MrvZqtDsQF" role="m$_yQ">
-        <node concept="3Mxwew" id="2MrvZqtDsQG" role="3MwsjC">
-          <property role="3MwjfP" value="com.mpsbasics.testutils" />
-        </node>
-      </node>
-      <node concept="3_J27D" id="2MrvZqtDsQH" role="m_cZH">
-        <node concept="3Mxwew" id="2MrvZqtDsQI" role="3MwsjC">
-          <property role="3MwjfP" value="com.mpsbasics.testutils" />
-        </node>
-      </node>
-      <node concept="3_J27D" id="2MrvZqtDsQJ" role="m$_w8">
-        <node concept="3Mxwey" id="2MrvZqtDsQK" role="3MwsjC">
-          <ref role="3Mxwex" node="4aeOpjlAy7f" resolve="version" />
-        </node>
-      </node>
-      <node concept="m$f5U" id="2MrvZqtDsQL" role="m$_yh">
-        <ref role="m$f5T" node="2MrvZqtDw3j" resolve="com.mpsbasics.testutils" />
-      </node>
-      <node concept="m$_yC" id="2MrvZqtLZFU" role="m$_yJ">
-        <ref role="m$_y1" node="7he_lUumEw2" resolve="com.mpsbasics" />
-      </node>
-    </node>
     <node concept="m$_wf" id="1k6eCQnEZzO" role="3989C9">
       <property role="m$_wk" value="fasten.symo" />
       <node concept="3_J27D" id="1k6eCQnEZzQ" role="m$_yQ">
@@ -883,7 +752,7 @@
         <ref role="m$f5T" node="1k6eCQnESS5" resolve="fasten.symo" />
       </node>
       <node concept="m$_yC" id="1k6eCQnF0Ux" role="m$_yJ">
-        <ref role="m$_y1" node="7he_lUumEw2" resolve="com.mpsbasics" />
+        <ref role="m$_y1" to="k3fp:6hyv0iVPlE4" resolve="com.mpsbasics" />
       </node>
       <node concept="m$_yC" id="1k6eCQnF16T" role="m$_yJ">
         <ref role="m$_y1" node="1uyUeTt3ODd" resolve="com.mbeddr.formal.base" />
@@ -916,7 +785,7 @@
         <ref role="m$_y1" to="ffeo:RJsmGEieyQ" resolve="jetbrains.mps.vcs" />
       </node>
       <node concept="m$_yC" id="5t37uj6Y1l2" role="m$_yJ">
-        <ref role="m$_y1" node="7he_lUumEw2" resolve="com.mpsbasics" />
+        <ref role="m$_y1" to="k3fp:6hyv0iVPlE4" resolve="com.mpsbasics" />
       </node>
       <node concept="3_J27D" id="1uyUeTt3ODf" role="m$_yQ">
         <node concept="3Mxwew" id="1uyUeTt3QtK" role="3MwsjC">
@@ -973,7 +842,7 @@
         <ref role="m$_y1" to="90a9:1Rj3F434oop" resolve="com.mbeddr.mpsutil.treenotations" />
       </node>
       <node concept="m$_yC" id="7yAshxDrStT" role="m$_yJ">
-        <ref role="m$_y1" node="7he_lUumEw2" resolve="com.mpsbasics" />
+        <ref role="m$_y1" to="k3fp:6hyv0iVPlE4" resolve="com.mpsbasics" />
       </node>
       <node concept="m$_yC" id="7yAshxDrSRE" role="m$_yJ">
         <ref role="m$_y1" node="42jqVeFkUv3" resolve="com.mbeddr.formal.nusmv" />
@@ -1281,2597 +1150,8 @@
       <node concept="m$_yC" id="1n_6a3Gkd$P" role="m$_yJ">
         <ref role="m$_y1" to="jrpl:fm3v0X36My" resolve="org.mpsqa.build" />
       </node>
-    </node>
-    <node concept="2G$12M" id="7he_lUumA35" role="3989C9">
-      <property role="TrG5h" value="com.mpsbasics" />
-      <node concept="1E1JtA" id="7he_lUumAlC" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="com.mpsbasics.docx4j.core" />
-        <property role="3LESm3" value="fdd69818-de3d-4ebf-9ec6-17ea152db151" />
-        <node concept="398BVA" id="7he_lUumAmU" role="3LF7KH">
-          <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-          <node concept="2Ry0Ak" id="7he_lUumAum" role="iGT6I">
-            <property role="2Ry0Am" value="solutions" />
-            <node concept="2Ry0Ak" id="7he_lUumAwR" role="2Ry0An">
-              <property role="2Ry0Am" value="com.mpsbasics.docx4j.core" />
-              <node concept="2Ry0Ak" id="7he_lUumAzo" role="2Ry0An">
-                <property role="2Ry0Am" value="com.mpsbasics.docx4j.core.msd" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="7he_lUumA$C" role="3bR37C">
-          <node concept="3bR9La" id="7he_lUumA$D" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1H905DlDUSw" resolve="MPS.OpenAPI" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="7he_lUumA$E" role="3bR37C">
-          <node concept="3bR9La" id="7he_lUumA$F" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="7he_lUumA$G" role="3bR37C">
-          <node concept="3bR9La" id="7he_lUumA$H" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:44LXwdzyvTi" resolve="Annotations" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="7he_lUumA$I" role="3bR37C">
-          <node concept="3bR9La" id="7he_lUumA$J" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1ia2VB5guYy" resolve="MPS.IDEA" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="7he_lUumA$K" role="3bR37C">
-          <node concept="3bR9La" id="7he_lUumA$L" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:7Kfy9QB6L4X" resolve="jetbrains.mps.lang.editor" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="7he_lUumA$M" role="3bR37C">
-          <node concept="3bR9La" id="7he_lUumA$N" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1TaHNgiIbIZ" resolve="MPS.Editor" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="7he_lUumA$O" role="3bR37C">
-          <node concept="3bR9La" id="7he_lUumA$P" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1TaHNgiIbIQ" resolve="MPS.Core" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="7he_lUumA$Q" role="3bR37C">
-          <node concept="3bR9La" id="7he_lUumA$R" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:7Kfy9QB6LaO" resolve="jetbrains.mps.lang.structure" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="7he_lUumA$S" role="3bR37C">
-          <node concept="3bR9La" id="7he_lUumA$T" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:3MI1gu0QouH" resolve="jetbrains.mps.editor.runtime" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="7he_lUumCgP" role="3bR37C">
-          <node concept="3bR9La" id="7he_lUumCgQ" role="1SiIV1">
-            <ref role="3bR37D" node="7he_lUumABC" resolve="com.mpsbasics.docx4j.lib" />
-          </node>
-        </node>
-        <node concept="1BupzO" id="5TezZ1VeiX$" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="5TezZ1VeiX_" role="1HemKq">
-            <node concept="398BVA" id="5TezZ1VeiXp" role="3LXTmr">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="5TezZ1VeiXq" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="5TezZ1VeiXr" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.core" />
-                  <node concept="2Ry0Ak" id="5TezZ1VeiXs" role="2Ry0An">
-                    <property role="2Ry0Am" value="models" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="5TezZ1VeiXA" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-        <node concept="3rtmxn" id="7Jv9b4B5bWJ" role="3bR31x">
-          <node concept="3LXTmp" id="7Jv9b4B5bWK" role="3rtmxm">
-            <node concept="3qWCbU" id="7Jv9b4B5bWL" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="7Jv9b4B5bWM" role="3LXTmr">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="7Jv9b4B5bWN" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="7Jv9b4B5bWO" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.core" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="4ziKDEng$PY" role="3bR37C">
-          <node concept="3bR9La" id="4ziKDEng$PZ" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1TaHNgiIbJb" resolve="MPS.Platform" />
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtA" id="7he_lUumABC" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="com.mpsbasics.docx4j.lib" />
-        <property role="3LESm3" value="71bb25aa-20fa-4c18-8954-1b176576f52d" />
-        <node concept="398BVA" id="7he_lUumABD" role="3LF7KH">
-          <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-          <node concept="2Ry0Ak" id="7he_lUumABE" role="iGT6I">
-            <property role="2Ry0Am" value="solutions" />
-            <node concept="2Ry0Ak" id="7he_lUumABF" role="2Ry0An">
-              <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-              <node concept="2Ry0Ak" id="7he_lUumAF9" role="2Ry0An">
-                <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib.msd" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="7he_lUumABJ" role="3bR37C">
-          <node concept="3bR9La" id="7he_lUumABK" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
-          </node>
-        </node>
-        <node concept="3rtmxn" id="7Jv9b4B5bWQ" role="3bR31x">
-          <node concept="3LXTmp" id="7Jv9b4B5bWR" role="3rtmxm">
-            <node concept="3qWCbU" id="7Jv9b4B5bWS" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="7Jv9b4B5bWT" role="3LXTmr">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="7Jv9b4B5bWU" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="7Jv9b4B5bWV" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rG6Y" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rG6Z" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rG6L" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rG6M" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rG6N" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rG6O" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rG6P" role="2Ry0An">
-                      <property role="2Ry0Am" value="antlr-runtime.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rG7d" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rG7e" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rG70" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rG71" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rG72" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rG73" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rG74" role="2Ry0An">
-                      <property role="2Ry0Am" value="antlr.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rG7s" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rG7t" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rG7f" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rG7g" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rG7h" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rG7i" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rG7j" role="2Ry0An">
-                      <property role="2Ry0Am" value="checker-qual.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rG7F" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rG7G" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rG7u" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rG7v" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rG7w" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rG7x" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rG7y" role="2Ry0An">
-                      <property role="2Ry0Am" value="commons-codec.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rG7U" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rG7V" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rG7H" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rG7I" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rG7J" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rG7K" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rG7L" role="2Ry0An">
-                      <property role="2Ry0Am" value="commons-compress.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rG89" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rG8a" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rG7W" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rG7X" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rG7Y" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rG7Z" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rG80" role="2Ry0An">
-                      <property role="2Ry0Am" value="commons-io.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rG8o" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rG8p" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rG8b" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rG8c" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rG8d" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rG8e" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rG8f" role="2Ry0An">
-                      <property role="2Ry0Am" value="commons-lang3.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rG8B" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rG8C" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rG8q" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rG8r" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rG8s" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rG8t" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rG8u" role="2Ry0An">
-                      <property role="2Ry0Am" value="docx4j-core.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rG8Q" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rG8R" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rG8D" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rG8E" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rG8F" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rG8G" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rG8H" role="2Ry0An">
-                      <property role="2Ry0Am" value="docx4j-JAXB-MOXy.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rG95" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rG96" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rG8S" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rG8T" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rG8U" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rG8V" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rG8W" role="2Ry0An">
-                      <property role="2Ry0Am" value="docx4j-openxml-objects-pml.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rG9k" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rG9l" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rG97" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rG98" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rG99" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rG9a" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rG9b" role="2Ry0An">
-                      <property role="2Ry0Am" value="docx4j-openxml-objects-sml.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rG9z" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rG9$" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rG9m" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rG9n" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rG9o" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rG9p" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rG9q" role="2Ry0An">
-                      <property role="2Ry0Am" value="docx4j-openxml-objects.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rG9M" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rG9N" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rG9_" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rG9A" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rG9B" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rG9C" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rG9D" role="2Ry0An">
-                      <property role="2Ry0Am" value="error_prone_annotations.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rGa1" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rGa2" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rG9O" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rG9P" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rG9Q" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rG9R" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rG9S" role="2Ry0An">
-                      <property role="2Ry0Am" value="fontbox.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rGag" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rGah" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rGa3" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rGa4" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rGa5" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rGa6" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rGa7" role="2Ry0An">
-                      <property role="2Ry0Am" value="jakarta.activation-api.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rGaI" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rGaJ" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rGax" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rGay" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rGaz" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rGa$" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rGa_" role="2Ry0An">
-                      <property role="2Ry0Am" value="jakarta.mail-api.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rGbc" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rGbd" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rGaZ" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rGb0" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rGb1" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rGb2" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rGb3" role="2Ry0An">
-                      <property role="2Ry0Am" value="jakarta.xml.bind-api.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rGbr" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rGbs" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rGbe" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rGbf" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rGbg" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rGbh" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rGbi" role="2Ry0An">
-                      <property role="2Ry0Am" value="jaxb-svg11.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rGbE" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rGbF" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rGbt" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rGbu" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rGbv" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rGbw" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rGbx" role="2Ry0An">
-                      <property role="2Ry0Am" value="jcl-over-slf4j.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rGbT" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rGbU" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rGbG" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rGbH" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rGbI" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rGbJ" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rGbK" role="2Ry0An">
-                      <property role="2Ry0Am" value="mbassador.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rGc8" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rGc9" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rGbV" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rGbW" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rGbX" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rGbY" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rGbZ" role="2Ry0An">
-                      <property role="2Ry0Am" value="org.eclipse.persistence.asm.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rGcn" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rGco" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rGca" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rGcb" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rGcc" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rGcd" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rGce" role="2Ry0An">
-                      <property role="2Ry0Am" value="org.eclipse.persistence.core.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rGcA" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rGcB" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rGcp" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rGcq" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rGcr" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rGcs" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rGct" role="2Ry0An">
-                      <property role="2Ry0Am" value="org.eclipse.persistence.moxy.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rGcP" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rGcQ" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rGcC" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rGcD" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rGcE" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rGcF" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rGcG" role="2Ry0An">
-                      <property role="2Ry0Am" value="qdox.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rGdj" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rGdk" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rGd6" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rGd7" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rGd8" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rGd9" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rGda" role="2Ry0An">
-                      <property role="2Ry0Am" value="stringtemplate.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rGdy" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rGdz" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rGdl" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rGdm" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rGdn" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rGdo" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rGdp" role="2Ry0An">
-                      <property role="2Ry0Am" value="wmf2svg.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rGdL" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rGdM" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rGd$" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rGd_" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rGdA" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rGdB" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rGdC" role="2Ry0An">
-                      <property role="2Ry0Am" value="xalan-interpretive.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rGe0" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rGe1" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rGdN" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rGdO" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rGdP" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rGdQ" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rGdR" role="2Ry0An">
-                      <property role="2Ry0Am" value="xalan-serializer.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rGef" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rGeg" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rGe2" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rGe3" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rGe4" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rGe5" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rGe6" role="2Ry0An">
-                      <property role="2Ry0Am" value="xmlgraphics-commons.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="6CRJe3tfG0b" role="3bR37C">
-          <node concept="1BurEX" id="6CRJe3tfG0c" role="1SiIV1">
-            <node concept="398BVA" id="6CRJe3tfFZY" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="6CRJe3tfFZZ" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="6CRJe3tfG00" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="6CRJe3tfG01" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="6CRJe3tfG02" role="2Ry0An">
-                      <property role="2Ry0Am" value="angus-activation.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="6CRJe3tfG0q" role="3bR37C">
-          <node concept="1BurEX" id="6CRJe3tfG0r" role="1SiIV1">
-            <node concept="398BVA" id="6CRJe3tfG0d" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="6CRJe3tfG0e" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="6CRJe3tfG0f" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="6CRJe3tfG0g" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="6CRJe3tfG0h" role="2Ry0An">
-                      <property role="2Ry0Am" value="angus-mail.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="6CRJe3tfG1t" role="3bR37C">
-          <node concept="1BurEX" id="6CRJe3tfG1u" role="1SiIV1">
-            <node concept="398BVA" id="6CRJe3tfG1g" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="6CRJe3tfG1h" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="6CRJe3tfG1i" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="6CRJe3tfG1j" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="6CRJe3tfG1k" role="2Ry0An">
-                      <property role="2Ry0Am" value="commons-collections4.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="6CRJe3tfG2j" role="3bR37C">
-          <node concept="1BurEX" id="6CRJe3tfG2k" role="1SiIV1">
-            <node concept="398BVA" id="6CRJe3tfG26" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="6CRJe3tfG27" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="6CRJe3tfG28" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="6CRJe3tfG29" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="6CRJe3tfG2a" role="2Ry0An">
-                      <property role="2Ry0Am" value="commons-logging.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="6CRJe3tfG4N" role="3bR37C">
-          <node concept="1BurEX" id="6CRJe3tfG4O" role="1SiIV1">
-            <node concept="398BVA" id="6CRJe3tfG4A" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="6CRJe3tfG4B" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="6CRJe3tfG4C" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="6CRJe3tfG4D" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="6CRJe3tfG4E" role="2Ry0An">
-                      <property role="2Ry0Am" value="jaxb-core.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="6CRJe3tfG5u" role="3bR37C">
-          <node concept="1BurEX" id="6CRJe3tfG5v" role="1SiIV1">
-            <node concept="398BVA" id="6CRJe3tfG5h" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="6CRJe3tfG5i" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="6CRJe3tfG5j" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="6CRJe3tfG5k" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="6CRJe3tfG5l" role="2Ry0An">
-                      <property role="2Ry0Am" value="jaxb-xjc.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="6CRJe3tfG6I" role="3bR37C">
-          <node concept="1BurEX" id="6CRJe3tfG6J" role="1SiIV1">
-            <node concept="398BVA" id="6CRJe3tfG6x" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="6CRJe3tfG6y" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="6CRJe3tfG6z" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="6CRJe3tfG6$" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="6CRJe3tfG6_" role="2Ry0An">
-                      <property role="2Ry0Am" value="pdfbox-io.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="6CRJe3tfG7a" role="3bR37C">
-          <node concept="1BurEX" id="6CRJe3tfG7b" role="1SiIV1">
-            <node concept="398BVA" id="6CRJe3tfG6X" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="6CRJe3tfG6Y" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="6CRJe3tfG6Z" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="6CRJe3tfG70" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="6CRJe3tfG71" role="2Ry0An">
-                      <property role="2Ry0Am" value="SparseBitSet.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtA" id="7he_lUumBj6" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="com.mpsbasics.snode.utils" />
-        <property role="3LESm3" value="8da51702-0e05-44c8-96db-8f11d1457c0c" />
-        <node concept="398BVA" id="7he_lUumBj7" role="3LF7KH">
-          <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-          <node concept="2Ry0Ak" id="7he_lUumBj8" role="iGT6I">
-            <property role="2Ry0Am" value="solutions" />
-            <node concept="2Ry0Ak" id="7he_lUumBj9" role="2Ry0An">
-              <property role="2Ry0Am" value="com.mpsbasics.snode.utils" />
-              <node concept="2Ry0Ak" id="7he_lUumBRd" role="2Ry0An">
-                <property role="2Ry0Am" value="com.mpsbasics.snode.utils.msd" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="7he_lUumBjb" role="3bR37C">
-          <node concept="3bR9La" id="7he_lUumBjc" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="7he_lUumC6J" role="3bR37C">
-          <node concept="3bR9La" id="7he_lUumC6K" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1H905DlDUSw" resolve="MPS.OpenAPI" />
-          </node>
-        </node>
-        <node concept="1BupzO" id="5TezZ1Vej58" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="5TezZ1Vej59" role="1HemKq">
-            <node concept="398BVA" id="5TezZ1Vej4X" role="3LXTmr">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="5TezZ1Vej4Y" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="5TezZ1Vej4Z" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.snode.utils" />
-                  <node concept="2Ry0Ak" id="5TezZ1Vej50" role="2Ry0An">
-                    <property role="2Ry0Am" value="models" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="5TezZ1Vej5a" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-        <node concept="3rtmxn" id="7Jv9b4B5bWX" role="3bR31x">
-          <node concept="3LXTmp" id="7Jv9b4B5bWY" role="3rtmxm">
-            <node concept="3qWCbU" id="7Jv9b4B5bWZ" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="7Jv9b4B5bX0" role="3LXTmr">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="7Jv9b4B5bX1" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="7Jv9b4B5bX2" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.snode.utils" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtA" id="2u7UHDCnPLY" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="com.mpsbasics.project.utils" />
-        <property role="3LESm3" value="1f4710e9-f074-4732-a0bd-6fa896d282b7" />
-        <node concept="398BVA" id="2u7UHDCnPZq" role="3LF7KH">
-          <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-          <node concept="2Ry0Ak" id="2u7UHDCnQeS" role="iGT6I">
-            <property role="2Ry0Am" value="solutions" />
-            <node concept="2Ry0Ak" id="2u7UHDCnQul" role="2Ry0An">
-              <property role="2Ry0Am" value="com.mpsbasics.project.utils" />
-              <node concept="2Ry0Ak" id="2u7UHDCnQHM" role="2Ry0An">
-                <property role="2Ry0Am" value="com.mpsbasics.project.utils.msd" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2u7UHDCnQWT" role="3bR37C">
-          <node concept="3bR9La" id="2u7UHDCnQWU" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2u7UHDCnQWV" role="3bR37C">
-          <node concept="3bR9La" id="2u7UHDCnQWW" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1ia2VB5guYy" resolve="MPS.IDEA" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2u7UHDCnQWX" role="3bR37C">
-          <node concept="3bR9La" id="2u7UHDCnQWY" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1TaHNgiIbJb" resolve="MPS.Platform" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2u7UHDCnQWZ" role="3bR37C">
-          <node concept="3bR9La" id="2u7UHDCnQX0" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1TaHNgiIbIQ" resolve="MPS.Core" />
-          </node>
-        </node>
-        <node concept="1BupzO" id="2u7UHDCnQXc" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="2u7UHDCnQXd" role="1HemKq">
-            <node concept="398BVA" id="2u7UHDCnQX1" role="3LXTmr">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2u7UHDCnQX2" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2u7UHDCnQX3" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.project.utils" />
-                  <node concept="2Ry0Ak" id="2u7UHDCnQX4" role="2Ry0An">
-                    <property role="2Ry0Am" value="models" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="2u7UHDCnQXe" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-        <node concept="3rtmxn" id="4euqtkrusKF" role="3bR31x">
-          <node concept="3LXTmp" id="4euqtkrusKG" role="3rtmxm">
-            <node concept="3qWCbU" id="4euqtkrusKH" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="4euqtkrusKI" role="3LXTmr">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="4euqtkrusKJ" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="4euqtkrusKK" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.project.utils" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtA" id="2u7UHDCnRuK" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="com.mpsbasics.editor.utils" />
-        <property role="3LESm3" value="6b84fb9e-5f09-4a61-bf31-3bfdc54820e3" />
-        <node concept="398BVA" id="2u7UHDCnRGu" role="3LF7KH">
-          <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-          <node concept="2Ry0Ak" id="2u7UHDCnRVW" role="iGT6I">
-            <property role="2Ry0Am" value="solutions" />
-            <node concept="2Ry0Ak" id="2u7UHDCnSj5" role="2Ry0An">
-              <property role="2Ry0Am" value="com.mpsbasics.editor.utils" />
-              <node concept="2Ry0Ak" id="2u7UHDCnSyy" role="2Ry0An">
-                <property role="2Ry0Am" value="com.mpsbasics.editor.utils.msd" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2u7UHDCnSLO" role="3bR37C">
-          <node concept="3bR9La" id="2u7UHDCnSLP" role="1SiIV1">
-            <ref role="3bR37D" node="2u7UHDCnPLY" resolve="com.mpsbasics.project.utils" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2u7UHDCnSLQ" role="3bR37C">
-          <node concept="3bR9La" id="2u7UHDCnSLR" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1ia2VB5guYy" resolve="MPS.IDEA" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2u7UHDCnSLU" role="3bR37C">
-          <node concept="3bR9La" id="2u7UHDCnSLV" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:3MI1gu0QouH" resolve="jetbrains.mps.editor.runtime" />
-          </node>
-        </node>
-        <node concept="1BupzO" id="2u7UHDCnSM7" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="2u7UHDCnSM8" role="1HemKq">
-            <node concept="398BVA" id="2u7UHDCnSLW" role="3LXTmr">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2u7UHDCnSLX" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2u7UHDCnSLY" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.editor.utils" />
-                  <node concept="2Ry0Ak" id="2u7UHDCnSLZ" role="2Ry0An">
-                    <property role="2Ry0Am" value="models" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="2u7UHDCnSM9" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-        <node concept="3rtmxn" id="4euqtkrusKM" role="3bR31x">
-          <node concept="3LXTmp" id="4euqtkrusKN" role="3rtmxm">
-            <node concept="3qWCbU" id="4euqtkrusKO" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="4euqtkrusKP" role="3LXTmr">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="4euqtkrusKQ" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="4euqtkrusKR" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.editor.utils" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="YXkTXVNhjn" role="3bR37C">
-          <node concept="3bR9La" id="YXkTXVNhjo" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="YXkTXVNhjp" role="3bR37C">
-          <node concept="3bR9La" id="YXkTXVNhjq" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1TaHNgiIbIZ" resolve="MPS.Editor" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2i2e8U1mG6w" role="3bR37C">
-          <node concept="3bR9La" id="2i2e8U1mG6x" role="1SiIV1">
-            <ref role="3bR37D" to="90a9:6bkzxtWPDx1" resolve="de.itemis.stubs.batik" />
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtA" id="2u7UHDC1RNf" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="com.mpsbasics.pdfbox" />
-        <property role="3LESm3" value="bc7d0863-298c-41cf-984f-a0421e757da5" />
-        <node concept="398BVA" id="2u7UHDC1S2a" role="3LF7KH">
-          <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-          <node concept="2Ry0Ak" id="2u7UHDC1Sye" role="iGT6I">
-            <property role="2Ry0Am" value="solutions" />
-            <node concept="2Ry0Ak" id="2u7UHDC1SOx" role="2Ry0An">
-              <property role="2Ry0Am" value="com.mpsbasics.pdfbox" />
-              <node concept="2Ry0Ak" id="2u7UHDC1T5A" role="2Ry0An">
-                <property role="2Ry0Am" value="com.mpsbasics.pdfbox.msd" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2u7UHDC1Tlm" role="3bR37C">
-          <node concept="3bR9La" id="2u7UHDC1Tln" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2u7UHDC1VSB" role="3bR37C">
-          <node concept="3bR9La" id="2u7UHDC1VSC" role="1SiIV1">
-            <ref role="3bR37D" node="2u7UHDC1TKp" resolve="com.mpsbasics.pdfexporter" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2u7UHDCnTe3" role="3bR37C">
-          <node concept="3bR9La" id="2u7UHDCnTe4" role="1SiIV1">
-            <ref role="3bR37D" node="2u7UHDCnRuK" resolve="com.mpsbasics.editor.utils" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="3TNxfDZ5bWu" role="3bR37C">
-          <node concept="3bR9La" id="3TNxfDZ5bWv" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1ia2VB5guYy" resolve="MPS.IDEA" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="3TNxfDZ5bWy" role="3bR37C">
-          <node concept="3bR9La" id="3TNxfDZ5bWz" role="1SiIV1">
-            <ref role="3bR37D" to="al5i:Vtr7jyAKU4" resolve="com.mbeddr.mpsutil.filepicker" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rGeZ" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rGf0" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rGeM" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rGeN" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rGeO" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.pdfbox" />
-                  <node concept="2Ry0Ak" id="2fGryx5rGeP" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rGeQ" role="2Ry0An">
-                      <property role="2Ry0Am" value="graphics2d.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3rtmxn" id="4euqtkrusKT" role="3bR31x">
-          <node concept="3LXTmp" id="4euqtkrusKU" role="3rtmxm">
-            <node concept="3qWCbU" id="4euqtkrusKV" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="4euqtkrusKW" role="3LXTmr">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="4euqtkrusKX" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="4euqtkrusKY" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.pdfbox" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rGfe" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rGff" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rGf1" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rGf2" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rGf3" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.pdfbox" />
-                  <node concept="2Ry0Ak" id="2fGryx5rGf4" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rGf5" role="2Ry0An">
-                      <property role="2Ry0Am" value="openhtmltopdf-core.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rGft" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rGfu" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rGfg" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rGfh" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rGfi" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.pdfbox" />
-                  <node concept="2Ry0Ak" id="2fGryx5rGfj" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rGfk" role="2Ry0An">
-                      <property role="2Ry0Am" value="openhtmltopdf-pdfbox.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rGfG" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rGfH" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rGfv" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rGfw" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rGfx" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.pdfbox" />
-                  <node concept="2Ry0Ak" id="2fGryx5rGfy" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rGfz" role="2Ry0An">
-                      <property role="2Ry0Am" value="pdfbox-app.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1BupzO" id="2_t3nDPzVqu" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="2_t3nDPzVqv" role="1HemKq">
-            <node concept="398BVA" id="2_t3nDPzVqj" role="3LXTmr">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2_t3nDPzVqk" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2_t3nDPzVql" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.pdfbox" />
-                  <node concept="2Ry0Ak" id="2_t3nDPzVqm" role="2Ry0An">
-                    <property role="2Ry0Am" value="models" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="2_t3nDPzVqw" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rGfV" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rGfW" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rGfI" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rGfJ" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rGfK" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.pdfbox" />
-                  <node concept="2Ry0Ak" id="2fGryx5rGfL" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rGfM" role="2Ry0An">
-                      <property role="2Ry0Am" value="xmpbox.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtD" id="2u7UHDC1TKp" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="com.mpsbasics.pdfexporter" />
-        <property role="3LESm3" value="ece26728-2885-4b26-9f61-67d2821fc361" />
-        <node concept="398BVA" id="2u7UHDC1Ug2" role="3LF7KH">
-          <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-          <node concept="2Ry0Ak" id="2u7UHDC1UCq" role="iGT6I">
-            <property role="2Ry0Am" value="languages" />
-            <node concept="2Ry0Ak" id="2u7UHDC1UTv" role="2Ry0An">
-              <property role="2Ry0Am" value="com.mpsbasics.pdfexporter" />
-              <node concept="2Ry0Ak" id="2u7UHDC1Vaa" role="2Ry0An">
-                <property role="2Ry0Am" value="com.mpsbasics.pdfexporter.mpl" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2u7UHDC1Vqt" role="3bR37C">
-          <node concept="3bR9La" id="2u7UHDC1Vqu" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1TaHNgiIbIZ" resolve="MPS.Editor" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2u7UHDC1Vqv" role="3bR37C">
-          <node concept="3bR9La" id="2u7UHDC1Vqw" role="1SiIV1">
-            <ref role="3bR37D" node="2u7UHDC1RNf" resolve="com.mpsbasics.pdfbox" />
-          </node>
-        </node>
-        <node concept="1BupzO" id="2u7UHDC1VqG" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="2u7UHDC1VqH" role="1HemKq">
-            <node concept="398BVA" id="2u7UHDC1Vqx" role="3LXTmr">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2u7UHDC1Vqy" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="2u7UHDC1Vqz" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.pdfexporter" />
-                  <node concept="2Ry0Ak" id="2u7UHDC1Vq$" role="2Ry0An">
-                    <property role="2Ry0Am" value="models" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="2u7UHDC1VqI" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="3TNxfDZ5bWW" role="3bR37C">
-          <node concept="3bR9La" id="3TNxfDZ5bWX" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:3HV74$ebibC" resolve="jetbrains.mps.lang.text" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="3TNxfDZ5bWY" role="3bR37C">
-          <node concept="3bR9La" id="3TNxfDZ5bWZ" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="3TNxfDZ5bX0" role="3bR37C">
-          <node concept="3bR9La" id="3TNxfDZ5bX1" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:7Kfy9QB6LfQ" resolve="jetbrains.mps.kernel" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="3TNxfDZ5bX2" role="3bR37C">
-          <node concept="3bR9La" id="3TNxfDZ5bX3" role="1SiIV1">
-            <ref role="3bR37D" to="al5i:Vtr7jyAKU4" resolve="com.mbeddr.mpsutil.filepicker" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="3TNxfDZ5bX4" role="3bR37C">
-          <node concept="3bR9La" id="3TNxfDZ5bX5" role="1SiIV1">
-            <ref role="3bR37D" node="2u7UHDCnRuK" resolve="com.mpsbasics.editor.utils" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2ZPTSaoSrQ9" role="3bR37C">
-          <node concept="3bR9La" id="2ZPTSaoSrQa" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1H905DlDUSw" resolve="MPS.OpenAPI" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2ZPTSaoSrQb" role="3bR37C">
-          <node concept="3bR9La" id="2ZPTSaoSrQc" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:3MI1gu0QouH" resolve="jetbrains.mps.editor.runtime" />
-          </node>
-        </node>
-        <node concept="3rtmxn" id="4euqtkrusLZ" role="3bR31x">
-          <node concept="3LXTmp" id="4euqtkrusM0" role="3rtmxm">
-            <node concept="3qWCbU" id="4euqtkrusM1" role="3LXTna">
-              <property role="3qWCbO" value="com/mpsbasics/pdfexporter/structure/*.png" />
-            </node>
-            <node concept="398BVA" id="4euqtkrusM2" role="3LXTmr">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="4euqtkrusM3" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="4euqtkrusM4" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.pdfexporter" />
-                  <node concept="2Ry0Ak" id="2oWhy0w_F$j" role="2Ry0An">
-                    <property role="2Ry0Am" value="source_gen" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtA" id="2wSfKqy9hC9" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="com.mpsbasics.jira.pluginSolution" />
-        <property role="3LESm3" value="47b4ca2d-4ed7-41a6-b64f-df36b50a3c95" />
-        <node concept="398BVA" id="2wSfKqy9hTU" role="3LF7KH">
-          <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-          <node concept="2Ry0Ak" id="2wSfKqy9ibO" role="iGT6I">
-            <property role="2Ry0Am" value="solutions" />
-            <node concept="2Ry0Ak" id="2wSfKqy9iuV" role="2Ry0An">
-              <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
-              <node concept="2Ry0Ak" id="2wSfKqy9iK0" role="2Ry0An">
-                <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution.msd" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2wSfKqy9j1e" role="3bR37C">
-          <node concept="3bR9La" id="2wSfKqy9j1f" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
-          </node>
-        </node>
-        <node concept="3rtmxn" id="2bBfLTGrYR5" role="3bR31x">
-          <node concept="3LXTmp" id="2bBfLTGrYR6" role="3rtmxm">
-            <node concept="3qWCbU" id="2bBfLTGrYR7" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="2bBfLTGrYR8" role="3LXTmr">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2bBfLTGrYR9" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2bBfLTGrYRa" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rGgl" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rGgm" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rGg8" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rGg9" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rGga" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
-                  <node concept="2Ry0Ak" id="2fGryx5rGgb" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rGgc" role="2Ry0An">
-                      <property role="2Ry0Am" value="atlassian-event.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rGg$" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rGg_" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rGgn" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rGgo" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rGgp" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
-                  <node concept="2Ry0Ak" id="2fGryx5rGgq" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rGgr" role="2Ry0An">
-                      <property role="2Ry0Am" value="atlassian-httpclient-api.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rGgN" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rGgO" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rGgA" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rGgB" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rGgC" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
-                  <node concept="2Ry0Ak" id="2fGryx5rGgD" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rGgE" role="2Ry0An">
-                      <property role="2Ry0Am" value="atlassian-util-concurrent.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rGhh" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rGhi" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rGh4" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rGh5" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rGh6" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
-                  <node concept="2Ry0Ak" id="2fGryx5rGh7" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rGh8" role="2Ry0An">
-                      <property role="2Ry0Am" value="commons-logging.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rGhw" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rGhx" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rGhj" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rGhk" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rGhl" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
-                  <node concept="2Ry0Ak" id="2fGryx5rGhm" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rGhn" role="2Ry0An">
-                      <property role="2Ry0Am" value="guava.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rGhJ" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rGhK" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rGhy" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rGhz" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rGh$" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
-                  <node concept="2Ry0Ak" id="2fGryx5rGh_" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rGhA" role="2Ry0An">
-                      <property role="2Ry0Am" value="httpasyncclient-cache.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rGhY" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rGhZ" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rGhL" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rGhM" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rGhN" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
-                  <node concept="2Ry0Ak" id="2fGryx5rGhO" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rGhP" role="2Ry0An">
-                      <property role="2Ry0Am" value="httpasyncclient.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rGid" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rGie" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rGi0" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rGi1" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rGi2" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
-                  <node concept="2Ry0Ak" id="2fGryx5rGi3" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rGi4" role="2Ry0An">
-                      <property role="2Ry0Am" value="httpclient-cache.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rGis" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rGit" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rGif" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rGig" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rGih" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
-                  <node concept="2Ry0Ak" id="2fGryx5rGii" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rGij" role="2Ry0An">
-                      <property role="2Ry0Am" value="httpclient.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rGiF" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rGiG" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rGiu" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rGiv" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rGiw" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
-                  <node concept="2Ry0Ak" id="2fGryx5rGix" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rGiy" role="2Ry0An">
-                      <property role="2Ry0Am" value="httpcore-nio.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rGiU" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rGiV" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rGiH" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rGiI" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rGiJ" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
-                  <node concept="2Ry0Ak" id="2fGryx5rGiK" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rGiL" role="2Ry0An">
-                      <property role="2Ry0Am" value="httpcore.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rGj9" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rGja" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rGiW" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rGiX" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rGiY" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
-                  <node concept="2Ry0Ak" id="2fGryx5rGiZ" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rGj0" role="2Ry0An">
-                      <property role="2Ry0Am" value="httpmime.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rGkM" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rGkN" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rGk_" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rGkA" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rGkB" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
-                  <node concept="2Ry0Ak" id="2fGryx5rGkC" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rGkD" role="2Ry0An">
-                      <property role="2Ry0Am" value="jersey-client.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rGlv" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rGlw" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rGli" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rGlj" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rGlk" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
-                  <node concept="2Ry0Ak" id="2fGryx5rGll" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rGlm" role="2Ry0An">
-                      <property role="2Ry0Am" value="jettison.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rGlI" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rGlJ" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rGlx" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rGly" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rGlz" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
-                  <node concept="2Ry0Ak" id="2fGryx5rGl$" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rGl_" role="2Ry0An">
-                      <property role="2Ry0Am" value="jira-rest-java-client-api.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rGlX" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rGlY" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rGlK" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rGlL" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rGlM" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
-                  <node concept="2Ry0Ak" id="2fGryx5rGlN" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rGlO" role="2Ry0An">
-                      <property role="2Ry0Am" value="jira-rest-java-client-core.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rGmc" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rGmd" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rGlZ" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rGm0" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rGm1" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
-                  <node concept="2Ry0Ak" id="2fGryx5rGm2" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rGm3" role="2Ry0An">
-                      <property role="2Ry0Am" value="joda-time.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rGmr" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rGms" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rGme" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rGmf" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rGmg" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
-                  <node concept="2Ry0Ak" id="2fGryx5rGmh" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rGmi" role="2Ry0An">
-                      <property role="2Ry0Am" value="jsr305.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rGmT" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rGmU" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rGmG" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rGmH" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rGmI" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
-                  <node concept="2Ry0Ak" id="2fGryx5rGmJ" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rGmK" role="2Ry0An">
-                      <property role="2Ry0Am" value="spring-beans.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rGn8" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rGn9" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rGmV" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rGmW" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rGmX" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
-                  <node concept="2Ry0Ak" id="2fGryx5rGmY" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rGmZ" role="2Ry0An">
-                      <property role="2Ry0Am" value="spring-core.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1BupzO" id="2_t3nDPzVxa" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="2_t3nDPzVxb" role="1HemKq">
-            <node concept="398BVA" id="2_t3nDPzVwZ" role="3LXTmr">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2_t3nDPzVx0" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2_t3nDPzVx1" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
-                  <node concept="2Ry0Ak" id="2_t3nDPzVx2" role="2Ry0An">
-                    <property role="2Ry0Am" value="models" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="2_t3nDPzVxc" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtD" id="2wSfKqy9jAQ" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="com.mpsbasics.jira" />
-        <property role="3LESm3" value="fde86f49-830f-414f-9c22-2a9e300eaba6" />
-        <node concept="398BVA" id="2wSfKqy9jXx" role="3LF7KH">
-          <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-          <node concept="2Ry0Ak" id="2wSfKqy9kkH" role="iGT6I">
-            <property role="2Ry0Am" value="languages" />
-            <node concept="2Ry0Ak" id="2wSfKqy9kGG" role="2Ry0An">
-              <property role="2Ry0Am" value="com.mpsbasics.jira" />
-              <node concept="2Ry0Ak" id="2wSfKqy9l4F" role="2Ry0An">
-                <property role="2Ry0Am" value="com.mpsbasics.jira.mpl" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2wSfKqy9lsa" role="3bR37C">
-          <node concept="3bR9La" id="2wSfKqy9lsb" role="1SiIV1">
-            <ref role="3bR37D" node="2wSfKqy9hC9" resolve="com.mpsbasics.jira.pluginSolution" />
-          </node>
-        </node>
-        <node concept="1BupzO" id="2wSfKqy9lsn" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="2wSfKqy9lso" role="1HemKq">
-            <node concept="398BVA" id="2wSfKqy9lsc" role="3LXTmr">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2wSfKqy9lsd" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="2wSfKqy9lse" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.jira" />
-                  <node concept="2Ry0Ak" id="2wSfKqy9lsf" role="2Ry0An">
-                    <property role="2Ry0Am" value="models" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="2wSfKqy9lsp" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-        <node concept="3rtmxn" id="2wSfKqy9mq3" role="3bR31x">
-          <node concept="3LXTmp" id="2wSfKqy9mq4" role="3rtmxm">
-            <node concept="398BVA" id="2wSfKqy9mq5" role="3LXTmr">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2wSfKqy9mq6" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="2wSfKqy9mq7" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.jira" />
-                  <node concept="2Ry0Ak" id="2oWhy0wGITY" role="2Ry0An">
-                    <property role="2Ry0Am" value="source_gen" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="2wSfKqy9mq9" role="3LXTna">
-              <property role="3qWCbO" value="com/mpsbasics/jira/structure/*.png" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtD" id="2dsc7GndbM" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="com.mpsbasics.core" />
-        <property role="3LESm3" value="792be022-0a7a-4b28-bfd8-b1b2d347b772" />
-        <node concept="398BVA" id="2dsc7GndbN" role="3LF7KH">
-          <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-          <node concept="2Ry0Ak" id="2dsc7GndbO" role="iGT6I">
-            <property role="2Ry0Am" value="languages" />
-            <node concept="2Ry0Ak" id="2dsc7GndbP" role="2Ry0An">
-              <property role="2Ry0Am" value="com.mpsbasics.core" />
-              <node concept="2Ry0Ak" id="2dsc7GndbQ" role="2Ry0An">
-                <property role="2Ry0Am" value="com.mpsbasics.core.mpl" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2dsc7GndbR" role="3bR37C">
-          <node concept="3bR9La" id="2dsc7GndbS" role="1SiIV1">
-            <ref role="3bR37D" to="90a9:6SVXTgIejl1" resolve="de.itemis.mps.editor.celllayout.runtime" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2dsc7GndbT" role="3bR37C">
-          <node concept="3bR9La" id="2dsc7GndbU" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1TaHNgiIbJt" resolve="jetbrains.mps.ide.platform" />
-          </node>
-        </node>
-        <node concept="1BupzO" id="2dsc7GndbV" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="2dsc7GndbW" role="1HemKq">
-            <node concept="398BVA" id="2dsc7GndbX" role="3LXTmr">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2dsc7GndbY" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="2dsc7GndbZ" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.core" />
-                  <node concept="2Ry0Ak" id="2dsc7Gndc0" role="2Ry0An">
-                    <property role="2Ry0Am" value="models" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="2dsc7Gndc1" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-        <node concept="3rtmxn" id="2dsc7Gndc2" role="3bR31x">
-          <node concept="3LXTmp" id="2dsc7Gndc3" role="3rtmxm">
-            <node concept="398BVA" id="2dsc7Gndc4" role="3LXTmr">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2dsc7Gndc5" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="2dsc7Gndc6" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.core" />
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="2dsc7Gndc7" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="vYco6EFZa3" role="3bR37C">
-          <node concept="3bR9La" id="vYco6EFZa4" role="1SiIV1">
-            <ref role="3bR37D" node="2u7UHDCnRuK" resolve="com.mpsbasics.editor.utils" />
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtD" id="6FJpOMBsZUh" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="com.mpsbasics.words.generic" />
-        <property role="3LESm3" value="e4b230e7-8e1a-4a05-8148-8713530572c1" />
-        <node concept="398BVA" id="6FJpOMBt05F" role="3LF7KH">
-          <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-          <node concept="2Ry0Ak" id="6FJpOMBt1vp" role="iGT6I">
-            <property role="2Ry0Am" value="languages" />
-            <node concept="2Ry0Ak" id="6FJpOMBt2cO" role="2Ry0An">
-              <property role="2Ry0Am" value="com.mpsbasics.words.generic" />
-              <node concept="2Ry0Ak" id="6FJpOMBt2zz" role="2Ry0An">
-                <property role="2Ry0Am" value="com.mpsbasics.words.generic.mpl" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="6FJpOMBt2V$" role="3bR37C">
-          <node concept="3bR9La" id="6FJpOMBt2V_" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:7Kfy9QB6LfQ" resolve="jetbrains.mps.kernel" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="6FJpOMBt2VA" role="3bR37C">
-          <node concept="3bR9La" id="6FJpOMBt2VB" role="1SiIV1">
-            <ref role="3bR37D" node="2dsc7GndbM" resolve="com.mpsbasics.core" />
-          </node>
-        </node>
-        <node concept="1BupzO" id="6FJpOMBt2VN" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="6FJpOMBt2VO" role="1HemKq">
-            <node concept="398BVA" id="6FJpOMBt2VC" role="3LXTmr">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="6FJpOMBt2VD" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="6FJpOMBt2VE" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.words.generic" />
-                  <node concept="2Ry0Ak" id="6FJpOMBt2VF" role="2Ry0An">
-                    <property role="2Ry0Am" value="models" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="6FJpOMBt2VP" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="6FJpOMBt2VQ" role="3bR37C">
-          <node concept="1Busua" id="6FJpOMBt2VR" role="1SiIV1">
-            <ref role="1Busuk" to="90a9:1sO539bGQvB" resolve="de.slisson.mps.richtext" />
-          </node>
-        </node>
-        <node concept="3rtmxn" id="6FJpOMBt3Sx" role="3bR31x">
-          <node concept="3LXTmp" id="6FJpOMBt3Sy" role="3rtmxm">
-            <node concept="398BVA" id="6FJpOMBt3Sz" role="3LXTmr">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="6FJpOMBt3S$" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="6FJpOMBt3S_" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.words.generic" />
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="6FJpOMBt3SB" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtD" id="4m8f5php_QJ" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="com.mpsbasics.plaintext.yaml" />
-        <property role="3LESm3" value="4556fd77-6edd-4716-8b05-e35fd684d04d" />
-        <node concept="398BVA" id="4m8f5php_QK" role="3LF7KH">
-          <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-          <node concept="2Ry0Ak" id="4m8f5php_QL" role="iGT6I">
-            <property role="2Ry0Am" value="languages" />
-            <node concept="2Ry0Ak" id="4m8f5php_QM" role="2Ry0An">
-              <property role="2Ry0Am" value="com.mpsbasics.plaintext.yaml" />
-              <node concept="2Ry0Ak" id="4m8f5phpAua" role="2Ry0An">
-                <property role="2Ry0Am" value="com.mpsbasics.plaintext.yaml.mpl" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1BupzO" id="4m8f5php_QS" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="4m8f5phpAR3" role="1HemKq">
-            <node concept="398BVA" id="4m8f5phpAQS" role="3LXTmr">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="4m8f5phpAQT" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="4m8f5phpAQU" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.plaintext.yaml" />
-                  <node concept="2Ry0Ak" id="4m8f5phpAQV" role="2Ry0An">
-                    <property role="2Ry0Am" value="models" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="4m8f5phpAR4" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-        <node concept="3rtmxn" id="4m8f5php_R1" role="3bR31x">
-          <node concept="3LXTmp" id="4m8f5php_R2" role="3rtmxm">
-            <node concept="398BVA" id="4m8f5php_R3" role="3LXTmr">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="4m8f5php_R4" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="4m8f5phpBR3" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.plaintext.yaml" />
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="4m8f5php_R6" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="4m8f5phpAQK" role="3bR37C">
-          <node concept="3bR9La" id="4m8f5phpAQL" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="4m8f5phpAQM" role="3bR37C">
-          <node concept="3bR9La" id="4m8f5phpAQN" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1TaHNgiIbIZ" resolve="MPS.Editor" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="4m8f5phpAQO" role="3bR37C">
-          <node concept="3bR9La" id="4m8f5phpAQP" role="1SiIV1">
-            <ref role="3bR37D" to="90a9:3$A0JaN5bpX" resolve="MPS.ThirdParty" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="4m8f5phpAQQ" role="3bR37C">
-          <node concept="3bR9La" id="4m8f5phpAQR" role="1SiIV1">
-            <ref role="3bR37D" to="90a9:PE3B26QCrP" resolve="org.apache.commons" />
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtD" id="5C1tqSGWhFP" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="com.mpsbasics.plaintext.yaml.dsl.base" />
-        <property role="3LESm3" value="91ea57f8-7d6f-44b2-9328-d39a2e01a88b" />
-        <node concept="398BVA" id="5C1tqSGWhWm" role="3LF7KH">
-          <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-          <node concept="2Ry0Ak" id="5C1tqSGWiHL" role="iGT6I">
-            <property role="2Ry0Am" value="languages" />
-            <node concept="2Ry0Ak" id="5C1tqSGWjvb" role="2Ry0An">
-              <property role="2Ry0Am" value="com.mpsbasics.plaintext.yaml.dsl.base" />
-              <node concept="2Ry0Ak" id="5C1tqSGWk08" role="2Ry0An">
-                <property role="2Ry0Am" value="com.mpsbasics.plaintext.yaml.dsl.base.mpl" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="5C1tqSGWkwj" role="3bR37C">
-          <node concept="3bR9La" id="5C1tqSGWkwk" role="1SiIV1">
-            <ref role="3bR37D" node="4m8f5php_QJ" resolve="com.mpsbasics.plaintext.yaml" />
-          </node>
-        </node>
-        <node concept="1BupzO" id="5C1tqSGWkww" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="5C1tqSGWkwx" role="1HemKq">
-            <node concept="398BVA" id="5C1tqSGWkwl" role="3LXTmr">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="5C1tqSGWkwm" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="5C1tqSGWkwn" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.plaintext.yaml.dsl.base" />
-                  <node concept="2Ry0Ak" id="5C1tqSGWkwo" role="2Ry0An">
-                    <property role="2Ry0Am" value="models" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="5C1tqSGWkwy" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="5C1tqSGWkwz" role="3bR37C">
-          <node concept="1Busua" id="5C1tqSGWkw$" role="1SiIV1">
-            <ref role="1Busuk" node="4m8f5php_QJ" resolve="com.mpsbasics.plaintext.yaml" />
-          </node>
-        </node>
-        <node concept="3rtmxn" id="5C1tqSGWlcS" role="3bR31x">
-          <node concept="3LXTmp" id="5C1tqSGWlcT" role="3rtmxm">
-            <node concept="398BVA" id="5C1tqSGWlcU" role="3LXTmr">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="5C1tqSGWlcV" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="5C1tqSGWlcW" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.plaintext.yaml.dsl.base" />
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="5C1tqSGWlcY" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtD" id="4$EmJHcVzRj" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="com.mpsbasics.genai" />
-        <property role="3LESm3" value="e49ae71b-b7a6-4321-84b6-ac9a82e13853" />
-        <node concept="398BVA" id="4$EmJHcV$5M" role="3LF7KH">
-          <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-          <node concept="2Ry0Ak" id="4$EmJHcV$L7" role="iGT6I">
-            <property role="2Ry0Am" value="languages" />
-            <node concept="2Ry0Ak" id="4$EmJHcV_sr" role="2Ry0An">
-              <property role="2Ry0Am" value="com.mpsbasics.genai" />
-              <node concept="2Ry0Ak" id="4$EmJHcV_Tk" role="2Ry0An">
-                <property role="2Ry0Am" value="com.mpsbasics.genai.mpl" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="4$EmJHcVAlA" role="3bR37C">
-          <node concept="3bR9La" id="4$EmJHcVAlB" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:3HV74$ebibC" resolve="jetbrains.mps.lang.text" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="4$EmJHcVAlC" role="3bR37C">
-          <node concept="3bR9La" id="4$EmJHcVAlD" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:4SM2EuqHUPF" resolve="jetbrains.mps.lang.modelapi" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="4$EmJHcVAlE" role="3bR37C">
-          <node concept="3bR9La" id="4$EmJHcVAlF" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1TaHNgiIbIZ" resolve="MPS.Editor" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="4$EmJHcVAlG" role="3bR37C">
-          <node concept="3bR9La" id="4$EmJHcVAlH" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:7Kfy9QB6LfQ" resolve="jetbrains.mps.kernel" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="4$EmJHcVAlI" role="3bR37C">
-          <node concept="3bR9La" id="4$EmJHcVAlJ" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:7Kfy9QB6L9O" resolve="jetbrains.mps.lang.smodel" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="4$EmJHcVAlM" role="3bR37C">
-          <node concept="3bR9La" id="4$EmJHcVAlN" role="1SiIV1">
-            <ref role="3bR37D" to="al5i:6o5cjw5gEyi" resolve="com.mbeddr.mpsutil.json" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="4$EmJHcVAlO" role="3bR37C">
-          <node concept="3bR9La" id="4$EmJHcVAlP" role="1SiIV1">
-            <ref role="3bR37D" to="al5i:Vtr7jyAKU4" resolve="com.mbeddr.mpsutil.filepicker" />
-          </node>
-        </node>
-        <node concept="1BupzO" id="4$EmJHcVAm3" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="4$EmJHcVAm4" role="1HemKq">
-            <node concept="398BVA" id="4$EmJHcVAlS" role="3LXTmr">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="4$EmJHcVAlT" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="4$EmJHcVAlU" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.genai" />
-                  <node concept="2Ry0Ak" id="4$EmJHcVAlV" role="2Ry0An">
-                    <property role="2Ry0Am" value="models" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="4$EmJHcVAm5" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="4$EmJHcVEet" role="3bR37C">
-          <node concept="3bR9La" id="4$EmJHcVEeu" role="1SiIV1">
-            <ref role="3bR37D" node="4$EmJHcVBeX" resolve="com.mpsbasics.langchain4j" />
-          </node>
-        </node>
-        <node concept="3rtmxn" id="4$EmJHcVEY7" role="3bR31x">
-          <node concept="3LXTmp" id="4$EmJHcVEY8" role="3rtmxm">
-            <node concept="398BVA" id="4$EmJHcVEY9" role="3LXTmr">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="4$EmJHcVEYa" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="4$EmJHcVEYb" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.genai" />
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="4$EmJHcVEYd" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtA" id="4$EmJHcVBeX" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="com.mpsbasics.langchain4j" />
-        <property role="3LESm3" value="033ccb15-c42a-4e5a-82f2-5fe5cdc5fd43" />
-        <node concept="398BVA" id="4$EmJHcVBts" role="3LF7KH">
-          <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-          <node concept="2Ry0Ak" id="4$EmJHcVBUm" role="iGT6I">
-            <property role="2Ry0Am" value="solutions" />
-            <node concept="2Ry0Ak" id="4$EmJHcVCnf" role="2Ry0An">
-              <property role="2Ry0Am" value="com.mpsbasics.langchain4j" />
-              <node concept="2Ry0Ak" id="4$EmJHcVCO8" role="2Ry0An">
-                <property role="2Ry0Am" value="com.mpsbasics.langchain4j.msd" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="4$EmJHcVDg_" role="3bR37C">
-          <node concept="3bR9La" id="4$EmJHcVDgA" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="4$EmJHcVDgB" role="3bR37C">
-          <node concept="3bR9La" id="4$EmJHcVDgC" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:3HV74$ebibC" resolve="jetbrains.mps.lang.text" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="4$EmJHcVDgD" role="3bR37C">
-          <node concept="3bR9La" id="4$EmJHcVDgE" role="1SiIV1">
-            <ref role="3bR37D" node="4$EmJHcVzRj" resolve="com.mpsbasics.genai" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="4$EmJHcVDgF" role="3bR37C">
-          <node concept="3bR9La" id="4$EmJHcVDgG" role="1SiIV1">
-            <ref role="3bR37D" node="2u7UHDC1RNf" resolve="com.mpsbasics.pdfbox" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="4$EmJHcVDgH" role="3bR37C">
-          <node concept="3bR9La" id="4$EmJHcVDgI" role="1SiIV1">
-            <ref role="3bR37D" to="al5i:6o5cjw5gEyi" resolve="com.mbeddr.mpsutil.json" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="4$EmJHcVDgW" role="3bR37C">
-          <node concept="1BurEX" id="4$EmJHcVDgX" role="1SiIV1">
-            <node concept="398BVA" id="4$EmJHcVDgJ" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="4$EmJHcVDgK" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="4$EmJHcVDgL" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.langchain4j" />
-                  <node concept="2Ry0Ak" id="4$EmJHcVDgM" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="4$EmJHcVDgN" role="2Ry0An">
-                      <property role="2Ry0Am" value="langchain4j.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="4$EmJHcVDhb" role="3bR37C">
-          <node concept="1BurEX" id="4$EmJHcVDhc" role="1SiIV1">
-            <node concept="398BVA" id="4$EmJHcVDgY" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="4$EmJHcVDgZ" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="4$EmJHcVDh0" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.langchain4j" />
-                  <node concept="2Ry0Ak" id="4$EmJHcVDh1" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="4$EmJHcVDh2" role="2Ry0An">
-                      <property role="2Ry0Am" value="opennlp-tools.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="4$EmJHcVDhq" role="3bR37C">
-          <node concept="1BurEX" id="4$EmJHcVDhr" role="1SiIV1">
-            <node concept="398BVA" id="4$EmJHcVDhd" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="4$EmJHcVDhe" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="4$EmJHcVDhf" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.langchain4j" />
-                  <node concept="2Ry0Ak" id="4$EmJHcVDhg" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="4$EmJHcVDhh" role="2Ry0An">
-                      <property role="2Ry0Am" value="jackson-annotations.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="4$EmJHcVDhD" role="3bR37C">
-          <node concept="1BurEX" id="4$EmJHcVDhE" role="1SiIV1">
-            <node concept="398BVA" id="4$EmJHcVDhs" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="4$EmJHcVDht" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="4$EmJHcVDhu" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.langchain4j" />
-                  <node concept="2Ry0Ak" id="4$EmJHcVDhv" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="4$EmJHcVDhw" role="2Ry0An">
-                      <property role="2Ry0Am" value="jackson-core.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="4$EmJHcVDhS" role="3bR37C">
-          <node concept="1BurEX" id="4$EmJHcVDhT" role="1SiIV1">
-            <node concept="398BVA" id="4$EmJHcVDhF" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="4$EmJHcVDhG" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="4$EmJHcVDhH" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.langchain4j" />
-                  <node concept="2Ry0Ak" id="4$EmJHcVDhI" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="4$EmJHcVDhJ" role="2Ry0An">
-                      <property role="2Ry0Am" value="jackson-databind.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="4$EmJHcVDi7" role="3bR37C">
-          <node concept="1BurEX" id="4$EmJHcVDi8" role="1SiIV1">
-            <node concept="398BVA" id="4$EmJHcVDhU" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="4$EmJHcVDhV" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="4$EmJHcVDhW" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.langchain4j" />
-                  <node concept="2Ry0Ak" id="4$EmJHcVDhX" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="4$EmJHcVDhY" role="2Ry0An">
-                      <property role="2Ry0Am" value="jspecify.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="4$EmJHcVDim" role="3bR37C">
-          <node concept="1BurEX" id="4$EmJHcVDin" role="1SiIV1">
-            <node concept="398BVA" id="4$EmJHcVDi9" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="4$EmJHcVDia" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="4$EmJHcVDib" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.langchain4j" />
-                  <node concept="2Ry0Ak" id="4$EmJHcVDic" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="4$EmJHcVDid" role="2Ry0An">
-                      <property role="2Ry0Am" value="jtokkit.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="4$EmJHcVDi_" role="3bR37C">
-          <node concept="1BurEX" id="4$EmJHcVDiA" role="1SiIV1">
-            <node concept="398BVA" id="4$EmJHcVDio" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="4$EmJHcVDip" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="4$EmJHcVDiq" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.langchain4j" />
-                  <node concept="2Ry0Ak" id="4$EmJHcVDir" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="4$EmJHcVDis" role="2Ry0An">
-                      <property role="2Ry0Am" value="langchain4j-core.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="4$EmJHcVDiO" role="3bR37C">
-          <node concept="1BurEX" id="4$EmJHcVDiP" role="1SiIV1">
-            <node concept="398BVA" id="4$EmJHcVDiB" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="4$EmJHcVDiC" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="4$EmJHcVDiD" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.langchain4j" />
-                  <node concept="2Ry0Ak" id="4$EmJHcVDiE" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="4$EmJHcVDiF" role="2Ry0An">
-                      <property role="2Ry0Am" value="langchain4j-http-client-jdk.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="4$EmJHcVDj3" role="3bR37C">
-          <node concept="1BurEX" id="4$EmJHcVDj4" role="1SiIV1">
-            <node concept="398BVA" id="4$EmJHcVDiQ" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="4$EmJHcVDiR" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="4$EmJHcVDiS" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.langchain4j" />
-                  <node concept="2Ry0Ak" id="4$EmJHcVDiT" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="4$EmJHcVDiU" role="2Ry0An">
-                      <property role="2Ry0Am" value="langchain4j-http-client.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="4$EmJHcVDji" role="3bR37C">
-          <node concept="1BurEX" id="4$EmJHcVDjj" role="1SiIV1">
-            <node concept="398BVA" id="4$EmJHcVDj5" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="4$EmJHcVDj6" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="4$EmJHcVDj7" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.langchain4j" />
-                  <node concept="2Ry0Ak" id="4$EmJHcVDj8" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="4$EmJHcVDj9" role="2Ry0An">
-                      <property role="2Ry0Am" value="langchain4j-open-ai.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1BupzO" id="4$EmJHcVDjI" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="4$EmJHcVDjJ" role="1HemKq">
-            <node concept="398BVA" id="4$EmJHcVDjz" role="3LXTmr">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="4$EmJHcVDj$" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="4$EmJHcVDj_" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.langchain4j" />
-                  <node concept="2Ry0Ak" id="4$EmJHcVDjA" role="2Ry0An">
-                    <property role="2Ry0Am" value="models" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="4$EmJHcVDjK" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-        <node concept="3rtmxn" id="2vXuZjNWT$M" role="3bR31x">
-          <node concept="3LXTmp" id="2vXuZjNWT$N" role="3rtmxm">
-            <node concept="3qWCbU" id="2vXuZjNWT$O" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="2vXuZjNWT$P" role="3LXTmr">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2vXuZjNWT$Q" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2vXuZjNWT$R" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.langchain4j" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="2G$12M" id="2MrvZqtDw3j" role="3989C9">
-      <property role="TrG5h" value="com.mpsbasics.testutils" />
-      <node concept="1E1JtA" id="2MrvZqtDizQ" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="com.mpsbasics.docx4j.testutils" />
-        <property role="3LESm3" value="5f04c496-eb21-4501-981b-4e5fc2ab46ec" />
-        <node concept="398BVA" id="2MrvZqtDiKJ" role="3LF7KH">
-          <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-          <node concept="2Ry0Ak" id="2MrvZqtDj3D" role="iGT6I">
-            <property role="2Ry0Am" value="solutions" />
-            <node concept="2Ry0Ak" id="2MrvZqtDjmW" role="2Ry0An">
-              <property role="2Ry0Am" value="com.mpsbasics.docx4j.testutils" />
-              <node concept="2Ry0Ak" id="2MrvZqtDjC7" role="2Ry0An">
-                <property role="2Ry0Am" value="com.mpsbasics.docx4j.testutils.msd" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2MrvZqtDjUI" role="3bR37C">
-          <node concept="3bR9La" id="2MrvZqtDjUJ" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2MrvZqtDjUK" role="3bR37C">
-          <node concept="3bR9La" id="2MrvZqtDjUL" role="1SiIV1">
-            <ref role="3bR37D" node="7he_lUumABC" resolve="com.mpsbasics.docx4j.lib" />
-          </node>
-        </node>
-        <node concept="1BupzO" id="2MrvZqtDjUZ" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="2MrvZqtDjV0" role="1HemKq">
-            <node concept="398BVA" id="2MrvZqtDjUO" role="3LXTmr">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2MrvZqtDjUP" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2MrvZqtDjUQ" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.testutils" />
-                  <node concept="2Ry0Ak" id="2MrvZqtDjUR" role="2Ry0An">
-                    <property role="2Ry0Am" value="models" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="2MrvZqtDjV1" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-        <node concept="3rtmxn" id="4euqtkrusL7" role="3bR31x">
-          <node concept="3LXTmp" id="4euqtkrusL8" role="3rtmxm">
-            <node concept="3qWCbU" id="4euqtkrusL9" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="4euqtkrusLa" role="3LXTmr">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="4euqtkrusLb" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="4euqtkrusLc" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.testutils" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
+      <node concept="m$_yC" id="5gFsbf3gFnG" role="m$_yJ">
+        <ref role="m$_y1" to="k3fp:5gFsbf342Kk" resolve="com.mpsbasics.build" />
       </node>
     </node>
     <node concept="2G$12M" id="1k6eCQnESS5" role="3989C9">
@@ -3938,7 +1218,7 @@
         </node>
         <node concept="1SiIV0" id="2dsc7GnBJY" role="3bR37C">
           <node concept="3bR9La" id="2dsc7GnBJZ" role="1SiIV1">
-            <ref role="3bR37D" node="2dsc7GndbM" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
       </node>
@@ -4018,7 +1298,7 @@
         </node>
         <node concept="1SiIV0" id="2dsc7GnBKb" role="3bR37C">
           <node concept="3bR9La" id="2dsc7GnBKc" role="1SiIV1">
-            <ref role="3bR37D" node="2dsc7GndbM" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
       </node>
@@ -4106,7 +1386,7 @@
         </node>
         <node concept="1SiIV0" id="2dsc7GnBKo" role="3bR37C">
           <node concept="3bR9La" id="2dsc7GnBKp" role="1SiIV1">
-            <ref role="3bR37D" node="2dsc7GndbM" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
         <node concept="1SiIV0" id="3acQo$0zFLg" role="3bR37C">
@@ -4181,7 +1461,7 @@
         </node>
         <node concept="1SiIV0" id="2oZKZkZRGIw" role="3bR37C">
           <node concept="1Busua" id="2oZKZkZRGIx" role="1SiIV1">
-            <ref role="1Busuk" node="2dsc7GndbM" resolve="com.mpsbasics.core" />
+            <ref role="1Busuk" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
       </node>
@@ -4346,12 +1626,12 @@
         </node>
         <node concept="1SiIV0" id="7he_lUumILi" role="3bR37C">
           <node concept="3bR9La" id="7he_lUumILj" role="1SiIV1">
-            <ref role="3bR37D" node="7he_lUumAlC" resolve="com.mpsbasics.docx4j.core" />
+            <ref role="3bR37D" to="k3fp:6hyv0iVPlFH" resolve="com.mpsbasics.docx4j.core" />
           </node>
         </node>
         <node concept="1SiIV0" id="7he_lUumILk" role="3bR37C">
           <node concept="3bR9La" id="7he_lUumILl" role="1SiIV1">
-            <ref role="3bR37D" node="7he_lUumABC" resolve="com.mpsbasics.docx4j.lib" />
+            <ref role="3bR37D" to="k3fp:6hyv0iVPlFI" resolve="com.mpsbasics.docx4j.lib" />
           </node>
         </node>
         <node concept="1SiIV0" id="7he_lUumILo" role="3bR37C">
@@ -4440,12 +1720,12 @@
         </node>
         <node concept="1SiIV0" id="7he_lUumIVb" role="3bR37C">
           <node concept="3bR9La" id="7he_lUumIVc" role="1SiIV1">
-            <ref role="3bR37D" node="7he_lUumAlC" resolve="com.mpsbasics.docx4j.core" />
+            <ref role="3bR37D" to="k3fp:6hyv0iVPlFH" resolve="com.mpsbasics.docx4j.core" />
           </node>
         </node>
         <node concept="1SiIV0" id="7he_lUumIVd" role="3bR37C">
           <node concept="3bR9La" id="7he_lUumIVe" role="1SiIV1">
-            <ref role="3bR37D" node="7he_lUumABC" resolve="com.mpsbasics.docx4j.lib" />
+            <ref role="3bR37D" to="k3fp:6hyv0iVPlFI" resolve="com.mpsbasics.docx4j.lib" />
           </node>
         </node>
         <node concept="1SiIV0" id="7he_lUumJrT" role="3bR37C">
@@ -4634,12 +1914,12 @@
         </node>
         <node concept="1SiIV0" id="6FJpOMBt9_r" role="3bR37C">
           <node concept="3bR9La" id="6FJpOMBt9_s" role="1SiIV1">
-            <ref role="3bR37D" node="6FJpOMBsZUh" resolve="com.mpsbasics.words.generic" />
+            <ref role="3bR37D" to="k3fp:6FJpOMBsZUh" resolve="com.mpsbasics.words.generic" />
           </node>
         </node>
         <node concept="1SiIV0" id="2dsc7GnBM7" role="3bR37C">
           <node concept="3bR9La" id="2dsc7GnBM8" role="1SiIV1">
-            <ref role="3bR37D" node="2dsc7GndbM" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
         <node concept="1SiIV0" id="5xecbsSrHwn" role="3bR37C">
@@ -4757,7 +2037,7 @@
         </node>
         <node concept="1SiIV0" id="2dsc7GnBMx" role="3bR37C">
           <node concept="3bR9La" id="2dsc7GnBMy" role="1SiIV1">
-            <ref role="3bR37D" node="2dsc7GndbM" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
       </node>
@@ -4980,7 +2260,7 @@
         </node>
         <node concept="1SiIV0" id="2dsc7GnBN4" role="3bR37C">
           <node concept="3bR9La" id="2dsc7GnBN5" role="1SiIV1">
-            <ref role="3bR37D" node="2dsc7GndbM" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
       </node>
@@ -5754,7 +3034,7 @@
         </node>
         <node concept="1SiIV0" id="2dsc7GnBPk" role="3bR37C">
           <node concept="3bR9La" id="2dsc7GnBPl" role="1SiIV1">
-            <ref role="3bR37D" node="2dsc7GndbM" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
       </node>
@@ -6027,7 +3307,7 @@
         </node>
         <node concept="1SiIV0" id="2dsc7GnBPT" role="3bR37C">
           <node concept="3bR9La" id="2dsc7GnBPU" role="1SiIV1">
-            <ref role="3bR37D" node="2dsc7GndbM" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
       </node>
@@ -6195,7 +3475,7 @@
         </node>
         <node concept="1SiIV0" id="2dsc7GnBQ6" role="3bR37C">
           <node concept="3bR9La" id="2dsc7GnBQ7" role="1SiIV1">
-            <ref role="3bR37D" node="2dsc7GndbM" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
       </node>
@@ -6260,6 +3540,25 @@
               </node>
               <node concept="3qWCbU" id="5TezZ1Vej8V" role="3LXTna">
                 <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+              </node>
+            </node>
+          </node>
+          <node concept="3rtmxn" id="3te$DfsEp2n" role="3bR31x">
+            <node concept="3LXTmp" id="3te$DfsEp2o" role="3rtmxm">
+              <node concept="3qWCbU" id="3te$DfsEp2p" role="3LXTna">
+                <property role="3qWCbO" value="icons/**, resources/**" />
+              </node>
+              <node concept="398BVA" id="3te$DfsEp53" role="3LXTmr">
+                <ref role="398BVh" node="7he_lUuoRR9" resolve="mbeddr.formal.spin.code" />
+                <node concept="2Ry0Ak" id="3te$DfsEp54" role="iGT6I">
+                  <property role="2Ry0Am" value="languages" />
+                  <node concept="2Ry0Ak" id="3te$DfsEp55" role="2Ry0An">
+                    <property role="2Ry0Am" value="com.mbeddr.formal.spin.ext" />
+                    <node concept="2Ry0Ak" id="3te$DfsEp56" role="2Ry0An">
+                      <property role="2Ry0Am" value="generator" />
+                    </node>
+                  </node>
+                </node>
               </node>
             </node>
           </node>
@@ -6501,7 +3800,7 @@
         </node>
         <node concept="1SiIV0" id="2dsc7GnBQS" role="3bR37C">
           <node concept="3bR9La" id="2dsc7GnBQT" role="1SiIV1">
-            <ref role="3bR37D" node="2dsc7GndbM" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
       </node>
@@ -6684,7 +3983,7 @@
         </node>
         <node concept="1SiIV0" id="2dsc7GnBRt" role="3bR37C">
           <node concept="3bR9La" id="2dsc7GnBRu" role="1SiIV1">
-            <ref role="3bR37D" node="2dsc7GndbM" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
       </node>
@@ -6857,7 +4156,7 @@
         </node>
         <node concept="1SiIV0" id="2dsc7GnBRP" role="3bR37C">
           <node concept="3bR9La" id="2dsc7GnBRQ" role="1SiIV1">
-            <ref role="3bR37D" node="2dsc7GndbM" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
       </node>
@@ -7393,7 +4692,7 @@
         </node>
         <node concept="1SiIV0" id="5t37uj6UBgn" role="3bR37C">
           <node concept="3bR9La" id="5t37uj6UBgo" role="1SiIV1">
-            <ref role="3bR37D" node="7he_lUumBj6" resolve="com.mpsbasics.snode.utils" />
+            <ref role="3bR37D" to="k3fp:6hyv0iVPlFJ" resolve="com.mpsbasics.snode.utils" />
           </node>
         </node>
         <node concept="1SiIV0" id="8xY_IhvyHr" role="3bR37C">
@@ -7408,12 +4707,12 @@
         </node>
         <node concept="1SiIV0" id="1hVhF3lk3Jg" role="3bR37C">
           <node concept="3bR9La" id="1hVhF3lk3Jh" role="1SiIV1">
-            <ref role="3bR37D" node="2u7UHDCnPLY" resolve="com.mpsbasics.project.utils" />
+            <ref role="3bR37D" to="k3fp:2u7UHDCnPLY" resolve="com.mpsbasics.project.utils" />
           </node>
         </node>
         <node concept="1SiIV0" id="2dsc7GnBSX" role="3bR37C">
           <node concept="3bR9La" id="2dsc7GnBSY" role="1SiIV1">
-            <ref role="3bR37D" node="2dsc7GndbM" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
         <node concept="1SiIV0" id="3aXq4CuhzUK" role="3bR37C">
@@ -7428,7 +4727,7 @@
         </node>
         <node concept="1SiIV0" id="3tsEGTjSC2s" role="3bR37C">
           <node concept="3bR9La" id="3tsEGTjSC2t" role="1SiIV1">
-            <ref role="3bR37D" node="2u7UHDCnRuK" resolve="com.mpsbasics.editor.utils" />
+            <ref role="3bR37D" to="k3fp:2u7UHDCnRuK" resolve="com.mpsbasics.editor.utils" />
           </node>
         </node>
       </node>
@@ -7576,7 +4875,7 @@
         </node>
         <node concept="1SiIV0" id="2dsc7GnBTl" role="3bR37C">
           <node concept="3bR9La" id="2dsc7GnBTm" role="1SiIV1">
-            <ref role="3bR37D" node="2dsc7GndbM" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
       </node>
@@ -7681,7 +4980,7 @@
         </node>
         <node concept="1SiIV0" id="2dsc7GnBTy" role="3bR37C">
           <node concept="3bR9La" id="2dsc7GnBTz" role="1SiIV1">
-            <ref role="3bR37D" node="2dsc7GndbM" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
         <node concept="1SiIV0" id="3acQo$0zFTK" role="3bR37C">
@@ -7756,7 +5055,7 @@
         </node>
         <node concept="1SiIV0" id="2dsc7GnBTJ" role="3bR37C">
           <node concept="3bR9La" id="2dsc7GnBTK" role="1SiIV1">
-            <ref role="3bR37D" node="2dsc7GndbM" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
         <node concept="1SiIV0" id="1ppJrCAlPQm" role="3bR37C">
@@ -7841,7 +5140,7 @@
         </node>
         <node concept="1SiIV0" id="2dsc7GnBU9" role="3bR37C">
           <node concept="3bR9La" id="2dsc7GnBUa" role="1SiIV1">
-            <ref role="3bR37D" node="2dsc7GndbM" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
       </node>
@@ -8090,7 +5389,7 @@
         </node>
         <node concept="1SiIV0" id="2dsc7GnBV6" role="3bR37C">
           <node concept="3bR9La" id="2dsc7GnBV7" role="1SiIV1">
-            <ref role="3bR37D" node="2dsc7GndbM" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
       </node>
@@ -8701,7 +6000,7 @@
         </node>
         <node concept="1SiIV0" id="2dsc7GnBWY" role="3bR37C">
           <node concept="3bR9La" id="2dsc7GnBWZ" role="1SiIV1">
-            <ref role="3bR37D" node="2dsc7GndbM" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
       </node>
@@ -8841,7 +6140,7 @@
         </node>
         <node concept="1SiIV0" id="2dsc7GnBXb" role="3bR37C">
           <node concept="3bR9La" id="2dsc7GnBXc" role="1SiIV1">
-            <ref role="3bR37D" node="2dsc7GndbM" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
       </node>
@@ -8919,7 +6218,7 @@
         </node>
         <node concept="1SiIV0" id="2dsc7GnBX_" role="3bR37C">
           <node concept="3bR9La" id="2dsc7GnBXA" role="1SiIV1">
-            <ref role="3bR37D" node="2dsc7GndbM" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
       </node>
@@ -9476,7 +6775,7 @@
         </node>
         <node concept="1SiIV0" id="2dsc7GnBYU" role="3bR37C">
           <node concept="3bR9La" id="2dsc7GnBYV" role="1SiIV1">
-            <ref role="3bR37D" node="2dsc7GndbM" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
       </node>
@@ -9785,7 +7084,7 @@
         </node>
         <node concept="1SiIV0" id="2dsc7GnBZG" role="3bR37C">
           <node concept="3bR9La" id="2dsc7GnBZH" role="1SiIV1">
-            <ref role="3bR37D" node="2dsc7GndbM" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
       </node>
@@ -9992,7 +7291,7 @@
         </node>
         <node concept="1SiIV0" id="2dsc7GnC0u" role="3bR37C">
           <node concept="3bR9La" id="2dsc7GnC0v" role="1SiIV1">
-            <ref role="3bR37D" node="2dsc7GndbM" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
       </node>
@@ -10948,7 +8247,7 @@
         </node>
         <node concept="1SiIV0" id="2dsc7GnC3l" role="3bR37C">
           <node concept="3bR9La" id="2dsc7GnC3m" role="1SiIV1">
-            <ref role="3bR37D" node="2dsc7GndbM" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
       </node>
@@ -11267,7 +8566,7 @@
         </node>
         <node concept="1SiIV0" id="5t37uj6UBpB" role="3bR37C">
           <node concept="3bR9La" id="5t37uj6UBpC" role="1SiIV1">
-            <ref role="3bR37D" node="7he_lUumBj6" resolve="com.mpsbasics.snode.utils" />
+            <ref role="3bR37D" to="k3fp:6hyv0iVPlFJ" resolve="com.mpsbasics.snode.utils" />
           </node>
         </node>
         <node concept="1SiIV0" id="1x1_rydrReV" role="3bR37C">
@@ -11293,17 +8592,17 @@
         </node>
         <node concept="1SiIV0" id="1hVhF3lk3T3" role="3bR37C">
           <node concept="3bR9La" id="1hVhF3lk3T4" role="1SiIV1">
-            <ref role="3bR37D" node="2u7UHDCnRuK" resolve="com.mpsbasics.editor.utils" />
+            <ref role="3bR37D" to="k3fp:2u7UHDCnRuK" resolve="com.mpsbasics.editor.utils" />
           </node>
         </node>
         <node concept="1SiIV0" id="6_254RlouCF" role="3bR37C">
           <node concept="3bR9La" id="6_254RlouCG" role="1SiIV1">
-            <ref role="3bR37D" node="2dsc7GndbM" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
         <node concept="1SiIV0" id="2FavYGw23MC" role="3bR37C">
           <node concept="1Busua" id="6_254RlovI8" role="1SiIV1">
-            <ref role="1Busuk" node="6FJpOMBsZUh" resolve="com.mpsbasics.words.generic" />
+            <ref role="1Busuk" to="k3fp:6FJpOMBsZUh" resolve="com.mpsbasics.words.generic" />
           </node>
         </node>
         <node concept="1SiIV0" id="5mBZ2gvf9F7" role="3bR37C">
@@ -11413,12 +8712,12 @@
         </node>
         <node concept="1SiIV0" id="YXkTXVNhC4" role="3bR37C">
           <node concept="3bR9La" id="YXkTXVNhC5" role="1SiIV1">
-            <ref role="3bR37D" node="2u7UHDCnRuK" resolve="com.mpsbasics.editor.utils" />
+            <ref role="3bR37D" to="k3fp:2u7UHDCnRuK" resolve="com.mpsbasics.editor.utils" />
           </node>
         </node>
         <node concept="1SiIV0" id="2dsc7GnC4g" role="3bR37C">
           <node concept="3bR9La" id="2dsc7GnC4h" role="1SiIV1">
-            <ref role="3bR37D" node="2dsc7GndbM" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
       </node>
@@ -11551,12 +8850,12 @@
         </node>
         <node concept="1SiIV0" id="2dsc7GnC4t" role="3bR37C">
           <node concept="3bR9La" id="2dsc7GnC4u" role="1SiIV1">
-            <ref role="3bR37D" node="2dsc7GndbM" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
         <node concept="1SiIV0" id="5U_9MCNdVJ7" role="3bR37C">
           <node concept="3bR9La" id="5U_9MCNdVJ8" role="1SiIV1">
-            <ref role="3bR37D" node="2u7UHDCnPLY" resolve="com.mpsbasics.project.utils" />
+            <ref role="3bR37D" to="k3fp:2u7UHDCnPLY" resolve="com.mpsbasics.project.utils" />
           </node>
         </node>
       </node>
@@ -11810,7 +9109,7 @@
         </node>
         <node concept="1SiIV0" id="6FJpOMBt9Rr" role="3bR37C">
           <node concept="3bR9La" id="6FJpOMBt9Rs" role="1SiIV1">
-            <ref role="3bR37D" node="6FJpOMBsZUh" resolve="com.mpsbasics.words.generic" />
+            <ref role="3bR37D" to="k3fp:6FJpOMBsZUh" resolve="com.mpsbasics.words.generic" />
           </node>
         </node>
       </node>
@@ -11903,7 +9202,7 @@
         </node>
         <node concept="1SiIV0" id="2dsc7GnC5d" role="3bR37C">
           <node concept="3bR9La" id="2dsc7GnC5e" role="1SiIV1">
-            <ref role="3bR37D" node="2dsc7GndbM" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
       </node>
@@ -12051,7 +9350,7 @@
         </node>
         <node concept="1SiIV0" id="2dsc7GnC5q" role="3bR37C">
           <node concept="3bR9La" id="2dsc7GnC5r" role="1SiIV1">
-            <ref role="3bR37D" node="2dsc7GndbM" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
         <node concept="1SiIV0" id="2K8T9FD4u6L" role="3bR37C">
@@ -12098,7 +9397,7 @@
         </node>
         <node concept="1SiIV0" id="2K8T9FD4s2$" role="3bR37C">
           <node concept="3bR9La" id="2K8T9FD4s2_" role="1SiIV1">
-            <ref role="3bR37D" node="2dsc7GndbM" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
         <node concept="1SiIV0" id="2K8T9FD4s2A" role="3bR37C">
@@ -12567,12 +9866,12 @@
         </node>
         <node concept="1SiIV0" id="2dsc7GnC6Q" role="3bR37C">
           <node concept="3bR9La" id="2dsc7GnC6R" role="1SiIV1">
-            <ref role="3bR37D" node="2dsc7GndbM" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
         <node concept="1SiIV0" id="2dsc7GnC73" role="3bR37C">
           <node concept="1Busua" id="2dsc7GnC74" role="1SiIV1">
-            <ref role="1Busuk" node="2dsc7GndbM" resolve="com.mpsbasics.core" />
+            <ref role="1Busuk" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
       </node>
@@ -12675,12 +9974,12 @@
         </node>
         <node concept="1SiIV0" id="6FJpOMBt9T_" role="3bR37C">
           <node concept="3bR9La" id="6FJpOMBt9TA" role="1SiIV1">
-            <ref role="3bR37D" node="6FJpOMBsZUh" resolve="com.mpsbasics.words.generic" />
+            <ref role="3bR37D" to="k3fp:6FJpOMBsZUh" resolve="com.mpsbasics.words.generic" />
           </node>
         </node>
         <node concept="1SiIV0" id="2dsc7GnC75" role="3bR37C">
           <node concept="3bR9La" id="2dsc7GnC76" role="1SiIV1">
-            <ref role="3bR37D" node="2dsc7GndbM" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
       </node>
@@ -12816,7 +10115,7 @@
           </node>
         </node>
         <node concept="1E0d5M" id="1hVhF3lqy4f" role="1E1XAP">
-          <ref role="1E0d5P" node="2u7UHDCnPLY" resolve="com.mpsbasics.project.utils" />
+          <ref role="1E0d5P" to="k3fp:2u7UHDCnPLY" resolve="com.mpsbasics.project.utils" />
         </node>
         <node concept="1SiIV0" id="7OA8CsRhh8n" role="3bR37C">
           <node concept="3bR9La" id="7OA8CsRhh8o" role="1SiIV1">
@@ -12825,12 +10124,12 @@
         </node>
         <node concept="1SiIV0" id="2FavYGw2tqJ" role="3bR37C">
           <node concept="1Busua" id="2FavYGw2tqK" role="1SiIV1">
-            <ref role="1Busuk" node="6FJpOMBsZUh" resolve="com.mpsbasics.words.generic" />
+            <ref role="1Busuk" to="k3fp:6FJpOMBsZUh" resolve="com.mpsbasics.words.generic" />
           </node>
         </node>
         <node concept="1SiIV0" id="2dsc7GnC7i" role="3bR37C">
           <node concept="3bR9La" id="2dsc7GnC7j" role="1SiIV1">
-            <ref role="3bR37D" node="2dsc7GndbM" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
       </node>
@@ -13115,7 +10414,7 @@
         </node>
         <node concept="1SiIV0" id="2dsc7GnC8f" role="3bR37C">
           <node concept="3bR9La" id="2dsc7GnC8g" role="1SiIV1">
-            <ref role="3bR37D" node="2dsc7GndbM" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
       </node>
@@ -13157,7 +10456,7 @@
         </node>
         <node concept="1SiIV0" id="3h2IzuaJgHX" role="3bR37C">
           <node concept="3bR9La" id="3h2IzuaJgHY" role="1SiIV1">
-            <ref role="3bR37D" node="2wSfKqy9jAQ" resolve="com.mpsbasics.jira" />
+            <ref role="3bR37D" to="k3fp:2wSfKqy9jAQ" resolve="com.mpsbasics.jira" />
           </node>
         </node>
         <node concept="1SiIV0" id="3h2IzuaJgHZ" role="3bR37C">
@@ -13211,7 +10510,7 @@
         </node>
         <node concept="1SiIV0" id="2dsc7GnC8s" role="3bR37C">
           <node concept="3bR9La" id="2dsc7GnC8t" role="1SiIV1">
-            <ref role="3bR37D" node="2dsc7GndbM" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
       </node>
@@ -13423,7 +10722,7 @@
         </node>
         <node concept="1SiIV0" id="2dsc7GnC91" role="3bR37C">
           <node concept="3bR9La" id="2dsc7GnC92" role="1SiIV1">
-            <ref role="3bR37D" node="2dsc7GndbM" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
       </node>
@@ -13501,7 +10800,7 @@
         </node>
         <node concept="1SiIV0" id="2dsc7GnC9e" role="3bR37C">
           <node concept="3bR9La" id="2dsc7GnC9f" role="1SiIV1">
-            <ref role="3bR37D" node="2dsc7GndbM" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
       </node>
@@ -13604,12 +10903,12 @@
         </node>
         <node concept="1SiIV0" id="1hVhF3lk3XN" role="3bR37C">
           <node concept="3bR9La" id="1hVhF3lk3XO" role="1SiIV1">
-            <ref role="3bR37D" node="2u7UHDCnRuK" resolve="com.mpsbasics.editor.utils" />
+            <ref role="3bR37D" to="k3fp:2u7UHDCnRuK" resolve="com.mpsbasics.editor.utils" />
           </node>
         </node>
         <node concept="1SiIV0" id="2dsc7GnC9r" role="3bR37C">
           <node concept="3bR9La" id="2dsc7GnC9s" role="1SiIV1">
-            <ref role="3bR37D" node="2dsc7GndbM" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
       </node>
@@ -13752,7 +11051,7 @@
         </node>
         <node concept="1SiIV0" id="5mBZ2gvfx3T" role="3bR37C">
           <node concept="3bR9La" id="5mBZ2gvfx3U" role="1SiIV1">
-            <ref role="3bR37D" node="2dsc7GndbM" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
         <node concept="1BupzO" id="5mBZ2gvfx48" role="3bR31x">
@@ -13933,12 +11232,12 @@
         </node>
         <node concept="1SiIV0" id="1hVhF3lk3Yo" role="3bR37C">
           <node concept="3bR9La" id="1hVhF3lk3Yp" role="1SiIV1">
-            <ref role="3bR37D" node="2u7UHDCnRuK" resolve="com.mpsbasics.editor.utils" />
+            <ref role="3bR37D" to="k3fp:2u7UHDCnRuK" resolve="com.mpsbasics.editor.utils" />
           </node>
         </node>
         <node concept="1SiIV0" id="2dsc7GnC9N" role="3bR37C">
           <node concept="3bR9La" id="2dsc7GnC9O" role="1SiIV1">
-            <ref role="3bR37D" node="2dsc7GndbM" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
         <node concept="1SiIV0" id="5uow0HSPGvc" role="3bR37C">
@@ -14133,7 +11432,7 @@
         </node>
         <node concept="1SiIV0" id="2dsc7GnCao" role="3bR37C">
           <node concept="3bR9La" id="2dsc7GnCap" role="1SiIV1">
-            <ref role="3bR37D" node="2dsc7GndbM" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
         <node concept="1SiIV0" id="1IqNToc8MKa" role="3bR37C">
@@ -14301,7 +11600,7 @@
         </node>
         <node concept="1SiIV0" id="2dsc7GnCaK" role="3bR37C">
           <node concept="3bR9La" id="2dsc7GnCaL" role="1SiIV1">
-            <ref role="3bR37D" node="2dsc7GndbM" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
       </node>
@@ -14569,7 +11868,7 @@
         </node>
         <node concept="1SiIV0" id="2dsc7GnCbj" role="3bR37C">
           <node concept="3bR9La" id="2dsc7GnCbk" role="1SiIV1">
-            <ref role="3bR37D" node="2dsc7GndbM" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
       </node>
@@ -15105,7 +12404,7 @@
         </node>
         <node concept="1SiIV0" id="9wBdtpFYqW" role="3bR37C">
           <node concept="3bR9La" id="9wBdtpFYqX" role="1SiIV1">
-            <ref role="3bR37D" node="2u7UHDC1TKp" resolve="com.mpsbasics.pdfexporter" />
+            <ref role="3bR37D" to="k3fp:2u7UHDC1TKp" resolve="com.mpsbasics.pdfexporter" />
           </node>
         </node>
         <node concept="1SiIV0" id="6FJpOMBtycz" role="3bR37C">
@@ -15180,12 +12479,12 @@
         </node>
         <node concept="1SiIV0" id="4ziKDEngCuV" role="3bR37C">
           <node concept="3bR9La" id="4ziKDEngCuW" role="1SiIV1">
-            <ref role="3bR37D" node="7he_lUumAlC" resolve="com.mpsbasics.docx4j.core" />
+            <ref role="3bR37D" to="k3fp:6hyv0iVPlFH" resolve="com.mpsbasics.docx4j.core" />
           </node>
         </node>
         <node concept="1SiIV0" id="4ziKDEngCuZ" role="3bR37C">
           <node concept="3bR9La" id="4ziKDEngCv0" role="1SiIV1">
-            <ref role="3bR37D" node="7he_lUumABC" resolve="com.mpsbasics.docx4j.lib" />
+            <ref role="3bR37D" to="k3fp:6hyv0iVPlFI" resolve="com.mpsbasics.docx4j.lib" />
           </node>
         </node>
         <node concept="1SiIV0" id="4ziKDEngCv3" role="3bR37C">
@@ -15277,7 +12576,7 @@
         </node>
         <node concept="1SiIV0" id="1hVhF3lk41U" role="3bR37C">
           <node concept="3bR9La" id="1hVhF3lk41V" role="1SiIV1">
-            <ref role="3bR37D" node="2u7UHDCnRuK" resolve="com.mpsbasics.editor.utils" />
+            <ref role="3bR37D" to="k3fp:2u7UHDCnRuK" resolve="com.mpsbasics.editor.utils" />
           </node>
         </node>
       </node>
@@ -15304,7 +12603,7 @@
         </node>
         <node concept="1SiIV0" id="3TNxfDZ8qC_" role="3bR37C">
           <node concept="3bR9La" id="3TNxfDZ8qCA" role="1SiIV1">
-            <ref role="3bR37D" node="2u7UHDC1RNf" resolve="com.mpsbasics.pdfbox" />
+            <ref role="3bR37D" to="k3fp:2u7UHDC1RNf" resolve="com.mpsbasics.pdfbox" />
           </node>
         </node>
         <node concept="1BupzO" id="3TNxfDZ8qCM" role="3bR31x">
@@ -15331,7 +12630,7 @@
         </node>
         <node concept="1SiIV0" id="3TNxfDZ8qCP" role="3bR37C">
           <node concept="1Busua" id="3TNxfDZ8qCQ" role="1SiIV1">
-            <ref role="1Busuk" node="2u7UHDC1TKp" resolve="com.mpsbasics.pdfexporter" />
+            <ref role="1Busuk" to="k3fp:2u7UHDC1TKp" resolve="com.mpsbasics.pdfexporter" />
           </node>
         </node>
         <node concept="3rtmxn" id="4euqtkrusMd" role="3bR31x">
@@ -15352,7 +12651,7 @@
         </node>
         <node concept="1SiIV0" id="2dsc7GnCde" role="3bR37C">
           <node concept="3bR9La" id="2dsc7GnCdf" role="1SiIV1">
-            <ref role="3bR37D" node="2dsc7GndbM" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
       </node>
@@ -15427,7 +12726,7 @@
         </node>
         <node concept="1SiIV0" id="2dsc7GnCdr" role="3bR37C">
           <node concept="3bR9La" id="2dsc7GnCds" role="1SiIV1">
-            <ref role="3bR37D" node="2dsc7GndbM" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
         <node concept="1SiIV0" id="3heog7O6iJD" role="3bR37C">
@@ -15646,7 +12945,7 @@
         </node>
         <node concept="1SiIV0" id="2dsc7GnCdN" role="3bR37C">
           <node concept="3bR9La" id="2dsc7GnCdO" role="1SiIV1">
-            <ref role="3bR37D" node="2dsc7GndbM" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
       </node>
@@ -15798,12 +13097,12 @@
         </node>
         <node concept="1SiIV0" id="6FJpOMBta08" role="3bR37C">
           <node concept="3bR9La" id="6FJpOMBta09" role="1SiIV1">
-            <ref role="3bR37D" node="6FJpOMBsZUh" resolve="com.mpsbasics.words.generic" />
+            <ref role="3bR37D" to="k3fp:6FJpOMBsZUh" resolve="com.mpsbasics.words.generic" />
           </node>
         </node>
         <node concept="1SiIV0" id="2dsc7GnCe0" role="3bR37C">
           <node concept="3bR9La" id="2dsc7GnCe1" role="1SiIV1">
-            <ref role="3bR37D" node="2dsc7GndbM" resolve="com.mpsbasics.core" />
+            <ref role="3bR37D" to="k3fp:4lJSf3LkfPw" resolve="com.mpsbasics.core" />
           </node>
         </node>
         <node concept="1SiIV0" id="5xecbsSrHTS" role="3bR37C">
@@ -15835,7 +13134,7 @@
         </node>
         <node concept="1SiIV0" id="4$EmJHcVJsj" role="3bR37C">
           <node concept="3bR9La" id="4$EmJHcVJsk" role="1SiIV1">
-            <ref role="3bR37D" node="4$EmJHcVzRj" resolve="com.mpsbasics.genai" />
+            <ref role="3bR37D" to="k3fp:36zCbqqq6a9" resolve="com.mpsbasics.genai" />
           </node>
         </node>
         <node concept="1SiIV0" id="4$EmJHcVJsl" role="3bR37C">
@@ -15910,7 +13209,7 @@
         </node>
         <node concept="1SiIV0" id="4$EmJHcVN39" role="3bR37C">
           <node concept="3bR9La" id="4$EmJHcVN3a" role="1SiIV1">
-            <ref role="3bR37D" node="4$EmJHcVzRj" resolve="com.mpsbasics.genai" />
+            <ref role="3bR37D" to="k3fp:36zCbqqq6a9" resolve="com.mpsbasics.genai" />
           </node>
         </node>
         <node concept="1SiIV0" id="4$EmJHcVN3b" role="3bR37C">
@@ -15995,7 +13294,7 @@
         </node>
         <node concept="1SiIV0" id="4$EmJHcVR6p" role="3bR37C">
           <node concept="3bR9La" id="4$EmJHcVR6q" role="1SiIV1">
-            <ref role="3bR37D" node="4$EmJHcVBeX" resolve="com.mpsbasics.langchain4j" />
+            <ref role="3bR37D" to="k3fp:36zCbqqq9fZ" resolve="com.mpsbasics.langchain4j" />
           </node>
         </node>
         <node concept="1SiIV0" id="4$EmJHcVR6r" role="3bR37C">
@@ -16253,7 +13552,7 @@
           <ref role="3LEDTV" node="jPgKPEIhOV" resolve="com.mbeddr.formal.safety.argument.visualisation" />
         </node>
         <node concept="3LEDTy" id="6FJpOMBta0y" role="3LEDUa">
-          <ref role="3LEDTV" node="6FJpOMBsZUh" resolve="com.mpsbasics.words.generic" />
+          <ref role="3LEDTV" to="k3fp:6FJpOMBsZUh" resolve="com.mpsbasics.words.generic" />
         </node>
       </node>
     </node>
@@ -16349,7 +13648,7 @@
           <ref role="3LEDTV" node="3h2IzuaJeCO" resolve="com.mbeddr.formal.safety.argument.jira_integration" />
         </node>
         <node concept="3LEDTy" id="3h2IzuaJjMv" role="3LEDUa">
-          <ref role="3LEDTV" node="2wSfKqy9jAQ" resolve="com.mpsbasics.jira" />
+          <ref role="3LEDTV" to="k3fp:2wSfKqy9jAQ" resolve="com.mpsbasics.jira" />
         </node>
       </node>
     </node>
@@ -16384,7 +13683,7 @@
           <ref role="3LEz8N" to="al5i:7tNo_gxoK9_" resolve="com.mbeddr.documentation" />
         </node>
         <node concept="3LEDTy" id="1hVhF3lk427" role="3LEDUa">
-          <ref role="3LEDTV" node="2u7UHDC1TKp" resolve="com.mpsbasics.pdfexporter" />
+          <ref role="3LEDTV" to="k3fp:2u7UHDC1TKp" resolve="com.mpsbasics.pdfexporter" />
         </node>
         <node concept="3LEDTy" id="1hVhF3lk5vP" role="3LEDUa">
           <ref role="3LEDTV" node="3TNxfDZ8p0R" resolve="com.mbeddr.formal.safety.gsn.pdfexport" />
@@ -16714,7 +14013,7 @@
           <ref role="3LEz8N" to="al5i:7tNo_gxoK9_" resolve="com.mbeddr.documentation" />
         </node>
         <node concept="3LEDTy" id="9wBdtpFYsp" role="3LEDUa">
-          <ref role="3LEDTV" node="2u7UHDC1TKp" resolve="com.mpsbasics.pdfexporter" />
+          <ref role="3LEDTV" to="k3fp:2u7UHDC1TKp" resolve="com.mpsbasics.pdfexporter" />
         </node>
       </node>
     </node>
@@ -16797,6 +14096,11 @@
         <node concept="1SiIV0" id="1n_6a3Gkdka" role="3bR37C">
           <node concept="3bR9La" id="1n_6a3Gkdkb" role="1SiIV1">
             <ref role="3bR37D" to="jrpl:5Xjjs0Nf2r4" resolve="org.mpsqa.build" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="5gFsbf3gFkQ" role="3bR37C">
+          <node concept="3bR9La" id="5gFsbf3gFkR" role="1SiIV1">
+            <ref role="3bR37D" to="k3fp:5jdn85oHU1h" resolve="com.mpsbasics.build" />
           </node>
         </node>
       </node>
@@ -16888,6 +14192,12 @@
       <node concept="L2wRC" id="gYMUULBCit" role="39821P">
         <ref role="L2wRA" node="gYMUULBCgK" resolve="com.fasten.assurance.build" />
       </node>
+      <node concept="L2wRC" id="5gFsbf33IdL" role="39821P">
+        <ref role="L2wRA" node="5gFsbf33Ica" resolve="com.mpsbasics.build" />
+      </node>
+      <node concept="L2wRC" id="5gFsbf33IdO" role="39821P">
+        <ref role="L2wRA" node="5gFsbf33HVn" resolve="com.mpsbasics.tests.build" />
+      </node>
     </node>
     <node concept="10PD9b" id="3GDqItDlhWa" role="10PD9s" />
     <node concept="3b7kt6" id="3GDqItDloJY" role="10PD9s" />
@@ -16976,6 +14286,11 @@
           <ref role="3bR37D" to="jrpl:5Xjjs0Nf2r4" resolve="org.mpsqa.build" />
         </node>
       </node>
+      <node concept="1SiIV0" id="5gFsbf3gFvC" role="3bR37C">
+        <node concept="3bR9La" id="5gFsbf3gFvD" role="1SiIV1">
+          <ref role="3bR37D" node="5gFsbf33Ica" resolve="com.mpsbasics.build" />
+        </node>
+      </node>
     </node>
     <node concept="1E1JtA" id="gYMUULBCgK" role="3989C9">
       <property role="BnDLt" value="true" />
@@ -17049,6 +14364,155 @@
       <node concept="1SiIV0" id="6odNb$o7d41" role="3bR37C">
         <node concept="3bR9La" id="6odNb$o7d42" role="1SiIV1">
           <ref role="3bR37D" to="2tou:32O483pJL16" resolve="org.mpsqa.base.build" />
+        </node>
+      </node>
+      <node concept="1SiIV0" id="5gFsbf34xSk" role="3bR37C">
+        <node concept="3bR9La" id="5gFsbf34xSl" role="1SiIV1">
+          <ref role="3bR37D" node="5gFsbf33Ica" resolve="com.mpsbasics.build" />
+        </node>
+      </node>
+    </node>
+    <node concept="1E1JtA" id="5gFsbf33Ica" role="3989C9">
+      <property role="BnDLt" value="true" />
+      <property role="TrG5h" value="com.mpsbasics.build" />
+      <property role="3LESm3" value="ff2a102e-f030-4756-a6c9-02da709c686f" />
+      <node concept="398BVA" id="5gFsbf33Icd" role="3LF7KH">
+        <ref role="398BVh" node="3GDqItDloIT" resolve="mbeddr.formal.home" />
+        <node concept="2Ry0Ak" id="5gFsbf33Ich" role="iGT6I">
+          <property role="2Ry0Am" value="code" />
+          <node concept="2Ry0Ak" id="5gFsbf33Ick" role="2Ry0An">
+            <property role="2Ry0Am" value="languages" />
+            <node concept="2Ry0Ak" id="5gFsbf33Icn" role="2Ry0An">
+              <property role="2Ry0Am" value="com.mpsbasics" />
+              <node concept="2Ry0Ak" id="5gFsbf33Icq" role="2Ry0An">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="5gFsbf33Ict" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.build" />
+                  <node concept="2Ry0Ak" id="5gFsbf33Icw" role="2Ry0An">
+                    <property role="2Ry0Am" value="com.mpsbasics.build.msd" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1SiIV0" id="5gFsbf33IcR" role="3bR37C">
+        <node concept="3bR9La" id="5gFsbf33IcS" role="1SiIV1">
+          <ref role="3bR37D" to="ffeo:78GwwOvB3tw" resolve="jetbrains.mps.ide.build" />
+        </node>
+      </node>
+      <node concept="1BupzO" id="5gFsbf33Id0" role="3bR31x">
+        <property role="3ZfqAx" value="models" />
+        <property role="1Hdu6h" value="true" />
+        <property role="1HemKv" value="true" />
+        <node concept="3LXTmp" id="5gFsbf33Id1" role="1HemKq">
+          <node concept="398BVA" id="5gFsbf33IcT" role="3LXTmr">
+            <ref role="398BVh" node="3GDqItDloIT" resolve="mbeddr.formal.home" />
+            <node concept="2Ry0Ak" id="5gFsbf33IcU" role="iGT6I">
+              <property role="2Ry0Am" value="code" />
+              <node concept="2Ry0Ak" id="5gFsbf33IcV" role="2Ry0An">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="5gFsbf33IcW" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics" />
+                  <node concept="2Ry0Ak" id="5gFsbf33IcX" role="2Ry0An">
+                    <property role="2Ry0Am" value="solutions" />
+                    <node concept="2Ry0Ak" id="5gFsbf33IcY" role="2Ry0An">
+                      <property role="2Ry0Am" value="com.mpsbasics.build" />
+                      <node concept="2Ry0Ak" id="5gFsbf33IcZ" role="2Ry0An">
+                        <property role="2Ry0Am" value="models" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3qWCbU" id="5gFsbf33Id2" role="3LXTna">
+            <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+          </node>
+        </node>
+      </node>
+      <node concept="1SiIV0" id="5gFsbf34xSx" role="3bR37C">
+        <node concept="3bR9La" id="5gFsbf34xSy" role="1SiIV1">
+          <ref role="3bR37D" to="90a9:PE3B26VOkn" resolve="de.itemis.mps.extensions.build" />
+        </node>
+      </node>
+      <node concept="1SiIV0" id="5gFsbf34xSz" role="3bR37C">
+        <node concept="3bR9La" id="5gFsbf34xS$" role="1SiIV1">
+          <ref role="3bR37D" to="al5i:7Pr7tifzlku" resolve="com.mbeddr.platform" />
+        </node>
+      </node>
+    </node>
+    <node concept="1E1JtA" id="5gFsbf33HVn" role="3989C9">
+      <property role="BnDLt" value="true" />
+      <property role="TrG5h" value="com.mpsbasics.tests.build" />
+      <property role="3LESm3" value="501fd540-aef3-4d7b-b289-4bdbc8b5a74a" />
+      <node concept="398BVA" id="5gFsbf33HVt" role="3LF7KH">
+        <ref role="398BVh" node="3GDqItDloIT" resolve="mbeddr.formal.home" />
+        <node concept="2Ry0Ak" id="5gFsbf33HVx" role="iGT6I">
+          <property role="2Ry0Am" value="code" />
+          <node concept="2Ry0Ak" id="5gFsbf33HV$" role="2Ry0An">
+            <property role="2Ry0Am" value="languages" />
+            <node concept="2Ry0Ak" id="5gFsbf33HVB" role="2Ry0An">
+              <property role="2Ry0Am" value="com.mpsbasics" />
+              <node concept="2Ry0Ak" id="5gFsbf33HVE" role="2Ry0An">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="5gFsbf33HVH" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.tests.build" />
+                  <node concept="2Ry0Ak" id="5gFsbf33HVK" role="2Ry0An">
+                    <property role="2Ry0Am" value="com.mpsbasics.tests.build.msd" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1SiIV0" id="5gFsbf33HW7" role="3bR37C">
+        <node concept="3bR9La" id="5gFsbf33HW8" role="1SiIV1">
+          <ref role="3bR37D" to="ffeo:78GwwOvB3tw" resolve="jetbrains.mps.ide.build" />
+        </node>
+      </node>
+      <node concept="1BupzO" id="5gFsbf33HWg" role="3bR31x">
+        <property role="3ZfqAx" value="models" />
+        <property role="1Hdu6h" value="true" />
+        <property role="1HemKv" value="true" />
+        <node concept="3LXTmp" id="5gFsbf33HWh" role="1HemKq">
+          <node concept="398BVA" id="5gFsbf33HW9" role="3LXTmr">
+            <ref role="398BVh" node="3GDqItDloIT" resolve="mbeddr.formal.home" />
+            <node concept="2Ry0Ak" id="5gFsbf33HWa" role="iGT6I">
+              <property role="2Ry0Am" value="code" />
+              <node concept="2Ry0Ak" id="5gFsbf33HWb" role="2Ry0An">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="5gFsbf33HWc" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics" />
+                  <node concept="2Ry0Ak" id="5gFsbf33HWd" role="2Ry0An">
+                    <property role="2Ry0Am" value="solutions" />
+                    <node concept="2Ry0Ak" id="5gFsbf33HWe" role="2Ry0An">
+                      <property role="2Ry0Am" value="com.mpsbasics.tests.build" />
+                      <node concept="2Ry0Ak" id="5gFsbf33HWf" role="2Ry0An">
+                        <property role="2Ry0Am" value="models" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3qWCbU" id="5gFsbf33HWi" role="3LXTna">
+            <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+          </node>
+        </node>
+      </node>
+      <node concept="1SiIV0" id="5gFsbf33IdB" role="3bR37C">
+        <node concept="3bR9La" id="5gFsbf33IdC" role="1SiIV1">
+          <ref role="3bR37D" node="5gFsbf33Ica" resolve="com.mpsbasics.build" />
+        </node>
+      </node>
+      <node concept="1SiIV0" id="5gFsbf3gFw7" role="3bR37C">
+        <node concept="3bR9La" id="5gFsbf3gFw8" role="1SiIV1">
+          <ref role="3bR37D" to="al5i:7Pr7tifzlku" resolve="com.mbeddr.platform" />
         </node>
       </node>
     </node>
@@ -17172,6 +14636,20 @@
     <node concept="2sgV4H" id="2vdUOu0FXrq" role="1l3spa">
       <ref role="1l3spb" node="42jqVeFkUtb" resolve="com.mbeddr.formal.languages" />
     </node>
+    <node concept="2sgV4H" id="3te$DfsK2DR" role="1l3spa">
+      <ref role="1l3spb" to="k3fp:42jqVeFkUtb" resolve="com.mpsbasics" />
+      <node concept="55IIr" id="3te$DfsQ8GM" role="2JcizS">
+        <node concept="2Ry0Ak" id="3te$DfsQ8GN" role="iGT6I">
+          <property role="2Ry0Am" value=".." />
+          <node concept="2Ry0Ak" id="3te$DfsQ8GO" role="2Ry0An">
+            <property role="2Ry0Am" value="artifacts" />
+            <node concept="2Ry0Ak" id="3te$DfsQ8GP" role="2Ry0An">
+              <property role="2Ry0Am" value="com.mpsbasics" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
     <node concept="1l3spV" id="1IhJc2tzBMJ" role="1l3spN">
       <node concept="398223" id="1IhJc2tH7Ki" role="39821P">
         <node concept="3_J27D" id="1IhJc2tH7Kk" role="Nbhlr">
@@ -17217,24 +14695,6 @@
       </node>
       <node concept="L2wRC" id="1IhJc2tzBZ_" role="39821P">
         <ref role="L2wRA" node="1IhJc2tzBXn" resolve="test.mbeddr.formal.nusmv" />
-      </node>
-    </node>
-    <node concept="m$_wf" id="1IhJc2tzBPg" role="3989C9">
-      <property role="m$_wk" value="nusmv.tests.dummy" />
-      <node concept="3_J27D" id="1IhJc2tzBPh" role="m$_yQ">
-        <node concept="3Mxwew" id="1IhJc2tzBPs" role="3MwsjC">
-          <property role="3MwjfP" value="nusmv-tests" />
-        </node>
-      </node>
-      <node concept="3_J27D" id="1IhJc2tzBPi" role="m_cZH">
-        <node concept="3Mxwew" id="1IhJc2tzBPv" role="3MwsjC">
-          <property role="3MwjfP" value="nusmv.tests" />
-        </node>
-      </node>
-      <node concept="3_J27D" id="1IhJc2tzBPj" role="m$_w8">
-        <node concept="3Mxwew" id="1IhJc2tzBPy" role="3MwsjC">
-          <property role="3MwjfP" value="1.1" />
-        </node>
       </node>
     </node>
     <node concept="10PD9b" id="1IhJc2tzBV$" role="10PD9s" />
@@ -17932,6 +15392,20 @@
         <ref role="398BVh" node="wUJmWCxY0E" resolve="dependencies.mbeddr.platform" />
       </node>
     </node>
+    <node concept="2sgV4H" id="3te$DfsEoQK" role="1l3spa">
+      <ref role="1l3spb" to="k3fp:42jqVeFkUtb" resolve="com.mpsbasics" />
+      <node concept="55IIr" id="3te$DfsQ8GS" role="2JcizS">
+        <node concept="2Ry0Ak" id="3te$DfsQ8GT" role="iGT6I">
+          <property role="2Ry0Am" value=".." />
+          <node concept="2Ry0Ak" id="3te$DfsQ8GU" role="2Ry0An">
+            <property role="2Ry0Am" value="artifacts" />
+            <node concept="2Ry0Ak" id="3te$DfsQ8GV" role="2Ry0An">
+              <property role="2Ry0Am" value="com.mpsbasics" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
     <node concept="2sgV4H" id="7he_lUutsbk" role="1l3spa">
       <ref role="1l3spb" node="42jqVeFkUtb" resolve="com.mbeddr.formal.languages" />
     </node>
@@ -18246,7 +15720,7 @@
           <ref role="3_I8Xa" to="ffeo:3SKb_4JujwY" resolve="mps-spellcheck" />
         </node>
         <node concept="3_I8Xc" id="7he_lUutsoc" role="39821P">
-          <ref role="3_I8Xa" node="7he_lUumPyH" resolve="com.mpsbasics" />
+          <ref role="3_I8Xa" to="k3fp:6hyv0iVPlE_" resolve="com.mpsbasics" />
         </node>
         <node concept="3_I8Xc" id="7OA8CsRAtaL" role="39821P">
           <ref role="3_I8Xa" node="1k6eCQnF1G0" resolve="fasten.symo" />
@@ -18490,6 +15964,20 @@
     <node concept="2sgV4H" id="1FMyjUPkmd9" role="1l3spa">
       <ref role="1l3spb" node="42jqVeFkUtb" resolve="com.mbeddr.formal.languages" />
     </node>
+    <node concept="2sgV4H" id="3te$DfsEUAb" role="1l3spa">
+      <ref role="1l3spb" to="k3fp:42jqVeFkUtb" resolve="com.mpsbasics" />
+      <node concept="55IIr" id="3te$DfsQ8GY" role="2JcizS">
+        <node concept="2Ry0Ak" id="3te$DfsQ8GZ" role="iGT6I">
+          <property role="2Ry0Am" value=".." />
+          <node concept="2Ry0Ak" id="3te$DfsQ8H0" role="2Ry0An">
+            <property role="2Ry0Am" value="artifacts" />
+            <node concept="2Ry0Ak" id="3te$DfsQ8H1" role="2Ry0An">
+              <property role="2Ry0Am" value="com.mpsbasics" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
     <node concept="1l3spV" id="1FMyjUPkmda" role="1l3spN">
       <node concept="398223" id="1$9jWFVFL$P" role="39821P">
         <node concept="3_J27D" id="1$9jWFVFL$Q" role="Nbhlr">
@@ -18550,30 +16038,6 @@
       </node>
       <node concept="L2wRC" id="5h_XtOowe4M" role="39821P">
         <ref role="L2wRA" node="5h_XtOowdHr" resolve="test.mbeddr.formal.safety.argument.modelquery" />
-      </node>
-    </node>
-    <node concept="m$_wf" id="1FMyjUPkmds" role="3989C9">
-      <property role="m$_wk" value="safety.tests.dummy" />
-      <node concept="3_J27D" id="1FMyjUPkmdt" role="m$_yQ">
-        <node concept="3Mxwew" id="1FMyjUPkmdu" role="3MwsjC">
-          <property role="3MwjfP" value="safety-tests" />
-        </node>
-      </node>
-      <node concept="3_J27D" id="1FMyjUPkmdv" role="m_cZH">
-        <node concept="3Mxwew" id="1FMyjUPkmdw" role="3MwsjC">
-          <property role="3MwjfP" value="safety.tests" />
-        </node>
-      </node>
-      <node concept="3_J27D" id="1FMyjUPkmdx" role="m$_w8">
-        <node concept="3Mxwew" id="1FMyjUPkmdy" role="3MwsjC">
-          <property role="3MwjfP" value="1.1" />
-        </node>
-      </node>
-      <node concept="m$_yC" id="2MrvZqtDki2" role="m$_yJ">
-        <ref role="m$_y1" node="7he_lUumEw2" resolve="com.mpsbasics" />
-      </node>
-      <node concept="m$_yC" id="2MrvZqtDvTe" role="m$_yJ">
-        <ref role="m$_y1" node="2MrvZqtDsQE" resolve="com.mpsbasics.testutils" />
       </node>
     </node>
     <node concept="10PD9b" id="1FMyjUPkmdz" role="10PD9s" />
@@ -19155,7 +16619,7 @@
         </node>
         <node concept="1SiIV0" id="4ziKDEngDEn" role="3bR37C">
           <node concept="3bR9La" id="4ziKDEngDEo" role="1SiIV1">
-            <ref role="3bR37D" node="7he_lUumAlC" resolve="com.mpsbasics.docx4j.core" />
+            <ref role="3bR37D" to="k3fp:6hyv0iVPlFH" resolve="com.mpsbasics.docx4j.core" />
           </node>
         </node>
         <node concept="1SiIV0" id="4ziKDEngDEp" role="3bR37C">
@@ -19197,7 +16661,7 @@
         </node>
         <node concept="1SiIV0" id="2MrvZqtDzih" role="3bR37C">
           <node concept="3bR9La" id="2MrvZqtDzii" role="1SiIV1">
-            <ref role="3bR37D" node="2MrvZqtDizQ" resolve="com.mpsbasics.docx4j.testutils" />
+            <ref role="3bR37D" to="k3fp:5gFsbf33R6e" resolve="com.mpsbasics.docx4j.testutils" />
           </node>
         </node>
         <node concept="3rtmxn" id="4euqtkrusJN" role="3bR31x">
@@ -19396,6 +16860,20 @@
     <node concept="2sgV4H" id="6ucyvMUGDpe" role="1l3spa">
       <ref role="1l3spb" node="42jqVeFkUtb" resolve="com.mbeddr.formal.languages" />
     </node>
+    <node concept="2sgV4H" id="3te$DfsFlpS" role="1l3spa">
+      <ref role="1l3spb" to="k3fp:42jqVeFkUtb" resolve="com.mpsbasics" />
+      <node concept="55IIr" id="3te$DfsQ8DQ" role="2JcizS">
+        <node concept="2Ry0Ak" id="3te$DfsQ8DS" role="iGT6I">
+          <property role="2Ry0Am" value=".." />
+          <node concept="2Ry0Ak" id="3te$DfsQ8DV" role="2Ry0An">
+            <property role="2Ry0Am" value="artifacts" />
+            <node concept="2Ry0Ak" id="3te$DfsQ8DY" role="2Ry0An">
+              <property role="2Ry0Am" value="com.mpsbasics" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
     <node concept="1l3spV" id="6ucyvMUDFdL" role="1l3spN">
       <node concept="398223" id="6ucyvMUDFdM" role="39821P">
         <node concept="3_J27D" id="6ucyvMUDFdN" role="Nbhlr">
@@ -19542,27 +17020,6 @@
         <ref role="L2wRA" node="6oAzR4b6jhL" resolve="test.com.fasten.safety.bayesian_network" />
       </node>
     </node>
-    <node concept="m$_wf" id="6ucyvMUDFe3" role="3989C9">
-      <property role="m$_wk" value="nusmv.tests.dummy" />
-      <node concept="3_J27D" id="6ucyvMUDFe4" role="m$_yQ">
-        <node concept="3Mxwew" id="6ucyvMUDFe5" role="3MwsjC">
-          <property role="3MwjfP" value="nusmv-tests" />
-        </node>
-      </node>
-      <node concept="3_J27D" id="6ucyvMUDFe6" role="m_cZH">
-        <node concept="3Mxwew" id="6ucyvMUDFe7" role="3MwsjC">
-          <property role="3MwjfP" value="nusmv.tests" />
-        </node>
-      </node>
-      <node concept="3_J27D" id="6ucyvMUDFe8" role="m$_w8">
-        <node concept="3Mxwew" id="6ucyvMUDFe9" role="3MwsjC">
-          <property role="3MwjfP" value="1.1" />
-        </node>
-      </node>
-      <node concept="m$_yC" id="1HO1gFDOvxh" role="m$_yJ">
-        <ref role="m$_y1" to="90a9:2NTGYE$JTH6" resolve="com.dslfoundry.plaintextgen" />
-      </node>
-    </node>
     <node concept="10PD9b" id="6ucyvMUDFea" role="10PD9s" />
     <node concept="3b7kt6" id="6ucyvMUDFeb" role="10PD9s" />
     <node concept="1gjT0q" id="6ucyvMUDFec" role="10PD9s" />
@@ -19597,7 +17054,7 @@
         </node>
         <node concept="1SiIV0" id="4m8f5phpEyD" role="3bR37C">
           <node concept="3bR9La" id="4m8f5phpEyE" role="1SiIV1">
-            <ref role="3bR37D" node="4m8f5php_QJ" resolve="com.mpsbasics.plaintext.yaml" />
+            <ref role="3bR37D" to="k3fp:4m8f5php_QJ" resolve="com.mpsbasics.plaintext.yaml" />
           </node>
         </node>
         <node concept="1BupzO" id="4m8f5phpEyZ" role="3bR31x">
@@ -20254,7 +17711,7 @@
         </node>
         <node concept="1SiIV0" id="4ziKDEnkJja" role="3bR37C">
           <node concept="3bR9La" id="4ziKDEnkJjb" role="1SiIV1">
-            <ref role="3bR37D" node="7he_lUumAlC" resolve="com.mpsbasics.docx4j.core" />
+            <ref role="3bR37D" to="k3fp:6hyv0iVPlFH" resolve="com.mpsbasics.docx4j.core" />
           </node>
         </node>
         <node concept="1SiIV0" id="4ziKDEnkJjc" role="3bR37C">
@@ -20296,7 +17753,7 @@
         </node>
         <node concept="1SiIV0" id="2MrvZqtGvC$" role="3bR37C">
           <node concept="3bR9La" id="2MrvZqtGvC_" role="1SiIV1">
-            <ref role="3bR37D" node="2MrvZqtDizQ" resolve="com.mpsbasics.docx4j.testutils" />
+            <ref role="3bR37D" to="k3fp:5gFsbf33R6e" resolve="com.mpsbasics.docx4j.testutils" />
           </node>
         </node>
         <node concept="3rtmxn" id="4euqtkrusKm" role="3bR31x">

--- a/code/languages/com.mbeddr.formal.safety/solutions/com.mbeddr.formal.safety.build/models/com.mbeddr.formal.safety.build.mps
+++ b/code/languages/com.mbeddr.formal.safety/solutions/com.mbeddr.formal.safety.build/models/com.mbeddr.formal.safety.build.mps
@@ -1716,25 +1716,6 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="2fGryx5rGav" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rGaw" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rGai" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rGaj" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rGak" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rGal" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rGam" role="2Ry0An">
-                      <property role="2Ry0Am" value="jakarta.activation.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
         <node concept="1SiIV0" id="2fGryx5rGaI" role="3bR37C">
           <node concept="1BurEX" id="2fGryx5rGaJ" role="1SiIV1">
             <node concept="398BVA" id="2fGryx5rGax" role="1BurEY">
@@ -1747,25 +1728,6 @@
                     <property role="2Ry0Am" value="lib" />
                     <node concept="2Ry0Ak" id="2fGryx5rGa_" role="2Ry0An">
                       <property role="2Ry0Am" value="jakarta.mail-api.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rGaX" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rGaY" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rGaK" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rGaL" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rGaM" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rGaN" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rGaO" role="2Ry0An">
-                      <property role="2Ry0Am" value="jakarta.mail.jar" />
                     </node>
                   </node>
                 </node>
@@ -1925,25 +1887,6 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="2fGryx5rGd4" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rGd5" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rGcR" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rGcS" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rGcT" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rGcU" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rGcV" role="2Ry0An">
-                      <property role="2Ry0Am" value="slf4j-api.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
         <node concept="1SiIV0" id="2fGryx5rGdj" role="3bR37C">
           <node concept="1BurEX" id="2fGryx5rGdk" role="1SiIV1">
             <node concept="398BVA" id="2fGryx5rGd6" role="1BurEY">
@@ -2032,6 +1975,158 @@
                     <property role="2Ry0Am" value="lib" />
                     <node concept="2Ry0Ak" id="2fGryx5rGe6" role="2Ry0An">
                       <property role="2Ry0Am" value="xmlgraphics-commons.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6CRJe3tfG0b" role="3bR37C">
+          <node concept="1BurEX" id="6CRJe3tfG0c" role="1SiIV1">
+            <node concept="398BVA" id="6CRJe3tfFZY" role="1BurEY">
+              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="6CRJe3tfFZZ" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="6CRJe3tfG00" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
+                  <node concept="2Ry0Ak" id="6CRJe3tfG01" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="6CRJe3tfG02" role="2Ry0An">
+                      <property role="2Ry0Am" value="angus-activation.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6CRJe3tfG0q" role="3bR37C">
+          <node concept="1BurEX" id="6CRJe3tfG0r" role="1SiIV1">
+            <node concept="398BVA" id="6CRJe3tfG0d" role="1BurEY">
+              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="6CRJe3tfG0e" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="6CRJe3tfG0f" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
+                  <node concept="2Ry0Ak" id="6CRJe3tfG0g" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="6CRJe3tfG0h" role="2Ry0An">
+                      <property role="2Ry0Am" value="angus-mail.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6CRJe3tfG1t" role="3bR37C">
+          <node concept="1BurEX" id="6CRJe3tfG1u" role="1SiIV1">
+            <node concept="398BVA" id="6CRJe3tfG1g" role="1BurEY">
+              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="6CRJe3tfG1h" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="6CRJe3tfG1i" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
+                  <node concept="2Ry0Ak" id="6CRJe3tfG1j" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="6CRJe3tfG1k" role="2Ry0An">
+                      <property role="2Ry0Am" value="commons-collections4.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6CRJe3tfG2j" role="3bR37C">
+          <node concept="1BurEX" id="6CRJe3tfG2k" role="1SiIV1">
+            <node concept="398BVA" id="6CRJe3tfG26" role="1BurEY">
+              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="6CRJe3tfG27" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="6CRJe3tfG28" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
+                  <node concept="2Ry0Ak" id="6CRJe3tfG29" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="6CRJe3tfG2a" role="2Ry0An">
+                      <property role="2Ry0Am" value="commons-logging.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6CRJe3tfG4N" role="3bR37C">
+          <node concept="1BurEX" id="6CRJe3tfG4O" role="1SiIV1">
+            <node concept="398BVA" id="6CRJe3tfG4A" role="1BurEY">
+              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="6CRJe3tfG4B" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="6CRJe3tfG4C" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
+                  <node concept="2Ry0Ak" id="6CRJe3tfG4D" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="6CRJe3tfG4E" role="2Ry0An">
+                      <property role="2Ry0Am" value="jaxb-core.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6CRJe3tfG5u" role="3bR37C">
+          <node concept="1BurEX" id="6CRJe3tfG5v" role="1SiIV1">
+            <node concept="398BVA" id="6CRJe3tfG5h" role="1BurEY">
+              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="6CRJe3tfG5i" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="6CRJe3tfG5j" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
+                  <node concept="2Ry0Ak" id="6CRJe3tfG5k" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="6CRJe3tfG5l" role="2Ry0An">
+                      <property role="2Ry0Am" value="jaxb-xjc.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6CRJe3tfG6I" role="3bR37C">
+          <node concept="1BurEX" id="6CRJe3tfG6J" role="1SiIV1">
+            <node concept="398BVA" id="6CRJe3tfG6x" role="1BurEY">
+              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="6CRJe3tfG6y" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="6CRJe3tfG6z" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
+                  <node concept="2Ry0Ak" id="6CRJe3tfG6$" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="6CRJe3tfG6_" role="2Ry0An">
+                      <property role="2Ry0Am" value="pdfbox-io.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6CRJe3tfG7a" role="3bR37C">
+          <node concept="1BurEX" id="6CRJe3tfG7b" role="1SiIV1">
+            <node concept="398BVA" id="6CRJe3tfG6X" role="1BurEY">
+              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="6CRJe3tfG6Y" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="6CRJe3tfG6Z" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
+                  <node concept="2Ry0Ak" id="6CRJe3tfG70" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="6CRJe3tfG71" role="2Ry0An">
+                      <property role="2Ry0Am" value="SparseBitSet.jar" />
                     </node>
                   </node>
                 </node>
@@ -2922,25 +3017,6 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="2fGryx5rGmE" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rGmF" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rGmt" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rGmu" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rGmv" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
-                  <node concept="2Ry0Ak" id="2fGryx5rGmw" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rGmx" role="2Ry0An">
-                      <property role="2Ry0Am" value="slf4j-api.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
         <node concept="1SiIV0" id="2fGryx5rGmT" role="3bR37C">
           <node concept="1BurEX" id="2fGryx5rGmU" role="1SiIV1">
             <node concept="398BVA" id="2fGryx5rGmG" role="1BurEY">
@@ -3683,25 +3759,6 @@
                     <property role="2Ry0Am" value="lib" />
                     <node concept="2Ry0Ak" id="4$EmJHcVDj9" role="2Ry0An">
                       <property role="2Ry0Am" value="langchain4j-open-ai.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="4$EmJHcVDjx" role="3bR37C">
-          <node concept="1BurEX" id="4$EmJHcVDjy" role="1SiIV1">
-            <node concept="398BVA" id="4$EmJHcVDjk" role="1BurEY">
-              <ref role="398BVh" node="7he_lUum_$u" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="4$EmJHcVDjl" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="4$EmJHcVDjm" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.langchain4j" />
-                  <node concept="2Ry0Ak" id="4$EmJHcVDjn" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="4$EmJHcVDjo" role="2Ry0An">
-                      <property role="2Ry0Am" value="slf4j-api.jar" />
                     </node>
                   </node>
                 </node>

--- a/code/languages/com.mbeddr.formal.safety/solutions/com.mbeddr.formal.safety.build/models/com.mbeddr.formal.safety.build.mps
+++ b/code/languages/com.mbeddr.formal.safety/solutions/com.mbeddr.formal.safety.build/models/com.mbeddr.formal.safety.build.mps
@@ -547,7 +547,7 @@
       <node concept="aVJcg" id="4aeOpjlAysR" role="aVJcv">
         <node concept="NbPM2" id="4aeOpjlAysQ" role="aVJcq">
           <node concept="3Mxwew" id="4aeOpjlAysP" role="3MwsjC">
-            <property role="3MwjfP" value="2024-01-04" />
+            <property role="3MwjfP" value="2026-05-11" />
           </node>
         </node>
       </node>
@@ -14859,7 +14859,7 @@
     <node concept="2kB4xC" id="wUJmWCxY0a" role="1l3spd">
       <property role="TrG5h" value="build.date" />
       <node concept="hHN3E" id="wUJmWCxY0b" role="aVJcv">
-        <property role="hHN3Y" value="20241114" />
+        <property role="hHN3Y" value="20260511" />
       </node>
     </node>
     <node concept="2kB4xC" id="wUJmWCxY0c" role="1l3spd">
@@ -14867,7 +14867,7 @@
       <node concept="aVJcg" id="wUJmWCxY0d" role="aVJcv">
         <node concept="NbPM2" id="wUJmWCxY0e" role="aVJcq">
           <node concept="3Mxwew" id="wUJmWCxY0f" role="3MwsjC">
-            <property role="3MwjfP" value="FASTEN-241.SNAPSHOT" />
+            <property role="3MwjfP" value="FASTEN-251.SNAPSHOT" />
           </node>
         </node>
       </node>
@@ -14990,7 +14990,7 @@
       <node concept="aVJcg" id="wUJmWCxY0I" role="aVJcv">
         <node concept="NbPM2" id="wUJmWCxY0J" role="aVJcq">
           <node concept="3Mxwew" id="wUJmWCxY0K" role="3MwsjC">
-            <property role="3MwjfP" value="2024-11-14" />
+            <property role="3MwjfP" value="2026-05-11" />
           </node>
         </node>
       </node>

--- a/code/languages/com.mbeddr.formal.safety/tests/test.com.fasten.safety.doc2word/models/test.com.fasten.safety.doc2word._100_gsn_documents_testdata.mps
+++ b/code/languages/com.mbeddr.formal.safety/tests/test.com.fasten.safety.doc2word/models/test.com.fasten.safety.doc2word._100_gsn_documents_testdata.mps
@@ -153,7 +153,7 @@
     </node>
   </node>
   <node concept="1VB52S" id="3mpcDUdya9X">
-    <property role="TrG5h" value="_110_argument_over_hazards" />
+    <property role="TrG5h" value="_110_argument_over_hazards_gsn" />
     <node concept="2vn7WC" id="3mpcDUdyab3" role="2vn1q5">
       <property role="TrG5h" value="G01" />
       <node concept="19SGf9" id="3mpcDUdyab4" role="2vnaTY">
@@ -219,8 +219,8 @@
   </node>
   <node concept="qdN4g" id="3mpcDUdycH1">
     <property role="yApLE" value="1" />
-    <property role="TrG5h" value="_110_argument_over_hazards_doc" />
-    <ref role="qdN4h" node="3mpcDUdya9X" resolve="_110_argument_over_hazards" />
+    <property role="TrG5h" value="_110_argument_over_hazards" />
+    <ref role="qdN4h" node="3mpcDUdya9X" resolve="_110_argument_over_hazards_gsn" />
     <ref role="G9hjw" node="3mpcDUdy7QQ" resolve="config" />
     <node concept="1mvXsy" id="3mpcDUdycH7" role="1_0VJ0">
       <property role="TrG5h" value="overview" />
@@ -237,7 +237,7 @@
         <node concept="2bctqb" id="3mpcDUdycHd" role="3z_lpT" />
         <node concept="2NCZwO" id="3mpcDUdycHe" role="3z_lpI">
           <node concept="2NCMab" id="3mpcDUdycHn" role="2NCMaf">
-            <ref role="2NCMaa" node="3mpcDUdya9X" resolve="_110_argument_over_hazards" />
+            <ref role="2NCMaa" node="3mpcDUdya9X" resolve="_110_argument_over_hazards_gsn" />
           </node>
         </node>
       </node>

--- a/code/languages/com.mpsbasics/.mps/modules.xml
+++ b/code/languages/com.mpsbasics/.mps/modules.xml
@@ -9,10 +9,11 @@
       <modulePath path="$PROJECT_DIR$/languages/com.mpsbasics.plaintext.yaml.dsl.base/com.mpsbasics.plaintext.yaml.dsl.base.mpl" folder="plaintext_yaml" />
       <modulePath path="$PROJECT_DIR$/languages/com.mpsbasics.plaintext.yaml/com.mpsbasics.plaintext.yaml.mpl" folder="plaintext_yaml" />
       <modulePath path="$PROJECT_DIR$/languages/com.mpsbasics.words.generic/com.mpsbasics.words.generic.mpl" folder="words" />
-      <modulePath path="$PROJECT_DIR$/solutions/com.mpsbasics.build/com.mpsbasics.build.msd" folder="" />
+      <modulePath path="$PROJECT_DIR$/solutions/com.mpsbasics.build/com.mpsbasics.build.msd" folder="_001_build" />
       <modulePath path="$PROJECT_DIR$/solutions/com.mpsbasics.docx4j.core/com.mpsbasics.docx4j.core.msd" folder="docx4j" />
       <modulePath path="$PROJECT_DIR$/solutions/com.mpsbasics.docx4j.lib/com.mpsbasics.docx4j.lib.msd" folder="docx4j" />
       <modulePath path="$PROJECT_DIR$/solutions/com.mpsbasics.docx4j.sandbox/com.mpsbasics.docx4j.sandbox.msd" folder="docx4j" />
+      <modulePath path="$PROJECT_DIR$/solutions/com.mpsbasics.docx4j.tests/com.mpsbasics.docx4j.tests.msd" folder="docx4j" />
       <modulePath path="$PROJECT_DIR$/solutions/com.mpsbasics.docx4j.testutils/com.mpsbasics.docx4j.testutils.msd" folder="docx4j" />
       <modulePath path="$PROJECT_DIR$/solutions/com.mpsbasics.editor.utils/com.mpsbasics.editor.utils.msd" folder="" />
       <modulePath path="$PROJECT_DIR$/solutions/com.mpsbasics.genai.sandbox/com.mpsbasics.genai.sandbox.msd" folder="langchain4j" />
@@ -24,6 +25,7 @@
       <modulePath path="$PROJECT_DIR$/solutions/com.mpsbasics.plaintext.yaml.sandbox/com.mpsbasics.plaintext.yaml.sandbox.msd" folder="plaintext_yaml" />
       <modulePath path="$PROJECT_DIR$/solutions/com.mpsbasics.project.utils/com.mpsbasics.project.utils.msd" folder="" />
       <modulePath path="$PROJECT_DIR$/solutions/com.mpsbasics.snode.utils/com.mpsbasics.snode.utils.msd" folder="" />
+      <modulePath path="$PROJECT_DIR$/solutions/com.mpsbasics.tests.build/com.mpsbasics.tests.build.msd" folder="_001_build" />
       <modulePath path="$PROJECT_DIR$/solutions/test.com.mpsbasics.plaintext.yaml/test.com.mpsbasics.plaintext.yaml.msd" folder="plaintext_yaml" />
       <modulePath path="${mbeddr.formal.home}/code/languages/com.mbeddr.formal.repo_admin/solutions/com.fasten.meta.linters/com.fasten.meta.linters.msd" folder="_000_meta" />
     </projectModules>

--- a/code/languages/com.mpsbasics/solutions/com.mpsbasics.build/com.mpsbasics.build.msd
+++ b/code/languages/com.mpsbasics/solutions/com.mpsbasics.build/com.mpsbasics.build.msd
@@ -12,6 +12,8 @@
   </facets>
   <dependencies>
     <dependency reexport="false">422c2909-59d6-41a9-b318-40e6256b250f(jetbrains.mps.ide.build)</dependency>
+    <dependency reexport="false">3ae9cfda-f938-4524-b4ca-fbcba3b0525b(com.mbeddr.platform)</dependency>
+    <dependency reexport="false">f1fb7b1c-ce0d-423c-9369-4a661d600029(de.itemis.mps.extensions.build)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:798100da-4f0a-421a-b991-71f8c50ce5d2:jetbrains.mps.build" version="0" />
@@ -19,7 +21,9 @@
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
   </languageVersions>
   <dependencyVersions>
+    <module reference="3ae9cfda-f938-4524-b4ca-fbcba3b0525b(com.mbeddr.platform)" version="0" />
     <module reference="ff2a102e-f030-4756-a6c9-02da709c686f(com.mpsbasics.build)" version="0" />
+    <module reference="f1fb7b1c-ce0d-423c-9369-4a661d600029(de.itemis.mps.extensions.build)" version="0" />
     <module reference="422c2909-59d6-41a9-b318-40e6256b250f(jetbrains.mps.ide.build)" version="0" />
   </dependencyVersions>
 </solution>

--- a/code/languages/com.mpsbasics/solutions/com.mpsbasics.build/models/com.mpsbasics.build.build.mps
+++ b/code/languages/com.mpsbasics/solutions/com.mpsbasics.build/models/com.mpsbasics.build.build.mps
@@ -7,6 +7,8 @@
   </languages>
   <imports>
     <import index="ffeo" ref="r:874d959d-e3b4-4d04-b931-ca849af130dd(jetbrains.mps.ide.build)" />
+    <import index="al5i" ref="r:742f344d-4dc4-4862-992c-4bc94b094870(com.mbeddr.mpsutil.dev.build)" />
+    <import index="90a9" ref="r:fb24ac52-5985-4947-bba9-25be6fd32c1a(de.itemis.mps.extensions.build)" implicit="true" />
   </imports>
   <registry>
     <language id="798100da-4f0a-421a-b991-71f8c50ce5d2" name="jetbrains.mps.build">
@@ -54,6 +56,7 @@
       <concept id="5617550519002745363" name="jetbrains.mps.build.structure.BuildProject" flags="ng" index="1l3spW">
         <property id="4915877860348071612" name="fileName" index="turDy" />
         <property id="5204048710541015587" name="internalBaseDirectory" index="2DA0ip" />
+        <child id="4796668409958418110" name="scriptsDir" index="auvoZ" />
         <child id="6647099934206700656" name="plugins" index="10PD9s" />
         <child id="7389400916848080626" name="parts" index="3989C9" />
         <child id="3542413272732620719" name="aspects" index="1hWBAP" />
@@ -103,6 +106,9 @@
         <reference id="6592112598314801433" name="plugin" index="m_rDy" />
         <child id="3570488090019868128" name="packagingType" index="pUk7w" />
       </concept>
+      <concept id="6592112598314499036" name="jetbrains.mps.build.mps.structure.BuildMps_IdeaPluginModule" flags="ng" index="m$_yB">
+        <reference id="6592112598314499037" name="target" index="m$_yA" />
+      </concept>
       <concept id="6592112598314499027" name="jetbrains.mps.build.mps.structure.BuildMps_IdeaPluginDependency" flags="ng" index="m$_yC">
         <reference id="6592112598314499066" name="target" index="m$_y1" />
       </concept>
@@ -139,7 +145,11 @@
       <concept id="4278635856200826393" name="jetbrains.mps.build.mps.structure.BuildMps_ModuleDependencyJar" flags="ng" index="1BurEX">
         <child id="4278635856200826394" name="path" index="1BurEY" />
       </concept>
+      <concept id="4278635856200794926" name="jetbrains.mps.build.mps.structure.BuildMps_ModuleDependencyExtendLanguage" flags="ng" index="1Busua">
+        <reference id="4278635856200794928" name="language" index="1Busuk" />
+      </concept>
       <concept id="3189788309731840247" name="jetbrains.mps.build.mps.structure.BuildMps_Solution" flags="ng" index="1E1JtA" />
+      <concept id="3189788309731840248" name="jetbrains.mps.build.mps.structure.BuildMps_Language" flags="ng" index="1E1JtD" />
       <concept id="322010710375871467" name="jetbrains.mps.build.mps.structure.BuildMps_AbstractModule" flags="ng" index="3LEN3z">
         <property id="8369506495128725901" name="compact" index="BnDLt" />
         <property id="322010710375892619" name="uuid" index="3LESm3" />
@@ -152,7 +162,7 @@
   </registry>
   <node concept="1l3spW" id="42jqVeFkUtb">
     <property role="TrG5h" value="com.mpsbasics" />
-    <property role="2DA0ip" value="../../../../../build/scripts" />
+    <property role="2DA0ip" value="../.." />
     <property role="turDy" value="build-mpsbasics-languages.xml" />
     <node concept="2igEWh" id="4wvhzx$rMzu" role="1hWBAP">
       <property role="3UIfUI" value="4096" />
@@ -161,6 +171,15 @@
       <ref role="1l3spb" to="ffeo:3IKDaVZmzS6" resolve="mps" />
       <node concept="398BVA" id="678OVF4brWB" role="2JcizS">
         <ref role="398BVh" node="42jqVeFkUtk" resolve="mps.home" />
+      </node>
+    </node>
+    <node concept="2sgV4H" id="6hyv0iVPlE0" role="1l3spa">
+      <ref role="1l3spb" to="al5i:3AVJcIMlF8l" resolve="com.mbeddr.platform" />
+      <node concept="398BVA" id="6hyv0iVPlE$" role="2JcizS">
+        <ref role="398BVh" node="5gFsbf33UIa" resolve="dependencies.root" />
+        <node concept="2Ry0Ak" id="5gFsbf33X$O" role="iGT6I">
+          <property role="2Ry0Am" value="com.mbeddr.platform" />
+        </node>
       </node>
     </node>
     <node concept="10PD9b" id="42jqVeFkUtc" role="10PD9s" />
@@ -172,36 +191,28 @@
           <property role="2Ry0Am" value=".." />
           <node concept="2Ry0Ak" id="4MDOjos4th6" role="2Ry0An">
             <property role="2Ry0Am" value=".." />
+            <node concept="2Ry0Ak" id="5gFsbf33T7t" role="2Ry0An">
+              <property role="2Ry0Am" value=".." />
+            </node>
           </node>
         </node>
       </node>
     </node>
     <node concept="398rNT" id="42jqVeFkUtk" role="1l3spd">
       <property role="TrG5h" value="mps.home" />
-      <node concept="398BVA" id="42jqVeFkVem" role="398pKh">
-        <ref role="398BVh" node="42jqVeFkUG2" resolve="mbeddr.formal.home" />
-        <node concept="2Ry0Ak" id="6adXBxxVRT2" role="iGT6I">
-          <property role="2Ry0Am" value=".." />
-          <node concept="2Ry0Ak" id="2DcSMg46M8_" role="2Ry0An">
-            <property role="2Ry0Am" value=".." />
-            <node concept="2Ry0Ak" id="2Ttn9EOyTQv" role="2Ry0An">
-              <property role="2Ry0Am" value="MPS_2019_2_3_mbeddr_formal" />
-            </node>
-          </node>
-        </node>
-      </node>
     </node>
     <node concept="398rNT" id="6mm$FLYQyYs" role="1l3spd">
       <property role="TrG5h" value="mpsbasics.code" />
-      <node concept="398BVA" id="4MDOjos4ufk" role="398pKh">
+      <node concept="55IIr" id="5gFsbf33U54" role="398pKh" />
+    </node>
+    <node concept="398rNT" id="5gFsbf33UIa" role="1l3spd">
+      <property role="TrG5h" value="dependencies.root" />
+      <node concept="398BVA" id="5gFsbf33VFM" role="398pKh">
         <ref role="398BVh" node="42jqVeFkUG2" resolve="mbeddr.formal.home" />
-        <node concept="2Ry0Ak" id="4MDOjos4ufr" role="iGT6I">
-          <property role="2Ry0Am" value="code" />
-          <node concept="2Ry0Ak" id="4MDOjos4ufs" role="2Ry0An">
-            <property role="2Ry0Am" value="languages" />
-            <node concept="2Ry0Ak" id="3jaLROLwoKP" role="2Ry0An">
-              <property role="2Ry0Am" value="com.mpsbasics" />
-            </node>
+        <node concept="2Ry0Ak" id="5gFsbf33W9u" role="iGT6I">
+          <property role="2Ry0Am" value="build" />
+          <node concept="2Ry0Ak" id="5gFsbf33WVH" role="2Ry0An">
+            <property role="2Ry0Am" value="dependencies" />
           </node>
         </node>
       </node>
@@ -209,31 +220,72 @@
     <node concept="2kB4xC" id="4aeOpjlAy7f" role="1l3spd">
       <property role="TrG5h" value="version" />
       <node concept="aVJcg" id="4aeOpjlAysR" role="aVJcv">
-        <node concept="NbPM2" id="4aeOpjlAysQ" role="aVJcq">
-          <node concept="3Mxwew" id="4aeOpjlAysP" role="3MwsjC">
-            <property role="3MwjfP" value="2019-10-11" />
-          </node>
-        </node>
+        <node concept="NbPM2" id="4aeOpjlAysQ" role="aVJcq" />
       </node>
     </node>
     <node concept="1l3spV" id="42jqVeFkUvc" role="1l3spN">
-      <node concept="m$_wl" id="wUJmWCyrgV" role="39821P">
-        <ref role="m_rDy" node="42jqVeFkUv3" resolve="com.mpsbasics" />
-        <node concept="pUk6x" id="wUJmWCyrJM" role="pUk7w" />
-        <node concept="398223" id="wUJmWCzUGy" role="39821P">
-          <node concept="3_J27D" id="wUJmWCzUGz" role="Nbhlr">
-            <node concept="3Mxwew" id="wUJmWCzUGC" role="3MwsjC">
+      <node concept="m$_wl" id="5gFsbf345XQ" role="39821P">
+        <ref role="m_rDy" node="5gFsbf342Kk" resolve="com.mpsbasics.build" />
+        <node concept="pUk6x" id="5gFsbf346AY" role="pUk7w" />
+      </node>
+      <node concept="m$_wl" id="6hyv0iVPlE_" role="39821P">
+        <ref role="m_rDy" node="6hyv0iVPlE4" resolve="com.mpsbasics" />
+        <node concept="398223" id="6hyv0iVPlGW" role="39821P">
+          <node concept="3_J27D" id="6hyv0iVPlUb" role="Nbhlr">
+            <node concept="3Mxwew" id="6hyv0iVPm70" role="3MwsjC">
               <property role="3MwjfP" value="lib" />
             </node>
           </node>
-          <node concept="2HvfSZ" id="wUJmWCzVbr" role="39821P">
-            <node concept="398BVA" id="wUJmWCzWR9" role="2HvfZ0">
+          <node concept="2HvfSZ" id="7mFgjcXq$$3" role="39821P">
+            <node concept="398BVA" id="7mFgjcXq$Je" role="2HvfZ0">
               <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="wUJmWCzWRa" role="iGT6I">
+              <node concept="2Ry0Ak" id="7mFgjcXq$Jf" role="iGT6I">
                 <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="wUJmWCzWRb" role="2Ry0An">
+                <node concept="2Ry0Ak" id="7mFgjcXq$Jg" role="2Ry0An">
                   <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="wUJmWCzWRc" role="2Ry0An">
+                  <node concept="2Ry0Ak" id="7mFgjcXq$Jh" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2HvfSZ" id="1hVhF3lkf3q" role="39821P">
+            <node concept="398BVA" id="1hVhF3lkfdq" role="2HvfZ0">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="1hVhF3lkfmQ" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="1hVhF3lkfoZ" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.pdfbox" />
+                  <node concept="2Ry0Ak" id="1hVhF3lkfqk" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2HvfSZ" id="2wSfKqy9mOe" role="39821P">
+            <node concept="398BVA" id="2wSfKqy9n1s" role="2HvfZ0">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="2wSfKqy9ne6" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="2wSfKqy9ngd" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
+                  <node concept="2Ry0Ak" id="2wSfKqy9ngE" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2HvfSZ" id="36zCbqqqdlR" role="39821P">
+            <node concept="398BVA" id="36zCbqqqdEw" role="2HvfZ0">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="36zCbqqqdZ9" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="36zCbqqqe9S" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.langchain4j" />
+                  <node concept="2Ry0Ak" id="36zCbqqqekB" role="2Ry0An">
                     <property role="2Ry0Am" value="lib" />
                   </node>
                 </node>
@@ -241,10 +293,11 @@
             </node>
           </node>
         </node>
+        <node concept="pUk6x" id="6hyv0iVPlGX" role="pUk7w" />
       </node>
-      <node concept="m$_wl" id="2MrvZqtDm59" role="39821P">
+      <node concept="m$_wl" id="2MrvZqtGPu8" role="39821P">
         <ref role="m_rDy" node="2MrvZqtDklV" resolve="com.mpsbasics.testutils" />
-        <node concept="pUk6x" id="2MrvZqtDm5a" role="pUk7w" />
+        <node concept="pUk6x" id="2MrvZqtGPuh" role="pUk7w" />
       </node>
       <node concept="L2wRC" id="wUJmWCwVZN" role="39821P">
         <ref role="L2wRA" node="5jdn85oHU1h" resolve="com.mpsbasics.build" />
@@ -261,28 +314,79 @@
       <property role="1wOHq$" value="true" />
       <property role="3Ej$Sc" value="true" />
     </node>
-    <node concept="m$_wf" id="42jqVeFkUv3" role="3989C9">
-      <property role="m$_wk" value="com.mpsbasics" />
-      <node concept="3_J27D" id="42jqVeFkUv4" role="m$_yQ">
-        <node concept="3Mxwew" id="42jqVeFkUv5" role="3MwsjC">
-          <property role="3MwjfP" value="com.mpsbasics" />
+    <node concept="m$_wf" id="5gFsbf342Kk" role="3989C9">
+      <property role="m$_wk" value="com.mpsbasics.build" />
+      <node concept="3_J27D" id="5gFsbf342Km" role="m$_yQ">
+        <node concept="3Mxwew" id="5gFsbf344n6" role="3MwsjC">
+          <property role="3MwjfP" value="com.mpsbasics.build" />
         </node>
       </node>
-      <node concept="3_J27D" id="42jqVeFkUv6" role="m$_w8">
-        <node concept="3Mxwey" id="4aeOpjlAyy0" role="3MwsjC">
+      <node concept="3_J27D" id="5gFsbf342Ko" role="m_cZH">
+        <node concept="3Mxwew" id="5gFsbf344n7" role="3MwsjC">
+          <property role="3MwjfP" value="com.mpsbasics.build" />
+        </node>
+      </node>
+      <node concept="3_J27D" id="5gFsbf342Kq" role="m$_w8">
+        <node concept="3Mxwey" id="5gFsbf344FE" role="3MwsjC">
           <ref role="3Mxwex" node="4aeOpjlAy7f" resolve="version" />
         </node>
       </node>
-      <node concept="m$f5U" id="42jqVeFkUv8" role="m$_yh">
-        <ref role="m$f5T" node="42jqVeFkUv2" resolve="com.mpsbasics.docx4j" />
+      <node concept="m$_yB" id="5gFsbf3450d" role="m$_yh">
+        <ref role="m$_yA" node="5jdn85oHU1h" resolve="com.mpsbasics.build" />
       </node>
-      <node concept="m$_yC" id="42jqVeFkUv9" role="m$_yJ">
-        <ref role="m$_y1" to="ffeo:4k71ibbKLe8" resolve="jetbrains.mps.core" />
+      <node concept="m$_yC" id="5gFsbf345kK" role="m$_yJ">
+        <ref role="m$_y1" to="al5i:33r_JpZ6k_l" resolve="com.mbeddr.platform.build" />
       </node>
-      <node concept="3_J27D" id="42jqVeFkUva" role="m_cZH">
-        <node concept="3Mxwew" id="42jqVeFkUvb" role="3MwsjC">
+    </node>
+    <node concept="m$_wf" id="6hyv0iVPlE4" role="3989C9">
+      <property role="m$_wk" value="com.mpsbasics" />
+      <node concept="3_J27D" id="6hyv0iVPlEG" role="m$_yQ">
+        <node concept="3Mxwew" id="6hyv0iVPlH5" role="3MwsjC">
           <property role="3MwjfP" value="com.mpsbasics" />
         </node>
+      </node>
+      <node concept="3_J27D" id="6hyv0iVPlEH" role="m_cZH">
+        <node concept="3Mxwew" id="6hyv0iVPlH6" role="3MwsjC">
+          <property role="3MwjfP" value="com.mpsbasics" />
+        </node>
+      </node>
+      <node concept="3_J27D" id="6hyv0iVPlEI" role="m$_w8">
+        <node concept="3Mxwey" id="6hyv0iVPlH7" role="3MwsjC">
+          <ref role="3Mxwex" node="4aeOpjlAy7f" resolve="version" />
+        </node>
+      </node>
+      <node concept="m$f5U" id="6hyv0iVPlEJ" role="m$_yh">
+        <ref role="m$f5T" node="6hyv0iVPlEb" resolve="com.mpsbasics" />
+      </node>
+      <node concept="m$_yC" id="6hyv0iVPlEK" role="m$_yJ">
+        <ref role="m$_y1" to="ffeo:4k71ibbKLe8" resolve="jetbrains.mps.core" />
+      </node>
+      <node concept="m$_yC" id="6hyv0iVPlEL" role="m$_yJ">
+        <ref role="m$_y1" to="90a9:4p3FRivDLPy" resolve="org.apache.commons" />
+      </node>
+      <node concept="m$_yC" id="2u7UHDCnTyY" role="m$_yJ">
+        <ref role="m$_y1" to="al5i:64SK4bcJmGP" resolve="com.mbeddr.mpsutil.plantuml" />
+      </node>
+      <node concept="m$_yC" id="36zCbqqqepY" role="m$_yJ">
+        <ref role="m$_y1" to="al5i:NMVW79y25x" resolve="com.mbeddr.mpsutil.json" />
+      </node>
+      <node concept="m$_yC" id="3TNxfDZ8qPv" role="m$_yJ">
+        <ref role="m$_y1" to="al5i:Vtr7jyB0oM" resolve="com.mbeddr.mpsutil.filepicker" />
+      </node>
+      <node concept="m$_yC" id="hKYaKNdjV$" role="m$_yJ">
+        <ref role="m$_y1" to="90a9:3$A0JaN5ezp" resolve="MPS.ThirdParty" />
+      </node>
+      <node concept="m$_yC" id="5Gu43O52lhT" role="m$_yJ">
+        <ref role="m$_y1" to="90a9:6SVXTgIe8wD" resolve="de.itemis.mps.celllayout" />
+      </node>
+      <node concept="m$_yC" id="6FJpOMBt7hW" role="m$_yJ">
+        <ref role="m$_y1" to="90a9:1sO539bGQvt" resolve="de.slisson.mps.richtext" />
+      </node>
+      <node concept="m$_yC" id="5mv1DnKbokD" role="m$_yJ">
+        <ref role="m$_y1" to="ffeo:4O0hKJpmtq1" resolve="jetbrains.mps.trove" />
+      </node>
+      <node concept="m$_yC" id="5xR2VPu2qTq" role="m$_yJ">
+        <ref role="m$_y1" to="ffeo:6Hpa5co69BH" resolve="jetbrains.mps.editor.tooltips" />
       </node>
     </node>
     <node concept="m$_wf" id="2MrvZqtDklV" role="3989C9">
@@ -297,8 +401,8 @@
           <ref role="3Mxwex" node="4aeOpjlAy7f" resolve="version" />
         </node>
       </node>
-      <node concept="m$f5U" id="2MrvZqtDlpY" role="m$_yh">
-        <ref role="m$f5T" node="2MrvZqtDg3S" resolve="com.mpsbasics.docx4j.testutils" />
+      <node concept="m$_yB" id="5gFsbf33XTn" role="m$_yh">
+        <ref role="m$_yA" node="5gFsbf33R6e" resolve="com.mpsbasics.docx4j.testutils" />
       </node>
       <node concept="3_J27D" id="2MrvZqtDkm2" role="m_cZH">
         <node concept="3Mxwew" id="2MrvZqtDkm3" role="3MwsjC">
@@ -306,156 +410,169 @@
         </node>
       </node>
       <node concept="m$_yC" id="2MrvZqtDlR$" role="m$_yJ">
-        <ref role="m$_y1" node="42jqVeFkUv3" resolve="com.mpsbasics" />
+        <ref role="m$_y1" node="6hyv0iVPlE4" resolve="com.mpsbasics" />
       </node>
     </node>
-    <node concept="2G$12M" id="42jqVeFkUv2" role="3989C9">
-      <property role="TrG5h" value="com.mpsbasics.docx4j" />
-      <node concept="1E1JtA" id="1V$lRyiUHLD" role="2G$12L">
+    <node concept="2G$12M" id="6hyv0iVPlEb" role="3989C9">
+      <property role="TrG5h" value="com.mpsbasics" />
+      <node concept="1E1JtA" id="6hyv0iVPlFH" role="2G$12L">
         <property role="BnDLt" value="true" />
         <property role="TrG5h" value="com.mpsbasics.docx4j.core" />
         <property role="3LESm3" value="fdd69818-de3d-4ebf-9ec6-17ea152db151" />
-        <node concept="398BVA" id="1V$lRyiUHLE" role="3LF7KH">
+        <node concept="398BVA" id="6hyv0iVPlHq" role="3LF7KH">
           <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
-          <node concept="2Ry0Ak" id="1V$lRyiUHLF" role="iGT6I">
+          <node concept="2Ry0Ak" id="6hyv0iVPlUg" role="iGT6I">
             <property role="2Ry0Am" value="solutions" />
-            <node concept="2Ry0Ak" id="1V$lRyiUHLG" role="2Ry0An">
+            <node concept="2Ry0Ak" id="6hyv0iVPm75" role="2Ry0An">
               <property role="2Ry0Am" value="com.mpsbasics.docx4j.core" />
-              <node concept="2Ry0Ak" id="3jaLROLwoZJ" role="2Ry0An">
+              <node concept="2Ry0Ak" id="6hyv0iVPme5" role="2Ry0An">
                 <property role="2Ry0Am" value="com.mpsbasics.docx4j.core.msd" />
               </node>
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="1V$lRyiUHLI" role="3bR37C">
-          <node concept="3bR9La" id="1V$lRyiUHLJ" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1ia2VB5guYy" resolve="MPS.IDEA" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="1V$lRyiUHLQ" role="3bR37C">
-          <node concept="3bR9La" id="1V$lRyiUHLR" role="1SiIV1">
+        <node concept="1SiIV0" id="6hyv0iVPlHr" role="3bR37C">
+          <node concept="3bR9La" id="6hyv0iVPlUh" role="1SiIV1">
             <ref role="3bR37D" to="ffeo:1H905DlDUSw" resolve="MPS.OpenAPI" />
           </node>
         </node>
-        <node concept="1SiIV0" id="1V$lRyiUHLU" role="3bR37C">
-          <node concept="3bR9La" id="1V$lRyiUHLV" role="1SiIV1">
+        <node concept="1SiIV0" id="6hyv0iVPlHs" role="3bR37C">
+          <node concept="3bR9La" id="6hyv0iVPlUi" role="1SiIV1">
             <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
           </node>
         </node>
-        <node concept="1SiIV0" id="1V$lRyiUHLY" role="3bR37C">
-          <node concept="3bR9La" id="1V$lRyiUHLZ" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1TaHNgiIbIZ" resolve="MPS.Editor" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="1V$lRyiUHM2" role="3bR37C">
-          <node concept="3bR9La" id="1V$lRyiUHM3" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1TaHNgiIbIQ" resolve="MPS.Core" />
-          </node>
-        </node>
-        <node concept="3rtmxn" id="7RhjhI7eyqH" role="3bR31x">
-          <node concept="3LXTmp" id="7RhjhI7eyqI" role="3rtmxm">
-            <node concept="398BVA" id="7RhjhI7eyqJ" role="3LXTmr">
-              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="7RhjhI7eyqK" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="7RhjhI7eyqL" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mbeddr.formal.nusmv.pluginSolution" />
-                  <node concept="2Ry0Ak" id="7RhjhI7eyqM" role="2Ry0An">
-                    <property role="2Ry0Am" value="source_gen" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="7RhjhI7eyqN" role="3LXTna">
-              <property role="3qWCbO" value="com/mbeddr/formal/nusmv/pluginSolution/plugin/*.png" />
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="3jaLROLwoZL" role="3bR37C">
-          <node concept="3bR9La" id="3jaLROLwoZM" role="1SiIV1">
+        <node concept="1SiIV0" id="6hyv0iVPlHt" role="3bR37C">
+          <node concept="3bR9La" id="6hyv0iVPlUj" role="1SiIV1">
             <ref role="3bR37D" to="ffeo:44LXwdzyvTi" resolve="Annotations" />
           </node>
         </node>
-        <node concept="1SiIV0" id="3jaLROLwoZN" role="3bR37C">
-          <node concept="3bR9La" id="3jaLROLwoZO" role="1SiIV1">
+        <node concept="1SiIV0" id="6hyv0iVPlHu" role="3bR37C">
+          <node concept="3bR9La" id="6hyv0iVPlUk" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1ia2VB5guYy" resolve="MPS.IDEA" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6hyv0iVPlHv" role="3bR37C">
+          <node concept="3bR9La" id="6hyv0iVPlUl" role="1SiIV1">
             <ref role="3bR37D" to="ffeo:7Kfy9QB6L4X" resolve="jetbrains.mps.lang.editor" />
           </node>
         </node>
-        <node concept="1SiIV0" id="3jaLROLwoZP" role="3bR37C">
-          <node concept="3bR9La" id="3jaLROLwoZQ" role="1SiIV1">
+        <node concept="1SiIV0" id="6hyv0iVPlHw" role="3bR37C">
+          <node concept="3bR9La" id="6hyv0iVPlUm" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1TaHNgiIbIZ" resolve="MPS.Editor" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6hyv0iVPlHx" role="3bR37C">
+          <node concept="3bR9La" id="6hyv0iVPlUn" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1TaHNgiIbIQ" resolve="MPS.Core" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6hyv0iVPlHy" role="3bR37C">
+          <node concept="3bR9La" id="6hyv0iVPlUo" role="1SiIV1">
             <ref role="3bR37D" to="ffeo:7Kfy9QB6LaO" resolve="jetbrains.mps.lang.structure" />
           </node>
         </node>
-        <node concept="1SiIV0" id="3jaLROLwoZR" role="3bR37C">
-          <node concept="3bR9La" id="3jaLROLwoZS" role="1SiIV1">
+        <node concept="1SiIV0" id="6hyv0iVPlHz" role="3bR37C">
+          <node concept="3bR9La" id="6hyv0iVPlUp" role="1SiIV1">
             <ref role="3bR37D" to="ffeo:3MI1gu0QouH" resolve="jetbrains.mps.editor.runtime" />
           </node>
         </node>
-        <node concept="1SiIV0" id="3jaLROLwq5n" role="3bR37C">
-          <node concept="3bR9La" id="3jaLROLwq5o" role="1SiIV1">
-            <ref role="3bR37D" node="42jqVeFkUuP" resolve="com.mpsbasics.docx4j.lib" />
+        <node concept="1SiIV0" id="6hyv0iVPlH$" role="3bR37C">
+          <node concept="3bR9La" id="6hyv0iVPlUq" role="1SiIV1">
+            <ref role="3bR37D" node="6hyv0iVPlFI" resolve="com.mpsbasics.docx4j.lib" />
           </node>
         </node>
-        <node concept="1BupzO" id="7ZEfF1UiyDo" role="3bR31x">
+        <node concept="1BupzO" id="6hyv0iVPlH_" role="3bR31x">
           <property role="3ZfqAx" value="models" />
           <property role="1Hdu6h" value="true" />
           <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="7ZEfF1UiyDp" role="1HemKq">
-            <node concept="398BVA" id="7ZEfF1UiyDd" role="3LXTmr">
+          <node concept="3LXTmp" id="6hyv0iVPlUr" role="1HemKq">
+            <node concept="398BVA" id="6hyv0iVPm76" role="3LXTmr">
               <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="7ZEfF1UiyDe" role="iGT6I">
+              <node concept="2Ry0Ak" id="6hyv0iVPme6" role="iGT6I">
                 <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="7ZEfF1UiyDf" role="2Ry0An">
+                <node concept="2Ry0Ak" id="6hyv0iVPmiT" role="2Ry0An">
                   <property role="2Ry0Am" value="com.mpsbasics.docx4j.core" />
-                  <node concept="2Ry0Ak" id="7ZEfF1UiyDg" role="2Ry0An">
+                  <node concept="2Ry0Ak" id="6hyv0iVPmm4" role="2Ry0An">
                     <property role="2Ry0Am" value="models" />
                   </node>
                 </node>
               </node>
             </node>
-            <node concept="3qWCbU" id="7ZEfF1UiyDq" role="3LXTna">
+            <node concept="3qWCbU" id="6hyv0iVPm77" role="3LXTna">
               <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="5Z1A3yy1nIm" role="3bR37C">
-          <node concept="3bR9La" id="5Z1A3yy1nIn" role="1SiIV1">
+        <node concept="3rtmxn" id="6hyv0iVPlHA" role="3bR31x">
+          <node concept="3LXTmp" id="6hyv0iVPlUs" role="3rtmxm">
+            <node concept="3qWCbU" id="6hyv0iVPm78" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="6hyv0iVPm79" role="3LXTmr">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="6hyv0iVPme7" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="6hyv0iVPmiU" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.core" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="4ziKDEng_E7" role="3bR37C">
+          <node concept="3bR9La" id="4ziKDEng_E8" role="1SiIV1">
             <ref role="3bR37D" to="ffeo:1TaHNgiIbJb" resolve="MPS.Platform" />
           </node>
         </node>
       </node>
-      <node concept="1E1JtA" id="42jqVeFkUuP" role="2G$12L">
+      <node concept="1E1JtA" id="6hyv0iVPlFI" role="2G$12L">
         <property role="BnDLt" value="true" />
         <property role="TrG5h" value="com.mpsbasics.docx4j.lib" />
         <property role="3LESm3" value="71bb25aa-20fa-4c18-8954-1b176576f52d" />
-        <node concept="398BVA" id="6mm$FLYQztb" role="3LF7KH">
+        <node concept="398BVA" id="6hyv0iVPlHB" role="3LF7KH">
           <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
-          <node concept="2Ry0Ak" id="6mm$FLYQztg" role="iGT6I">
+          <node concept="2Ry0Ak" id="6hyv0iVPlUt" role="iGT6I">
             <property role="2Ry0Am" value="solutions" />
-            <node concept="2Ry0Ak" id="6mm$FLYQzth" role="2Ry0An">
+            <node concept="2Ry0Ak" id="6hyv0iVPm7a" role="2Ry0An">
               <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-              <node concept="2Ry0Ak" id="3jaLROLwp0b" role="2Ry0An">
+              <node concept="2Ry0Ak" id="6hyv0iVPme8" role="2Ry0An">
                 <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib.msd" />
               </node>
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="42jqVeFl1HO" role="3bR37C">
-          <node concept="3bR9La" id="42jqVeFl1HP" role="1SiIV1">
+        <node concept="1SiIV0" id="6hyv0iVPlHC" role="3bR37C">
+          <node concept="3bR9La" id="6hyv0iVPlUu" role="1SiIV1">
             <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
           </node>
         </node>
-        <node concept="1SiIV0" id="2fGryx5rwdQ" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rwdR" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rwdD" role="1BurEY">
+        <node concept="3rtmxn" id="6hyv0iVPlIc" role="3bR31x">
+          <node concept="3LXTmp" id="6hyv0iVPlV2" role="3rtmxm">
+            <node concept="3qWCbU" id="6hyv0iVPm7H" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="6hyv0iVPm7I" role="3LXTmr">
               <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rwdE" role="iGT6I">
+              <node concept="2Ry0Ak" id="6hyv0iVPmeF" role="iGT6I">
                 <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rwdF" role="2Ry0An">
+                <node concept="2Ry0Ak" id="6hyv0iVPmjt" role="2Ry0An">
                   <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rwdG" role="2Ry0An">
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2fGryx5rF4o" role="3bR37C">
+          <node concept="1BurEX" id="2fGryx5rF4p" role="1SiIV1">
+            <node concept="398BVA" id="2fGryx5rF4b" role="1BurEY">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="2fGryx5rF4c" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="2fGryx5rF4d" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
+                  <node concept="2Ry0Ak" id="2fGryx5rF4e" role="2Ry0An">
                     <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rwdH" role="2Ry0An">
+                    <node concept="2Ry0Ak" id="2fGryx5rF4f" role="2Ry0An">
                       <property role="2Ry0Am" value="antlr-runtime.jar" />
                     </node>
                   </node>
@@ -464,17 +581,17 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="2fGryx5rwe5" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rwe6" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rwdS" role="1BurEY">
+        <node concept="1SiIV0" id="2fGryx5rF4B" role="3bR37C">
+          <node concept="1BurEX" id="2fGryx5rF4C" role="1SiIV1">
+            <node concept="398BVA" id="2fGryx5rF4q" role="1BurEY">
               <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rwdT" role="iGT6I">
+              <node concept="2Ry0Ak" id="2fGryx5rF4r" role="iGT6I">
                 <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rwdU" role="2Ry0An">
+                <node concept="2Ry0Ak" id="2fGryx5rF4s" role="2Ry0An">
                   <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rwdV" role="2Ry0An">
+                  <node concept="2Ry0Ak" id="2fGryx5rF4t" role="2Ry0An">
                     <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rwdW" role="2Ry0An">
+                    <node concept="2Ry0Ak" id="2fGryx5rF4u" role="2Ry0An">
                       <property role="2Ry0Am" value="antlr.jar" />
                     </node>
                   </node>
@@ -483,17 +600,17 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="2fGryx5rwek" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rwel" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rwe7" role="1BurEY">
+        <node concept="1SiIV0" id="2fGryx5rF4Q" role="3bR37C">
+          <node concept="1BurEX" id="2fGryx5rF4R" role="1SiIV1">
+            <node concept="398BVA" id="2fGryx5rF4D" role="1BurEY">
               <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rwe8" role="iGT6I">
+              <node concept="2Ry0Ak" id="2fGryx5rF4E" role="iGT6I">
                 <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rwe9" role="2Ry0An">
+                <node concept="2Ry0Ak" id="2fGryx5rF4F" role="2Ry0An">
                   <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rwea" role="2Ry0An">
+                  <node concept="2Ry0Ak" id="2fGryx5rF4G" role="2Ry0An">
                     <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rweb" role="2Ry0An">
+                    <node concept="2Ry0Ak" id="2fGryx5rF4H" role="2Ry0An">
                       <property role="2Ry0Am" value="checker-qual.jar" />
                     </node>
                   </node>
@@ -502,17 +619,17 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="2fGryx5rwez" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rwe$" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rwem" role="1BurEY">
+        <node concept="1SiIV0" id="2fGryx5rF55" role="3bR37C">
+          <node concept="1BurEX" id="2fGryx5rF56" role="1SiIV1">
+            <node concept="398BVA" id="2fGryx5rF4S" role="1BurEY">
               <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rwen" role="iGT6I">
+              <node concept="2Ry0Ak" id="2fGryx5rF4T" role="iGT6I">
                 <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rweo" role="2Ry0An">
+                <node concept="2Ry0Ak" id="2fGryx5rF4U" role="2Ry0An">
                   <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rwep" role="2Ry0An">
+                  <node concept="2Ry0Ak" id="2fGryx5rF4V" role="2Ry0An">
                     <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rweq" role="2Ry0An">
+                    <node concept="2Ry0Ak" id="2fGryx5rF4W" role="2Ry0An">
                       <property role="2Ry0Am" value="commons-codec.jar" />
                     </node>
                   </node>
@@ -521,17 +638,17 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="2fGryx5rweM" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rweN" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rwe_" role="1BurEY">
+        <node concept="1SiIV0" id="2fGryx5rF5k" role="3bR37C">
+          <node concept="1BurEX" id="2fGryx5rF5l" role="1SiIV1">
+            <node concept="398BVA" id="2fGryx5rF57" role="1BurEY">
               <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rweA" role="iGT6I">
+              <node concept="2Ry0Ak" id="2fGryx5rF58" role="iGT6I">
                 <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rweB" role="2Ry0An">
+                <node concept="2Ry0Ak" id="2fGryx5rF59" role="2Ry0An">
                   <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rweC" role="2Ry0An">
+                  <node concept="2Ry0Ak" id="2fGryx5rF5a" role="2Ry0An">
                     <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rweD" role="2Ry0An">
+                    <node concept="2Ry0Ak" id="2fGryx5rF5b" role="2Ry0An">
                       <property role="2Ry0Am" value="commons-compress.jar" />
                     </node>
                   </node>
@@ -540,17 +657,17 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="2fGryx5rwf1" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rwf2" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rweO" role="1BurEY">
+        <node concept="1SiIV0" id="2fGryx5rF5z" role="3bR37C">
+          <node concept="1BurEX" id="2fGryx5rF5$" role="1SiIV1">
+            <node concept="398BVA" id="2fGryx5rF5m" role="1BurEY">
               <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rweP" role="iGT6I">
+              <node concept="2Ry0Ak" id="2fGryx5rF5n" role="iGT6I">
                 <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rweQ" role="2Ry0An">
+                <node concept="2Ry0Ak" id="2fGryx5rF5o" role="2Ry0An">
                   <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rweR" role="2Ry0An">
+                  <node concept="2Ry0Ak" id="2fGryx5rF5p" role="2Ry0An">
                     <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rweS" role="2Ry0An">
+                    <node concept="2Ry0Ak" id="2fGryx5rF5q" role="2Ry0An">
                       <property role="2Ry0Am" value="commons-io.jar" />
                     </node>
                   </node>
@@ -559,17 +676,17 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="2fGryx5rwfg" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rwfh" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rwf3" role="1BurEY">
+        <node concept="1SiIV0" id="2fGryx5rF5M" role="3bR37C">
+          <node concept="1BurEX" id="2fGryx5rF5N" role="1SiIV1">
+            <node concept="398BVA" id="2fGryx5rF5_" role="1BurEY">
               <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rwf4" role="iGT6I">
+              <node concept="2Ry0Ak" id="2fGryx5rF5A" role="iGT6I">
                 <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rwf5" role="2Ry0An">
+                <node concept="2Ry0Ak" id="2fGryx5rF5B" role="2Ry0An">
                   <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rwf6" role="2Ry0An">
+                  <node concept="2Ry0Ak" id="2fGryx5rF5C" role="2Ry0An">
                     <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rwf7" role="2Ry0An">
+                    <node concept="2Ry0Ak" id="2fGryx5rF5D" role="2Ry0An">
                       <property role="2Ry0Am" value="commons-lang3.jar" />
                     </node>
                   </node>
@@ -578,17 +695,17 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="2fGryx5rwfv" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rwfw" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rwfi" role="1BurEY">
+        <node concept="1SiIV0" id="2fGryx5rF61" role="3bR37C">
+          <node concept="1BurEX" id="2fGryx5rF62" role="1SiIV1">
+            <node concept="398BVA" id="2fGryx5rF5O" role="1BurEY">
               <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rwfj" role="iGT6I">
+              <node concept="2Ry0Ak" id="2fGryx5rF5P" role="iGT6I">
                 <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rwfk" role="2Ry0An">
+                <node concept="2Ry0Ak" id="2fGryx5rF5Q" role="2Ry0An">
                   <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rwfl" role="2Ry0An">
+                  <node concept="2Ry0Ak" id="2fGryx5rF5R" role="2Ry0An">
                     <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rwfm" role="2Ry0An">
+                    <node concept="2Ry0Ak" id="2fGryx5rF5S" role="2Ry0An">
                       <property role="2Ry0Am" value="docx4j-core.jar" />
                     </node>
                   </node>
@@ -597,17 +714,17 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="2fGryx5rwfI" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rwfJ" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rwfx" role="1BurEY">
+        <node concept="1SiIV0" id="2fGryx5rF6g" role="3bR37C">
+          <node concept="1BurEX" id="2fGryx5rF6h" role="1SiIV1">
+            <node concept="398BVA" id="2fGryx5rF63" role="1BurEY">
               <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rwfy" role="iGT6I">
+              <node concept="2Ry0Ak" id="2fGryx5rF64" role="iGT6I">
                 <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rwfz" role="2Ry0An">
+                <node concept="2Ry0Ak" id="2fGryx5rF65" role="2Ry0An">
                   <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rwf$" role="2Ry0An">
+                  <node concept="2Ry0Ak" id="2fGryx5rF66" role="2Ry0An">
                     <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rwf_" role="2Ry0An">
+                    <node concept="2Ry0Ak" id="2fGryx5rF67" role="2Ry0An">
                       <property role="2Ry0Am" value="docx4j-JAXB-MOXy.jar" />
                     </node>
                   </node>
@@ -616,17 +733,17 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="2fGryx5rwfX" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rwfY" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rwfK" role="1BurEY">
+        <node concept="1SiIV0" id="2fGryx5rF6v" role="3bR37C">
+          <node concept="1BurEX" id="2fGryx5rF6w" role="1SiIV1">
+            <node concept="398BVA" id="2fGryx5rF6i" role="1BurEY">
               <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rwfL" role="iGT6I">
+              <node concept="2Ry0Ak" id="2fGryx5rF6j" role="iGT6I">
                 <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rwfM" role="2Ry0An">
+                <node concept="2Ry0Ak" id="2fGryx5rF6k" role="2Ry0An">
                   <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rwfN" role="2Ry0An">
+                  <node concept="2Ry0Ak" id="2fGryx5rF6l" role="2Ry0An">
                     <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rwfO" role="2Ry0An">
+                    <node concept="2Ry0Ak" id="2fGryx5rF6m" role="2Ry0An">
                       <property role="2Ry0Am" value="docx4j-openxml-objects-pml.jar" />
                     </node>
                   </node>
@@ -635,17 +752,17 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="2fGryx5rwgc" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rwgd" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rwfZ" role="1BurEY">
+        <node concept="1SiIV0" id="2fGryx5rF6I" role="3bR37C">
+          <node concept="1BurEX" id="2fGryx5rF6J" role="1SiIV1">
+            <node concept="398BVA" id="2fGryx5rF6x" role="1BurEY">
               <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rwg0" role="iGT6I">
+              <node concept="2Ry0Ak" id="2fGryx5rF6y" role="iGT6I">
                 <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rwg1" role="2Ry0An">
+                <node concept="2Ry0Ak" id="2fGryx5rF6z" role="2Ry0An">
                   <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rwg2" role="2Ry0An">
+                  <node concept="2Ry0Ak" id="2fGryx5rF6$" role="2Ry0An">
                     <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rwg3" role="2Ry0An">
+                    <node concept="2Ry0Ak" id="2fGryx5rF6_" role="2Ry0An">
                       <property role="2Ry0Am" value="docx4j-openxml-objects-sml.jar" />
                     </node>
                   </node>
@@ -654,17 +771,17 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="2fGryx5rwgr" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rwgs" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rwge" role="1BurEY">
+        <node concept="1SiIV0" id="2fGryx5rF6X" role="3bR37C">
+          <node concept="1BurEX" id="2fGryx5rF6Y" role="1SiIV1">
+            <node concept="398BVA" id="2fGryx5rF6K" role="1BurEY">
               <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rwgf" role="iGT6I">
+              <node concept="2Ry0Ak" id="2fGryx5rF6L" role="iGT6I">
                 <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rwgg" role="2Ry0An">
+                <node concept="2Ry0Ak" id="2fGryx5rF6M" role="2Ry0An">
                   <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rwgh" role="2Ry0An">
+                  <node concept="2Ry0Ak" id="2fGryx5rF6N" role="2Ry0An">
                     <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rwgi" role="2Ry0An">
+                    <node concept="2Ry0Ak" id="2fGryx5rF6O" role="2Ry0An">
                       <property role="2Ry0Am" value="docx4j-openxml-objects.jar" />
                     </node>
                   </node>
@@ -673,17 +790,17 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="2fGryx5rwgE" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rwgF" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rwgt" role="1BurEY">
+        <node concept="1SiIV0" id="2fGryx5rF7c" role="3bR37C">
+          <node concept="1BurEX" id="2fGryx5rF7d" role="1SiIV1">
+            <node concept="398BVA" id="2fGryx5rF6Z" role="1BurEY">
               <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rwgu" role="iGT6I">
+              <node concept="2Ry0Ak" id="2fGryx5rF70" role="iGT6I">
                 <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rwgv" role="2Ry0An">
+                <node concept="2Ry0Ak" id="2fGryx5rF71" role="2Ry0An">
                   <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rwgw" role="2Ry0An">
+                  <node concept="2Ry0Ak" id="2fGryx5rF72" role="2Ry0An">
                     <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rwgx" role="2Ry0An">
+                    <node concept="2Ry0Ak" id="2fGryx5rF73" role="2Ry0An">
                       <property role="2Ry0Am" value="error_prone_annotations.jar" />
                     </node>
                   </node>
@@ -692,17 +809,17 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="2fGryx5rwgT" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rwgU" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rwgG" role="1BurEY">
+        <node concept="1SiIV0" id="2fGryx5rF7r" role="3bR37C">
+          <node concept="1BurEX" id="2fGryx5rF7s" role="1SiIV1">
+            <node concept="398BVA" id="2fGryx5rF7e" role="1BurEY">
               <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rwgH" role="iGT6I">
+              <node concept="2Ry0Ak" id="2fGryx5rF7f" role="iGT6I">
                 <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rwgI" role="2Ry0An">
+                <node concept="2Ry0Ak" id="2fGryx5rF7g" role="2Ry0An">
                   <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rwgJ" role="2Ry0An">
+                  <node concept="2Ry0Ak" id="2fGryx5rF7h" role="2Ry0An">
                     <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rwgK" role="2Ry0An">
+                    <node concept="2Ry0Ak" id="2fGryx5rF7i" role="2Ry0An">
                       <property role="2Ry0Am" value="fontbox.jar" />
                     </node>
                   </node>
@@ -711,17 +828,17 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="2fGryx5rwh8" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rwh9" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rwgV" role="1BurEY">
+        <node concept="1SiIV0" id="2fGryx5rF7E" role="3bR37C">
+          <node concept="1BurEX" id="2fGryx5rF7F" role="1SiIV1">
+            <node concept="398BVA" id="2fGryx5rF7t" role="1BurEY">
               <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rwgW" role="iGT6I">
+              <node concept="2Ry0Ak" id="2fGryx5rF7u" role="iGT6I">
                 <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rwgX" role="2Ry0An">
+                <node concept="2Ry0Ak" id="2fGryx5rF7v" role="2Ry0An">
                   <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rwgY" role="2Ry0An">
+                  <node concept="2Ry0Ak" id="2fGryx5rF7w" role="2Ry0An">
                     <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rwgZ" role="2Ry0An">
+                    <node concept="2Ry0Ak" id="2fGryx5rF7x" role="2Ry0An">
                       <property role="2Ry0Am" value="jakarta.activation-api.jar" />
                     </node>
                   </node>
@@ -730,17 +847,17 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="2fGryx5rwhA" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rwhB" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rwhp" role="1BurEY">
+        <node concept="1SiIV0" id="2fGryx5rF88" role="3bR37C">
+          <node concept="1BurEX" id="2fGryx5rF89" role="1SiIV1">
+            <node concept="398BVA" id="2fGryx5rF7V" role="1BurEY">
               <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rwhq" role="iGT6I">
+              <node concept="2Ry0Ak" id="2fGryx5rF7W" role="iGT6I">
                 <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rwhr" role="2Ry0An">
+                <node concept="2Ry0Ak" id="2fGryx5rF7X" role="2Ry0An">
                   <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rwhs" role="2Ry0An">
+                  <node concept="2Ry0Ak" id="2fGryx5rF7Y" role="2Ry0An">
                     <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rwht" role="2Ry0An">
+                    <node concept="2Ry0Ak" id="2fGryx5rF7Z" role="2Ry0An">
                       <property role="2Ry0Am" value="jakarta.mail-api.jar" />
                     </node>
                   </node>
@@ -749,17 +866,17 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="2fGryx5rwi4" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rwi5" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rwhR" role="1BurEY">
+        <node concept="1SiIV0" id="2fGryx5rF8A" role="3bR37C">
+          <node concept="1BurEX" id="2fGryx5rF8B" role="1SiIV1">
+            <node concept="398BVA" id="2fGryx5rF8p" role="1BurEY">
               <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rwhS" role="iGT6I">
+              <node concept="2Ry0Ak" id="2fGryx5rF8q" role="iGT6I">
                 <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rwhT" role="2Ry0An">
+                <node concept="2Ry0Ak" id="2fGryx5rF8r" role="2Ry0An">
                   <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rwhU" role="2Ry0An">
+                  <node concept="2Ry0Ak" id="2fGryx5rF8s" role="2Ry0An">
                     <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rwhV" role="2Ry0An">
+                    <node concept="2Ry0Ak" id="2fGryx5rF8t" role="2Ry0An">
                       <property role="2Ry0Am" value="jakarta.xml.bind-api.jar" />
                     </node>
                   </node>
@@ -768,17 +885,17 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="2fGryx5rwij" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rwik" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rwi6" role="1BurEY">
+        <node concept="1SiIV0" id="2fGryx5rF8P" role="3bR37C">
+          <node concept="1BurEX" id="2fGryx5rF8Q" role="1SiIV1">
+            <node concept="398BVA" id="2fGryx5rF8C" role="1BurEY">
               <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rwi7" role="iGT6I">
+              <node concept="2Ry0Ak" id="2fGryx5rF8D" role="iGT6I">
                 <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rwi8" role="2Ry0An">
+                <node concept="2Ry0Ak" id="2fGryx5rF8E" role="2Ry0An">
                   <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rwi9" role="2Ry0An">
+                  <node concept="2Ry0Ak" id="2fGryx5rF8F" role="2Ry0An">
                     <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rwia" role="2Ry0An">
+                    <node concept="2Ry0Ak" id="2fGryx5rF8G" role="2Ry0An">
                       <property role="2Ry0Am" value="jaxb-svg11.jar" />
                     </node>
                   </node>
@@ -787,17 +904,17 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="2fGryx5rwiy" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rwiz" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rwil" role="1BurEY">
+        <node concept="1SiIV0" id="2fGryx5rF94" role="3bR37C">
+          <node concept="1BurEX" id="2fGryx5rF95" role="1SiIV1">
+            <node concept="398BVA" id="2fGryx5rF8R" role="1BurEY">
               <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rwim" role="iGT6I">
+              <node concept="2Ry0Ak" id="2fGryx5rF8S" role="iGT6I">
                 <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rwin" role="2Ry0An">
+                <node concept="2Ry0Ak" id="2fGryx5rF8T" role="2Ry0An">
                   <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rwio" role="2Ry0An">
+                  <node concept="2Ry0Ak" id="2fGryx5rF8U" role="2Ry0An">
                     <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rwip" role="2Ry0An">
+                    <node concept="2Ry0Ak" id="2fGryx5rF8V" role="2Ry0An">
                       <property role="2Ry0Am" value="jcl-over-slf4j.jar" />
                     </node>
                   </node>
@@ -806,17 +923,17 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="2fGryx5rwiL" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rwiM" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rwi$" role="1BurEY">
+        <node concept="1SiIV0" id="2fGryx5rF9j" role="3bR37C">
+          <node concept="1BurEX" id="2fGryx5rF9k" role="1SiIV1">
+            <node concept="398BVA" id="2fGryx5rF96" role="1BurEY">
               <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rwi_" role="iGT6I">
+              <node concept="2Ry0Ak" id="2fGryx5rF97" role="iGT6I">
                 <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rwiA" role="2Ry0An">
+                <node concept="2Ry0Ak" id="2fGryx5rF98" role="2Ry0An">
                   <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rwiB" role="2Ry0An">
+                  <node concept="2Ry0Ak" id="2fGryx5rF99" role="2Ry0An">
                     <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rwiC" role="2Ry0An">
+                    <node concept="2Ry0Ak" id="2fGryx5rF9a" role="2Ry0An">
                       <property role="2Ry0Am" value="mbassador.jar" />
                     </node>
                   </node>
@@ -825,17 +942,17 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="2fGryx5rwj0" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rwj1" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rwiN" role="1BurEY">
+        <node concept="1SiIV0" id="2fGryx5rF9y" role="3bR37C">
+          <node concept="1BurEX" id="2fGryx5rF9z" role="1SiIV1">
+            <node concept="398BVA" id="2fGryx5rF9l" role="1BurEY">
               <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rwiO" role="iGT6I">
+              <node concept="2Ry0Ak" id="2fGryx5rF9m" role="iGT6I">
                 <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rwiP" role="2Ry0An">
+                <node concept="2Ry0Ak" id="2fGryx5rF9n" role="2Ry0An">
                   <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rwiQ" role="2Ry0An">
+                  <node concept="2Ry0Ak" id="2fGryx5rF9o" role="2Ry0An">
                     <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rwiR" role="2Ry0An">
+                    <node concept="2Ry0Ak" id="2fGryx5rF9p" role="2Ry0An">
                       <property role="2Ry0Am" value="org.eclipse.persistence.asm.jar" />
                     </node>
                   </node>
@@ -844,17 +961,17 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="2fGryx5rwjf" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rwjg" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rwj2" role="1BurEY">
+        <node concept="1SiIV0" id="2fGryx5rF9L" role="3bR37C">
+          <node concept="1BurEX" id="2fGryx5rF9M" role="1SiIV1">
+            <node concept="398BVA" id="2fGryx5rF9$" role="1BurEY">
               <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rwj3" role="iGT6I">
+              <node concept="2Ry0Ak" id="2fGryx5rF9_" role="iGT6I">
                 <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rwj4" role="2Ry0An">
+                <node concept="2Ry0Ak" id="2fGryx5rF9A" role="2Ry0An">
                   <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rwj5" role="2Ry0An">
+                  <node concept="2Ry0Ak" id="2fGryx5rF9B" role="2Ry0An">
                     <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rwj6" role="2Ry0An">
+                    <node concept="2Ry0Ak" id="2fGryx5rF9C" role="2Ry0An">
                       <property role="2Ry0Am" value="org.eclipse.persistence.core.jar" />
                     </node>
                   </node>
@@ -863,17 +980,17 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="2fGryx5rwju" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rwjv" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rwjh" role="1BurEY">
+        <node concept="1SiIV0" id="2fGryx5rFa0" role="3bR37C">
+          <node concept="1BurEX" id="2fGryx5rFa1" role="1SiIV1">
+            <node concept="398BVA" id="2fGryx5rF9N" role="1BurEY">
               <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rwji" role="iGT6I">
+              <node concept="2Ry0Ak" id="2fGryx5rF9O" role="iGT6I">
                 <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rwjj" role="2Ry0An">
+                <node concept="2Ry0Ak" id="2fGryx5rF9P" role="2Ry0An">
                   <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rwjk" role="2Ry0An">
+                  <node concept="2Ry0Ak" id="2fGryx5rF9Q" role="2Ry0An">
                     <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rwjl" role="2Ry0An">
+                    <node concept="2Ry0Ak" id="2fGryx5rF9R" role="2Ry0An">
                       <property role="2Ry0Am" value="org.eclipse.persistence.moxy.jar" />
                     </node>
                   </node>
@@ -882,17 +999,17 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="2fGryx5rwjH" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rwjI" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rwjw" role="1BurEY">
+        <node concept="1SiIV0" id="2fGryx5rFaf" role="3bR37C">
+          <node concept="1BurEX" id="2fGryx5rFag" role="1SiIV1">
+            <node concept="398BVA" id="2fGryx5rFa2" role="1BurEY">
               <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rwjx" role="iGT6I">
+              <node concept="2Ry0Ak" id="2fGryx5rFa3" role="iGT6I">
                 <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rwjy" role="2Ry0An">
+                <node concept="2Ry0Ak" id="2fGryx5rFa4" role="2Ry0An">
                   <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rwjz" role="2Ry0An">
+                  <node concept="2Ry0Ak" id="2fGryx5rFa5" role="2Ry0An">
                     <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rwj$" role="2Ry0An">
+                    <node concept="2Ry0Ak" id="2fGryx5rFa6" role="2Ry0An">
                       <property role="2Ry0Am" value="qdox.jar" />
                     </node>
                   </node>
@@ -901,17 +1018,17 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="2fGryx5rwkb" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rwkc" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rwjY" role="1BurEY">
+        <node concept="1SiIV0" id="2fGryx5rFaH" role="3bR37C">
+          <node concept="1BurEX" id="2fGryx5rFaI" role="1SiIV1">
+            <node concept="398BVA" id="2fGryx5rFaw" role="1BurEY">
               <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rwjZ" role="iGT6I">
+              <node concept="2Ry0Ak" id="2fGryx5rFax" role="iGT6I">
                 <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rwk0" role="2Ry0An">
+                <node concept="2Ry0Ak" id="2fGryx5rFay" role="2Ry0An">
                   <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rwk1" role="2Ry0An">
+                  <node concept="2Ry0Ak" id="2fGryx5rFaz" role="2Ry0An">
                     <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rwk2" role="2Ry0An">
+                    <node concept="2Ry0Ak" id="2fGryx5rFa$" role="2Ry0An">
                       <property role="2Ry0Am" value="stringtemplate.jar" />
                     </node>
                   </node>
@@ -920,17 +1037,17 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="2fGryx5rwkq" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rwkr" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rwkd" role="1BurEY">
+        <node concept="1SiIV0" id="2fGryx5rFaW" role="3bR37C">
+          <node concept="1BurEX" id="2fGryx5rFaX" role="1SiIV1">
+            <node concept="398BVA" id="2fGryx5rFaJ" role="1BurEY">
               <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rwke" role="iGT6I">
+              <node concept="2Ry0Ak" id="2fGryx5rFaK" role="iGT6I">
                 <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rwkf" role="2Ry0An">
+                <node concept="2Ry0Ak" id="2fGryx5rFaL" role="2Ry0An">
                   <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rwkg" role="2Ry0An">
+                  <node concept="2Ry0Ak" id="2fGryx5rFaM" role="2Ry0An">
                     <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rwkh" role="2Ry0An">
+                    <node concept="2Ry0Ak" id="2fGryx5rFaN" role="2Ry0An">
                       <property role="2Ry0Am" value="wmf2svg.jar" />
                     </node>
                   </node>
@@ -939,17 +1056,17 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="2fGryx5rwkD" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rwkE" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rwks" role="1BurEY">
+        <node concept="1SiIV0" id="2fGryx5rFbb" role="3bR37C">
+          <node concept="1BurEX" id="2fGryx5rFbc" role="1SiIV1">
+            <node concept="398BVA" id="2fGryx5rFaY" role="1BurEY">
               <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rwkt" role="iGT6I">
+              <node concept="2Ry0Ak" id="2fGryx5rFaZ" role="iGT6I">
                 <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rwku" role="2Ry0An">
+                <node concept="2Ry0Ak" id="2fGryx5rFb0" role="2Ry0An">
                   <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rwkv" role="2Ry0An">
+                  <node concept="2Ry0Ak" id="2fGryx5rFb1" role="2Ry0An">
                     <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rwkw" role="2Ry0An">
+                    <node concept="2Ry0Ak" id="2fGryx5rFb2" role="2Ry0An">
                       <property role="2Ry0Am" value="xalan-interpretive.jar" />
                     </node>
                   </node>
@@ -958,33 +1075,17 @@
             </node>
           </node>
         </node>
-        <node concept="3rtmxn" id="2my$dfVXqV3" role="3bR31x">
-          <node concept="3LXTmp" id="2my$dfVXqV4" role="3rtmxm">
-            <node concept="3qWCbU" id="2my$dfVXqV5" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="2my$dfVXqV6" role="3LXTmr">
+        <node concept="1SiIV0" id="2fGryx5rFbq" role="3bR37C">
+          <node concept="1BurEX" id="2fGryx5rFbr" role="1SiIV1">
+            <node concept="398BVA" id="2fGryx5rFbd" role="1BurEY">
               <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2my$dfVXqV7" role="iGT6I">
+              <node concept="2Ry0Ak" id="2fGryx5rFbe" role="iGT6I">
                 <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2my$dfVXqV8" role="2Ry0An">
+                <node concept="2Ry0Ak" id="2fGryx5rFbf" role="2Ry0An">
                   <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rwkS" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rwkT" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rwkF" role="1BurEY">
-              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rwkG" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rwkH" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rwkI" role="2Ry0An">
+                  <node concept="2Ry0Ak" id="2fGryx5rFbg" role="2Ry0An">
                     <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rwkJ" role="2Ry0An">
+                    <node concept="2Ry0Ak" id="2fGryx5rFbh" role="2Ry0An">
                       <property role="2Ry0Am" value="xalan-serializer.jar" />
                     </node>
                   </node>
@@ -993,17 +1094,17 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="2fGryx5rwl7" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rwl8" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rwkU" role="1BurEY">
+        <node concept="1SiIV0" id="2fGryx5rFbD" role="3bR37C">
+          <node concept="1BurEX" id="2fGryx5rFbE" role="1SiIV1">
+            <node concept="398BVA" id="2fGryx5rFbs" role="1BurEY">
               <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rwkV" role="iGT6I">
+              <node concept="2Ry0Ak" id="2fGryx5rFbt" role="iGT6I">
                 <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rwkW" role="2Ry0An">
+                <node concept="2Ry0Ak" id="2fGryx5rFbu" role="2Ry0An">
                   <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rwkX" role="2Ry0An">
+                  <node concept="2Ry0Ak" id="2fGryx5rFbv" role="2Ry0An">
                     <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rwkY" role="2Ry0An">
+                    <node concept="2Ry0Ak" id="2fGryx5rFbw" role="2Ry0An">
                       <property role="2Ry0Am" value="xmlgraphics-commons.jar" />
                     </node>
                   </node>
@@ -1012,17 +1113,17 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="6CRJe3tfAxU" role="3bR37C">
-          <node concept="1BurEX" id="6CRJe3tfAxV" role="1SiIV1">
-            <node concept="398BVA" id="6CRJe3tfAxH" role="1BurEY">
+        <node concept="1SiIV0" id="6CRJe3tfEFm" role="3bR37C">
+          <node concept="1BurEX" id="6CRJe3tfEFn" role="1SiIV1">
+            <node concept="398BVA" id="6CRJe3tfEF9" role="1BurEY">
               <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="6CRJe3tfAxI" role="iGT6I">
+              <node concept="2Ry0Ak" id="6CRJe3tfEFa" role="iGT6I">
                 <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="6CRJe3tfAxJ" role="2Ry0An">
+                <node concept="2Ry0Ak" id="6CRJe3tfEFb" role="2Ry0An">
                   <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="6CRJe3tfAxK" role="2Ry0An">
+                  <node concept="2Ry0Ak" id="6CRJe3tfEFc" role="2Ry0An">
                     <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="6CRJe3tfAxL" role="2Ry0An">
+                    <node concept="2Ry0Ak" id="6CRJe3tfEFd" role="2Ry0An">
                       <property role="2Ry0Am" value="angus-activation.jar" />
                     </node>
                   </node>
@@ -1031,17 +1132,17 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="6CRJe3tfAy9" role="3bR37C">
-          <node concept="1BurEX" id="6CRJe3tfAya" role="1SiIV1">
-            <node concept="398BVA" id="6CRJe3tfAxW" role="1BurEY">
+        <node concept="1SiIV0" id="6CRJe3tfEF_" role="3bR37C">
+          <node concept="1BurEX" id="6CRJe3tfEFA" role="1SiIV1">
+            <node concept="398BVA" id="6CRJe3tfEFo" role="1BurEY">
               <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="6CRJe3tfAxX" role="iGT6I">
+              <node concept="2Ry0Ak" id="6CRJe3tfEFp" role="iGT6I">
                 <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="6CRJe3tfAxY" role="2Ry0An">
+                <node concept="2Ry0Ak" id="6CRJe3tfEFq" role="2Ry0An">
                   <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="6CRJe3tfAxZ" role="2Ry0An">
+                  <node concept="2Ry0Ak" id="6CRJe3tfEFr" role="2Ry0An">
                     <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="6CRJe3tfAy0" role="2Ry0An">
+                    <node concept="2Ry0Ak" id="6CRJe3tfEFs" role="2Ry0An">
                       <property role="2Ry0Am" value="angus-mail.jar" />
                     </node>
                   </node>
@@ -1050,17 +1151,17 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="6CRJe3tfAzc" role="3bR37C">
-          <node concept="1BurEX" id="6CRJe3tfAzd" role="1SiIV1">
-            <node concept="398BVA" id="6CRJe3tfAyZ" role="1BurEY">
+        <node concept="1SiIV0" id="6CRJe3tfEGC" role="3bR37C">
+          <node concept="1BurEX" id="6CRJe3tfEGD" role="1SiIV1">
+            <node concept="398BVA" id="6CRJe3tfEGr" role="1BurEY">
               <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="6CRJe3tfAz0" role="iGT6I">
+              <node concept="2Ry0Ak" id="6CRJe3tfEGs" role="iGT6I">
                 <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="6CRJe3tfAz1" role="2Ry0An">
+                <node concept="2Ry0Ak" id="6CRJe3tfEGt" role="2Ry0An">
                   <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="6CRJe3tfAz2" role="2Ry0An">
+                  <node concept="2Ry0Ak" id="6CRJe3tfEGu" role="2Ry0An">
                     <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="6CRJe3tfAz3" role="2Ry0An">
+                    <node concept="2Ry0Ak" id="6CRJe3tfEGv" role="2Ry0An">
                       <property role="2Ry0Am" value="commons-collections4.jar" />
                     </node>
                   </node>
@@ -1069,17 +1170,17 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="6CRJe3tfA$2" role="3bR37C">
-          <node concept="1BurEX" id="6CRJe3tfA$3" role="1SiIV1">
-            <node concept="398BVA" id="6CRJe3tfAzP" role="1BurEY">
+        <node concept="1SiIV0" id="6CRJe3tfEHu" role="3bR37C">
+          <node concept="1BurEX" id="6CRJe3tfEHv" role="1SiIV1">
+            <node concept="398BVA" id="6CRJe3tfEHh" role="1BurEY">
               <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="6CRJe3tfAzQ" role="iGT6I">
+              <node concept="2Ry0Ak" id="6CRJe3tfEHi" role="iGT6I">
                 <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="6CRJe3tfAzR" role="2Ry0An">
+                <node concept="2Ry0Ak" id="6CRJe3tfEHj" role="2Ry0An">
                   <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="6CRJe3tfAzS" role="2Ry0An">
+                  <node concept="2Ry0Ak" id="6CRJe3tfEHk" role="2Ry0An">
                     <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="6CRJe3tfAzT" role="2Ry0An">
+                    <node concept="2Ry0Ak" id="6CRJe3tfEHl" role="2Ry0An">
                       <property role="2Ry0Am" value="commons-logging.jar" />
                     </node>
                   </node>
@@ -1088,17 +1189,17 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="6CRJe3tfAAy" role="3bR37C">
-          <node concept="1BurEX" id="6CRJe3tfAAz" role="1SiIV1">
-            <node concept="398BVA" id="6CRJe3tfAAl" role="1BurEY">
+        <node concept="1SiIV0" id="6CRJe3tfEJY" role="3bR37C">
+          <node concept="1BurEX" id="6CRJe3tfEJZ" role="1SiIV1">
+            <node concept="398BVA" id="6CRJe3tfEJL" role="1BurEY">
               <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="6CRJe3tfAAm" role="iGT6I">
+              <node concept="2Ry0Ak" id="6CRJe3tfEJM" role="iGT6I">
                 <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="6CRJe3tfAAn" role="2Ry0An">
+                <node concept="2Ry0Ak" id="6CRJe3tfEJN" role="2Ry0An">
                   <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="6CRJe3tfAAo" role="2Ry0An">
+                  <node concept="2Ry0Ak" id="6CRJe3tfEJO" role="2Ry0An">
                     <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="6CRJe3tfAAp" role="2Ry0An">
+                    <node concept="2Ry0Ak" id="6CRJe3tfEJP" role="2Ry0An">
                       <property role="2Ry0Am" value="jaxb-core.jar" />
                     </node>
                   </node>
@@ -1107,17 +1208,17 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="6CRJe3tfABd" role="3bR37C">
-          <node concept="1BurEX" id="6CRJe3tfABe" role="1SiIV1">
-            <node concept="398BVA" id="6CRJe3tfAB0" role="1BurEY">
+        <node concept="1SiIV0" id="6CRJe3tfEKD" role="3bR37C">
+          <node concept="1BurEX" id="6CRJe3tfEKE" role="1SiIV1">
+            <node concept="398BVA" id="6CRJe3tfEKs" role="1BurEY">
               <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="6CRJe3tfAB1" role="iGT6I">
+              <node concept="2Ry0Ak" id="6CRJe3tfEKt" role="iGT6I">
                 <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="6CRJe3tfAB2" role="2Ry0An">
+                <node concept="2Ry0Ak" id="6CRJe3tfEKu" role="2Ry0An">
                   <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="6CRJe3tfAB3" role="2Ry0An">
+                  <node concept="2Ry0Ak" id="6CRJe3tfEKv" role="2Ry0An">
                     <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="6CRJe3tfAB4" role="2Ry0An">
+                    <node concept="2Ry0Ak" id="6CRJe3tfEKw" role="2Ry0An">
                       <property role="2Ry0Am" value="jaxb-xjc.jar" />
                     </node>
                   </node>
@@ -1126,17 +1227,17 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="6CRJe3tfACt" role="3bR37C">
-          <node concept="1BurEX" id="6CRJe3tfACu" role="1SiIV1">
-            <node concept="398BVA" id="6CRJe3tfACg" role="1BurEY">
+        <node concept="1SiIV0" id="6CRJe3tfELT" role="3bR37C">
+          <node concept="1BurEX" id="6CRJe3tfELU" role="1SiIV1">
+            <node concept="398BVA" id="6CRJe3tfELG" role="1BurEY">
               <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="6CRJe3tfACh" role="iGT6I">
+              <node concept="2Ry0Ak" id="6CRJe3tfELH" role="iGT6I">
                 <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="6CRJe3tfACi" role="2Ry0An">
+                <node concept="2Ry0Ak" id="6CRJe3tfELI" role="2Ry0An">
                   <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="6CRJe3tfACj" role="2Ry0An">
+                  <node concept="2Ry0Ak" id="6CRJe3tfELJ" role="2Ry0An">
                     <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="6CRJe3tfACk" role="2Ry0An">
+                    <node concept="2Ry0Ak" id="6CRJe3tfELK" role="2Ry0An">
                       <property role="2Ry0Am" value="pdfbox-io.jar" />
                     </node>
                   </node>
@@ -1145,17 +1246,17 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="6CRJe3tfACT" role="3bR37C">
-          <node concept="1BurEX" id="6CRJe3tfACU" role="1SiIV1">
-            <node concept="398BVA" id="6CRJe3tfACG" role="1BurEY">
+        <node concept="1SiIV0" id="6CRJe3tfEMl" role="3bR37C">
+          <node concept="1BurEX" id="6CRJe3tfEMm" role="1SiIV1">
+            <node concept="398BVA" id="6CRJe3tfEM8" role="1BurEY">
               <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="6CRJe3tfACH" role="iGT6I">
+              <node concept="2Ry0Ak" id="6CRJe3tfEM9" role="iGT6I">
                 <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="6CRJe3tfACI" role="2Ry0An">
+                <node concept="2Ry0Ak" id="6CRJe3tfEMa" role="2Ry0An">
                   <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="6CRJe3tfACJ" role="2Ry0An">
+                  <node concept="2Ry0Ak" id="6CRJe3tfEMb" role="2Ry0An">
                     <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="6CRJe3tfACK" role="2Ry0An">
+                    <node concept="2Ry0Ak" id="6CRJe3tfEMc" role="2Ry0An">
                       <property role="2Ry0Am" value="SparseBitSet.jar" />
                     </node>
                   </node>
@@ -1165,67 +1266,1737 @@
           </node>
         </node>
       </node>
-    </node>
-    <node concept="2G$12M" id="2MrvZqtDg3S" role="3989C9">
-      <property role="TrG5h" value="com.mpsbasics.docx4j.testutils" />
-      <node concept="1E1JtA" id="2MrvZqtDizQ" role="2G$12L">
+      <node concept="1E1JtA" id="6hyv0iVPlFJ" role="2G$12L">
         <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="com.mpsbasics.docx4j.testutils" />
-        <property role="3LESm3" value="5f04c496-eb21-4501-981b-4e5fc2ab46ec" />
-        <node concept="398BVA" id="2MrvZqtDiKJ" role="3LF7KH">
+        <property role="TrG5h" value="com.mpsbasics.snode.utils" />
+        <property role="3LESm3" value="8da51702-0e05-44c8-96db-8f11d1457c0c" />
+        <node concept="398BVA" id="6hyv0iVPlId" role="3LF7KH">
           <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
-          <node concept="2Ry0Ak" id="2MrvZqtDj3D" role="iGT6I">
+          <node concept="2Ry0Ak" id="6hyv0iVPlV3" role="iGT6I">
             <property role="2Ry0Am" value="solutions" />
-            <node concept="2Ry0Ak" id="2MrvZqtDjmW" role="2Ry0An">
-              <property role="2Ry0Am" value="com.mpsbasics.docx4j.testutils" />
-              <node concept="2Ry0Ak" id="2MrvZqtDjC7" role="2Ry0An">
-                <property role="2Ry0Am" value="com.mpsbasics.docx4j.testutils.msd" />
+            <node concept="2Ry0Ak" id="6hyv0iVPm7J" role="2Ry0An">
+              <property role="2Ry0Am" value="com.mpsbasics.snode.utils" />
+              <node concept="2Ry0Ak" id="6hyv0iVPmeG" role="2Ry0An">
+                <property role="2Ry0Am" value="com.mpsbasics.snode.utils.msd" />
               </node>
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="2MrvZqtDjUI" role="3bR37C">
-          <node concept="3bR9La" id="2MrvZqtDjUJ" role="1SiIV1">
+        <node concept="1SiIV0" id="6hyv0iVPlIe" role="3bR37C">
+          <node concept="3bR9La" id="6hyv0iVPlV4" role="1SiIV1">
             <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
           </node>
         </node>
-        <node concept="1SiIV0" id="2MrvZqtDjUK" role="3bR37C">
-          <node concept="3bR9La" id="2MrvZqtDjUL" role="1SiIV1">
-            <ref role="3bR37D" node="42jqVeFkUuP" resolve="com.mpsbasics.docx4j.lib" />
+        <node concept="1SiIV0" id="6hyv0iVPlIf" role="3bR37C">
+          <node concept="3bR9La" id="6hyv0iVPlV5" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1H905DlDUSw" resolve="MPS.OpenAPI" />
           </node>
         </node>
-        <node concept="1BupzO" id="2MrvZqtDjUZ" role="3bR31x">
+        <node concept="1BupzO" id="6hyv0iVPlIi" role="3bR31x">
           <property role="3ZfqAx" value="models" />
           <property role="1Hdu6h" value="true" />
           <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="2MrvZqtDjV0" role="1HemKq">
-            <node concept="398BVA" id="2MrvZqtDjUO" role="3LXTmr">
+          <node concept="3LXTmp" id="6hyv0iVPlV8" role="1HemKq">
+            <node concept="398BVA" id="6hyv0iVPm7K" role="3LXTmr">
               <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2MrvZqtDjUP" role="iGT6I">
+              <node concept="2Ry0Ak" id="6hyv0iVPmeH" role="iGT6I">
                 <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2MrvZqtDjUQ" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.testutils" />
-                  <node concept="2Ry0Ak" id="2MrvZqtDjUR" role="2Ry0An">
+                <node concept="2Ry0Ak" id="6hyv0iVPmju" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.snode.utils" />
+                  <node concept="2Ry0Ak" id="6hyv0iVPmmB" role="2Ry0An">
                     <property role="2Ry0Am" value="models" />
                   </node>
                 </node>
               </node>
             </node>
-            <node concept="3qWCbU" id="2MrvZqtDjV1" role="3LXTna">
+            <node concept="3qWCbU" id="6hyv0iVPm7L" role="3LXTna">
               <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
             </node>
           </node>
         </node>
-        <node concept="3rtmxn" id="4euqtkrlyTw" role="3bR31x">
-          <node concept="3LXTmp" id="4euqtkrlyTx" role="3rtmxm">
-            <node concept="3qWCbU" id="4euqtkrlyTy" role="3LXTna">
+        <node concept="3rtmxn" id="6hyv0iVPlIj" role="3bR31x">
+          <node concept="3LXTmp" id="6hyv0iVPlV9" role="3rtmxm">
+            <node concept="3qWCbU" id="6hyv0iVPm7M" role="3LXTna">
               <property role="3qWCbO" value="icons/**, resources/**" />
             </node>
-            <node concept="398BVA" id="4euqtkrlyTz" role="3LXTmr">
+            <node concept="398BVA" id="6hyv0iVPm7N" role="3LXTmr">
               <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="4euqtkrlyT$" role="iGT6I">
+              <node concept="2Ry0Ak" id="6hyv0iVPmeI" role="iGT6I">
                 <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="4euqtkrlyT_" role="2Ry0An">
+                <node concept="2Ry0Ak" id="6hyv0iVPmjv" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.snode.utils" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtA" id="2u7UHDCnPLY" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="com.mpsbasics.project.utils" />
+        <property role="3LESm3" value="1f4710e9-f074-4732-a0bd-6fa896d282b7" />
+        <node concept="398BVA" id="2u7UHDCnPZq" role="3LF7KH">
+          <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+          <node concept="2Ry0Ak" id="2u7UHDCnQeS" role="iGT6I">
+            <property role="2Ry0Am" value="solutions" />
+            <node concept="2Ry0Ak" id="2u7UHDCnQul" role="2Ry0An">
+              <property role="2Ry0Am" value="com.mpsbasics.project.utils" />
+              <node concept="2Ry0Ak" id="2u7UHDCnQHM" role="2Ry0An">
+                <property role="2Ry0Am" value="com.mpsbasics.project.utils.msd" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2u7UHDCnQWT" role="3bR37C">
+          <node concept="3bR9La" id="2u7UHDCnQWU" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2u7UHDCnQWV" role="3bR37C">
+          <node concept="3bR9La" id="2u7UHDCnQWW" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1ia2VB5guYy" resolve="MPS.IDEA" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2u7UHDCnQWX" role="3bR37C">
+          <node concept="3bR9La" id="2u7UHDCnQWY" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1TaHNgiIbJb" resolve="MPS.Platform" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2u7UHDCnQWZ" role="3bR37C">
+          <node concept="3bR9La" id="2u7UHDCnQX0" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1TaHNgiIbIQ" resolve="MPS.Core" />
+          </node>
+        </node>
+        <node concept="1BupzO" id="2u7UHDCnQXc" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="2u7UHDCnQXd" role="1HemKq">
+            <node concept="398BVA" id="2u7UHDCnQX1" role="3LXTmr">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="2u7UHDCnQX2" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="2u7UHDCnQX3" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.project.utils" />
+                  <node concept="2Ry0Ak" id="2u7UHDCnQX4" role="2Ry0An">
+                    <property role="2Ry0Am" value="models" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="2u7UHDCnQXe" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+        <node concept="3rtmxn" id="4euqtkrusDt" role="3bR31x">
+          <node concept="3LXTmp" id="4euqtkrusDu" role="3rtmxm">
+            <node concept="3qWCbU" id="4euqtkrusDv" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="4euqtkrusDw" role="3LXTmr">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="4euqtkrusDx" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="4euqtkrusDy" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.project.utils" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtA" id="2u7UHDCnRuK" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="com.mpsbasics.editor.utils" />
+        <property role="3LESm3" value="6b84fb9e-5f09-4a61-bf31-3bfdc54820e3" />
+        <node concept="398BVA" id="2u7UHDCnRGu" role="3LF7KH">
+          <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+          <node concept="2Ry0Ak" id="2u7UHDCnRVW" role="iGT6I">
+            <property role="2Ry0Am" value="solutions" />
+            <node concept="2Ry0Ak" id="2u7UHDCnSj5" role="2Ry0An">
+              <property role="2Ry0Am" value="com.mpsbasics.editor.utils" />
+              <node concept="2Ry0Ak" id="2u7UHDCnSyy" role="2Ry0An">
+                <property role="2Ry0Am" value="com.mpsbasics.editor.utils.msd" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2u7UHDCnSLO" role="3bR37C">
+          <node concept="3bR9La" id="2u7UHDCnSLP" role="1SiIV1">
+            <ref role="3bR37D" node="2u7UHDCnPLY" resolve="com.mpsbasics.project.utils" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2u7UHDCnSLQ" role="3bR37C">
+          <node concept="3bR9La" id="2u7UHDCnSLR" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1ia2VB5guYy" resolve="MPS.IDEA" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2u7UHDCnSLU" role="3bR37C">
+          <node concept="3bR9La" id="2u7UHDCnSLV" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:3MI1gu0QouH" resolve="jetbrains.mps.editor.runtime" />
+          </node>
+        </node>
+        <node concept="1BupzO" id="2u7UHDCnSM7" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="2u7UHDCnSM8" role="1HemKq">
+            <node concept="398BVA" id="2u7UHDCnSLW" role="3LXTmr">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="2u7UHDCnSLX" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="2u7UHDCnSLY" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.editor.utils" />
+                  <node concept="2Ry0Ak" id="2u7UHDCnSLZ" role="2Ry0An">
+                    <property role="2Ry0Am" value="models" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="2u7UHDCnSM9" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+        <node concept="3rtmxn" id="4euqtkrusD$" role="3bR31x">
+          <node concept="3LXTmp" id="4euqtkrusD_" role="3rtmxm">
+            <node concept="3qWCbU" id="4euqtkrusDA" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="4euqtkrusDB" role="3LXTmr">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="4euqtkrusDC" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="4euqtkrusDD" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.editor.utils" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="YXkTXVNg_7" role="3bR37C">
+          <node concept="3bR9La" id="YXkTXVNg_8" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="YXkTXVNg_9" role="3bR37C">
+          <node concept="3bR9La" id="YXkTXVNg_a" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1TaHNgiIbIZ" resolve="MPS.Editor" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2i2e8U1mEgx" role="3bR37C">
+          <node concept="3bR9La" id="2i2e8U1mEgy" role="1SiIV1">
+            <ref role="3bR37D" to="90a9:6bkzxtWPDx1" resolve="de.itemis.stubs.batik" />
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtA" id="2u7UHDC1RNf" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="com.mpsbasics.pdfbox" />
+        <property role="3LESm3" value="bc7d0863-298c-41cf-984f-a0421e757da5" />
+        <node concept="398BVA" id="2u7UHDC1S2a" role="3LF7KH">
+          <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+          <node concept="2Ry0Ak" id="2u7UHDC1Sye" role="iGT6I">
+            <property role="2Ry0Am" value="solutions" />
+            <node concept="2Ry0Ak" id="2u7UHDC1SOx" role="2Ry0An">
+              <property role="2Ry0Am" value="com.mpsbasics.pdfbox" />
+              <node concept="2Ry0Ak" id="2u7UHDC1T5A" role="2Ry0An">
+                <property role="2Ry0Am" value="com.mpsbasics.pdfbox.msd" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2u7UHDC1Tlm" role="3bR37C">
+          <node concept="3bR9La" id="2u7UHDC1Tln" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2u7UHDC1VSB" role="3bR37C">
+          <node concept="3bR9La" id="2u7UHDC1VSC" role="1SiIV1">
+            <ref role="3bR37D" node="2u7UHDC1TKp" resolve="com.mpsbasics.pdfexporter" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2u7UHDCnTe3" role="3bR37C">
+          <node concept="3bR9La" id="2u7UHDCnTe4" role="1SiIV1">
+            <ref role="3bR37D" node="2u7UHDCnRuK" resolve="com.mpsbasics.editor.utils" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="3TNxfDZ5bWu" role="3bR37C">
+          <node concept="3bR9La" id="3TNxfDZ5bWv" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1ia2VB5guYy" resolve="MPS.IDEA" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="3TNxfDZ5bWy" role="3bR37C">
+          <node concept="3bR9La" id="3TNxfDZ5bWz" role="1SiIV1">
+            <ref role="3bR37D" to="al5i:Vtr7jyAKU4" resolve="com.mbeddr.mpsutil.filepicker" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2fGryx5rFcp" role="3bR37C">
+          <node concept="1BurEX" id="2fGryx5rFcq" role="1SiIV1">
+            <node concept="398BVA" id="2fGryx5rFcc" role="1BurEY">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="2fGryx5rFcd" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="2fGryx5rFce" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.pdfbox" />
+                  <node concept="2Ry0Ak" id="2fGryx5rFcf" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="2fGryx5rFcg" role="2Ry0An">
+                      <property role="2Ry0Am" value="graphics2d.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3rtmxn" id="4euqtkrusDF" role="3bR31x">
+          <node concept="3LXTmp" id="4euqtkrusDG" role="3rtmxm">
+            <node concept="3qWCbU" id="4euqtkrusDH" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="4euqtkrusDI" role="3LXTmr">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="4euqtkrusDJ" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="4euqtkrusDK" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.pdfbox" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2fGryx5rFcC" role="3bR37C">
+          <node concept="1BurEX" id="2fGryx5rFcD" role="1SiIV1">
+            <node concept="398BVA" id="2fGryx5rFcr" role="1BurEY">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="2fGryx5rFcs" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="2fGryx5rFct" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.pdfbox" />
+                  <node concept="2Ry0Ak" id="2fGryx5rFcu" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="2fGryx5rFcv" role="2Ry0An">
+                      <property role="2Ry0Am" value="openhtmltopdf-core.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2fGryx5rFcR" role="3bR37C">
+          <node concept="1BurEX" id="2fGryx5rFcS" role="1SiIV1">
+            <node concept="398BVA" id="2fGryx5rFcE" role="1BurEY">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="2fGryx5rFcF" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="2fGryx5rFcG" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.pdfbox" />
+                  <node concept="2Ry0Ak" id="2fGryx5rFcH" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="2fGryx5rFcI" role="2Ry0An">
+                      <property role="2Ry0Am" value="openhtmltopdf-pdfbox.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2fGryx5rFd6" role="3bR37C">
+          <node concept="1BurEX" id="2fGryx5rFd7" role="1SiIV1">
+            <node concept="398BVA" id="2fGryx5rFcT" role="1BurEY">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="2fGryx5rFcU" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="2fGryx5rFcV" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.pdfbox" />
+                  <node concept="2Ry0Ak" id="2fGryx5rFcW" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="2fGryx5rFcX" role="2Ry0An">
+                      <property role="2Ry0Am" value="pdfbox-app.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1BupzO" id="2_t3nDPzUj0" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="2_t3nDPzUj1" role="1HemKq">
+            <node concept="398BVA" id="2_t3nDPzUiP" role="3LXTmr">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="2_t3nDPzUiQ" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="2_t3nDPzUiR" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.pdfbox" />
+                  <node concept="2Ry0Ak" id="2_t3nDPzUiS" role="2Ry0An">
+                    <property role="2Ry0Am" value="models" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="2_t3nDPzUj2" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2fGryx5rFdl" role="3bR37C">
+          <node concept="1BurEX" id="2fGryx5rFdm" role="1SiIV1">
+            <node concept="398BVA" id="2fGryx5rFd8" role="1BurEY">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="2fGryx5rFd9" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="2fGryx5rFda" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.pdfbox" />
+                  <node concept="2Ry0Ak" id="2fGryx5rFdb" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="2fGryx5rFdc" role="2Ry0An">
+                      <property role="2Ry0Am" value="xmpbox.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtD" id="2u7UHDC1TKp" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="com.mpsbasics.pdfexporter" />
+        <property role="3LESm3" value="ece26728-2885-4b26-9f61-67d2821fc361" />
+        <node concept="398BVA" id="2u7UHDC1Ug2" role="3LF7KH">
+          <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+          <node concept="2Ry0Ak" id="2u7UHDC1UCq" role="iGT6I">
+            <property role="2Ry0Am" value="languages" />
+            <node concept="2Ry0Ak" id="2u7UHDC1UTv" role="2Ry0An">
+              <property role="2Ry0Am" value="com.mpsbasics.pdfexporter" />
+              <node concept="2Ry0Ak" id="2u7UHDC1Vaa" role="2Ry0An">
+                <property role="2Ry0Am" value="com.mpsbasics.pdfexporter.mpl" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2u7UHDC1Vqt" role="3bR37C">
+          <node concept="3bR9La" id="2u7UHDC1Vqu" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1TaHNgiIbIZ" resolve="MPS.Editor" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2u7UHDC1Vqv" role="3bR37C">
+          <node concept="3bR9La" id="2u7UHDC1Vqw" role="1SiIV1">
+            <ref role="3bR37D" node="2u7UHDC1RNf" resolve="com.mpsbasics.pdfbox" />
+          </node>
+        </node>
+        <node concept="1BupzO" id="2u7UHDC1VqG" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="2u7UHDC1VqH" role="1HemKq">
+            <node concept="398BVA" id="2u7UHDC1Vqx" role="3LXTmr">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="2u7UHDC1Vqy" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="2u7UHDC1Vqz" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.pdfexporter" />
+                  <node concept="2Ry0Ak" id="2u7UHDC1Vq$" role="2Ry0An">
+                    <property role="2Ry0Am" value="models" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="2u7UHDC1VqI" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="3TNxfDZ5bWW" role="3bR37C">
+          <node concept="3bR9La" id="3TNxfDZ5bWX" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:3HV74$ebibC" resolve="jetbrains.mps.lang.text" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="3TNxfDZ5bWY" role="3bR37C">
+          <node concept="3bR9La" id="3TNxfDZ5bWZ" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="3TNxfDZ5bX0" role="3bR37C">
+          <node concept="3bR9La" id="3TNxfDZ5bX1" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6LfQ" resolve="jetbrains.mps.kernel" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="3TNxfDZ5bX2" role="3bR37C">
+          <node concept="3bR9La" id="3TNxfDZ5bX3" role="1SiIV1">
+            <ref role="3bR37D" to="al5i:Vtr7jyAKU4" resolve="com.mbeddr.mpsutil.filepicker" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="3TNxfDZ5bX4" role="3bR37C">
+          <node concept="3bR9La" id="3TNxfDZ5bX5" role="1SiIV1">
+            <ref role="3bR37D" node="2u7UHDCnRuK" resolve="com.mpsbasics.editor.utils" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2ZPTSaoSrhy" role="3bR37C">
+          <node concept="3bR9La" id="2ZPTSaoSrhz" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1H905DlDUSw" resolve="MPS.OpenAPI" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2ZPTSaoSrh$" role="3bR37C">
+          <node concept="3bR9La" id="2ZPTSaoSrh_" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:3MI1gu0QouH" resolve="jetbrains.mps.editor.runtime" />
+          </node>
+        </node>
+        <node concept="3rtmxn" id="4euqtkrusLZ" role="3bR31x">
+          <node concept="3LXTmp" id="4euqtkrusM0" role="3rtmxm">
+            <node concept="3qWCbU" id="4euqtkrusM1" role="3LXTna">
+              <property role="3qWCbO" value="com/mpsbasics/pdfexporter/structure/*.png" />
+            </node>
+            <node concept="398BVA" id="4euqtkrusM2" role="3LXTmr">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="4euqtkrusM3" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="4euqtkrusM4" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.pdfexporter" />
+                  <node concept="2Ry0Ak" id="2oWhy0w_F$j" role="2Ry0An">
+                    <property role="2Ry0Am" value="source_gen" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtA" id="2wSfKqy9hC9" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="com.mpsbasics.jira.pluginSolution" />
+        <property role="3LESm3" value="47b4ca2d-4ed7-41a6-b64f-df36b50a3c95" />
+        <node concept="398BVA" id="2wSfKqy9hTU" role="3LF7KH">
+          <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+          <node concept="2Ry0Ak" id="2wSfKqy9ibO" role="iGT6I">
+            <property role="2Ry0Am" value="solutions" />
+            <node concept="2Ry0Ak" id="2wSfKqy9iuV" role="2Ry0An">
+              <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
+              <node concept="2Ry0Ak" id="2wSfKqy9iK0" role="2Ry0An">
+                <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution.msd" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2wSfKqy9j1e" role="3bR37C">
+          <node concept="3bR9La" id="2wSfKqy9j1f" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+          </node>
+        </node>
+        <node concept="3rtmxn" id="2bBfLTGrYGA" role="3bR31x">
+          <node concept="3LXTmp" id="2bBfLTGrYGB" role="3rtmxm">
+            <node concept="3qWCbU" id="2bBfLTGrYGC" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="2bBfLTGrYGD" role="3LXTmr">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="2bBfLTGrYGE" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="2bBfLTGrYGF" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2fGryx5rFdJ" role="3bR37C">
+          <node concept="1BurEX" id="2fGryx5rFdK" role="1SiIV1">
+            <node concept="398BVA" id="2fGryx5rFdy" role="1BurEY">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="2fGryx5rFdz" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="2fGryx5rFd$" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
+                  <node concept="2Ry0Ak" id="2fGryx5rFd_" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="2fGryx5rFdA" role="2Ry0An">
+                      <property role="2Ry0Am" value="atlassian-event.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2fGryx5rFdY" role="3bR37C">
+          <node concept="1BurEX" id="2fGryx5rFdZ" role="1SiIV1">
+            <node concept="398BVA" id="2fGryx5rFdL" role="1BurEY">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="2fGryx5rFdM" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="2fGryx5rFdN" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
+                  <node concept="2Ry0Ak" id="2fGryx5rFdO" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="2fGryx5rFdP" role="2Ry0An">
+                      <property role="2Ry0Am" value="atlassian-httpclient-api.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2fGryx5rFed" role="3bR37C">
+          <node concept="1BurEX" id="2fGryx5rFee" role="1SiIV1">
+            <node concept="398BVA" id="2fGryx5rFe0" role="1BurEY">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="2fGryx5rFe1" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="2fGryx5rFe2" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
+                  <node concept="2Ry0Ak" id="2fGryx5rFe3" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="2fGryx5rFe4" role="2Ry0An">
+                      <property role="2Ry0Am" value="atlassian-util-concurrent.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2fGryx5rFeF" role="3bR37C">
+          <node concept="1BurEX" id="2fGryx5rFeG" role="1SiIV1">
+            <node concept="398BVA" id="2fGryx5rFeu" role="1BurEY">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="2fGryx5rFev" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="2fGryx5rFew" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
+                  <node concept="2Ry0Ak" id="2fGryx5rFex" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="2fGryx5rFey" role="2Ry0An">
+                      <property role="2Ry0Am" value="commons-logging.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2fGryx5rFeU" role="3bR37C">
+          <node concept="1BurEX" id="2fGryx5rFeV" role="1SiIV1">
+            <node concept="398BVA" id="2fGryx5rFeH" role="1BurEY">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="2fGryx5rFeI" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="2fGryx5rFeJ" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
+                  <node concept="2Ry0Ak" id="2fGryx5rFeK" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="2fGryx5rFeL" role="2Ry0An">
+                      <property role="2Ry0Am" value="guava.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2fGryx5rFf9" role="3bR37C">
+          <node concept="1BurEX" id="2fGryx5rFfa" role="1SiIV1">
+            <node concept="398BVA" id="2fGryx5rFeW" role="1BurEY">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="2fGryx5rFeX" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="2fGryx5rFeY" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
+                  <node concept="2Ry0Ak" id="2fGryx5rFeZ" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="2fGryx5rFf0" role="2Ry0An">
+                      <property role="2Ry0Am" value="httpasyncclient-cache.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2fGryx5rFfo" role="3bR37C">
+          <node concept="1BurEX" id="2fGryx5rFfp" role="1SiIV1">
+            <node concept="398BVA" id="2fGryx5rFfb" role="1BurEY">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="2fGryx5rFfc" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="2fGryx5rFfd" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
+                  <node concept="2Ry0Ak" id="2fGryx5rFfe" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="2fGryx5rFff" role="2Ry0An">
+                      <property role="2Ry0Am" value="httpasyncclient.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2fGryx5rFfB" role="3bR37C">
+          <node concept="1BurEX" id="2fGryx5rFfC" role="1SiIV1">
+            <node concept="398BVA" id="2fGryx5rFfq" role="1BurEY">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="2fGryx5rFfr" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="2fGryx5rFfs" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
+                  <node concept="2Ry0Ak" id="2fGryx5rFft" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="2fGryx5rFfu" role="2Ry0An">
+                      <property role="2Ry0Am" value="httpclient-cache.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2fGryx5rFfQ" role="3bR37C">
+          <node concept="1BurEX" id="2fGryx5rFfR" role="1SiIV1">
+            <node concept="398BVA" id="2fGryx5rFfD" role="1BurEY">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="2fGryx5rFfE" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="2fGryx5rFfF" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
+                  <node concept="2Ry0Ak" id="2fGryx5rFfG" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="2fGryx5rFfH" role="2Ry0An">
+                      <property role="2Ry0Am" value="httpclient.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2fGryx5rFg5" role="3bR37C">
+          <node concept="1BurEX" id="2fGryx5rFg6" role="1SiIV1">
+            <node concept="398BVA" id="2fGryx5rFfS" role="1BurEY">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="2fGryx5rFfT" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="2fGryx5rFfU" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
+                  <node concept="2Ry0Ak" id="2fGryx5rFfV" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="2fGryx5rFfW" role="2Ry0An">
+                      <property role="2Ry0Am" value="httpcore-nio.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2fGryx5rFgk" role="3bR37C">
+          <node concept="1BurEX" id="2fGryx5rFgl" role="1SiIV1">
+            <node concept="398BVA" id="2fGryx5rFg7" role="1BurEY">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="2fGryx5rFg8" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="2fGryx5rFg9" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
+                  <node concept="2Ry0Ak" id="2fGryx5rFga" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="2fGryx5rFgb" role="2Ry0An">
+                      <property role="2Ry0Am" value="httpcore.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2fGryx5rFgz" role="3bR37C">
+          <node concept="1BurEX" id="2fGryx5rFg$" role="1SiIV1">
+            <node concept="398BVA" id="2fGryx5rFgm" role="1BurEY">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="2fGryx5rFgn" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="2fGryx5rFgo" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
+                  <node concept="2Ry0Ak" id="2fGryx5rFgp" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="2fGryx5rFgq" role="2Ry0An">
+                      <property role="2Ry0Am" value="httpmime.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2fGryx5rFic" role="3bR37C">
+          <node concept="1BurEX" id="2fGryx5rFid" role="1SiIV1">
+            <node concept="398BVA" id="2fGryx5rFhZ" role="1BurEY">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="2fGryx5rFi0" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="2fGryx5rFi1" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
+                  <node concept="2Ry0Ak" id="2fGryx5rFi2" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="2fGryx5rFi3" role="2Ry0An">
+                      <property role="2Ry0Am" value="jersey-client.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2fGryx5rFiT" role="3bR37C">
+          <node concept="1BurEX" id="2fGryx5rFiU" role="1SiIV1">
+            <node concept="398BVA" id="2fGryx5rFiG" role="1BurEY">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="2fGryx5rFiH" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="2fGryx5rFiI" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
+                  <node concept="2Ry0Ak" id="2fGryx5rFiJ" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="2fGryx5rFiK" role="2Ry0An">
+                      <property role="2Ry0Am" value="jettison.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2fGryx5rFj8" role="3bR37C">
+          <node concept="1BurEX" id="2fGryx5rFj9" role="1SiIV1">
+            <node concept="398BVA" id="2fGryx5rFiV" role="1BurEY">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="2fGryx5rFiW" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="2fGryx5rFiX" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
+                  <node concept="2Ry0Ak" id="2fGryx5rFiY" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="2fGryx5rFiZ" role="2Ry0An">
+                      <property role="2Ry0Am" value="jira-rest-java-client-api.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2fGryx5rFjn" role="3bR37C">
+          <node concept="1BurEX" id="2fGryx5rFjo" role="1SiIV1">
+            <node concept="398BVA" id="2fGryx5rFja" role="1BurEY">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="2fGryx5rFjb" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="2fGryx5rFjc" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
+                  <node concept="2Ry0Ak" id="2fGryx5rFjd" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="2fGryx5rFje" role="2Ry0An">
+                      <property role="2Ry0Am" value="jira-rest-java-client-core.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2fGryx5rFjA" role="3bR37C">
+          <node concept="1BurEX" id="2fGryx5rFjB" role="1SiIV1">
+            <node concept="398BVA" id="2fGryx5rFjp" role="1BurEY">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="2fGryx5rFjq" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="2fGryx5rFjr" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
+                  <node concept="2Ry0Ak" id="2fGryx5rFjs" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="2fGryx5rFjt" role="2Ry0An">
+                      <property role="2Ry0Am" value="joda-time.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2fGryx5rFjP" role="3bR37C">
+          <node concept="1BurEX" id="2fGryx5rFjQ" role="1SiIV1">
+            <node concept="398BVA" id="2fGryx5rFjC" role="1BurEY">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="2fGryx5rFjD" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="2fGryx5rFjE" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
+                  <node concept="2Ry0Ak" id="2fGryx5rFjF" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="2fGryx5rFjG" role="2Ry0An">
+                      <property role="2Ry0Am" value="jsr305.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2fGryx5rFkj" role="3bR37C">
+          <node concept="1BurEX" id="2fGryx5rFkk" role="1SiIV1">
+            <node concept="398BVA" id="2fGryx5rFk6" role="1BurEY">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="2fGryx5rFk7" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="2fGryx5rFk8" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
+                  <node concept="2Ry0Ak" id="2fGryx5rFk9" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="2fGryx5rFka" role="2Ry0An">
+                      <property role="2Ry0Am" value="spring-beans.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2fGryx5rFky" role="3bR37C">
+          <node concept="1BurEX" id="2fGryx5rFkz" role="1SiIV1">
+            <node concept="398BVA" id="2fGryx5rFkl" role="1BurEY">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="2fGryx5rFkm" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="2fGryx5rFkn" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
+                  <node concept="2Ry0Ak" id="2fGryx5rFko" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="2fGryx5rFkp" role="2Ry0An">
+                      <property role="2Ry0Am" value="spring-core.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1BupzO" id="2_t3nDPzUpG" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="2_t3nDPzUpH" role="1HemKq">
+            <node concept="398BVA" id="2_t3nDPzUpx" role="3LXTmr">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="2_t3nDPzUpy" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="2_t3nDPzUpz" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.jira.pluginSolution" />
+                  <node concept="2Ry0Ak" id="2_t3nDPzUp$" role="2Ry0An">
+                    <property role="2Ry0Am" value="models" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="2_t3nDPzUpI" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtD" id="2wSfKqy9jAQ" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="com.mpsbasics.jira" />
+        <property role="3LESm3" value="fde86f49-830f-414f-9c22-2a9e300eaba6" />
+        <node concept="398BVA" id="2wSfKqy9jXx" role="3LF7KH">
+          <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+          <node concept="2Ry0Ak" id="2wSfKqy9kkH" role="iGT6I">
+            <property role="2Ry0Am" value="languages" />
+            <node concept="2Ry0Ak" id="2wSfKqy9kGG" role="2Ry0An">
+              <property role="2Ry0Am" value="com.mpsbasics.jira" />
+              <node concept="2Ry0Ak" id="2wSfKqy9l4F" role="2Ry0An">
+                <property role="2Ry0Am" value="com.mpsbasics.jira.mpl" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2wSfKqy9lsa" role="3bR37C">
+          <node concept="3bR9La" id="2wSfKqy9lsb" role="1SiIV1">
+            <ref role="3bR37D" node="2wSfKqy9hC9" resolve="com.mpsbasics.jira.pluginSolution" />
+          </node>
+        </node>
+        <node concept="1BupzO" id="2wSfKqy9lsn" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="2wSfKqy9lso" role="1HemKq">
+            <node concept="398BVA" id="2wSfKqy9lsc" role="3LXTmr">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="2wSfKqy9lsd" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="2wSfKqy9lse" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.jira" />
+                  <node concept="2Ry0Ak" id="2wSfKqy9lsf" role="2Ry0An">
+                    <property role="2Ry0Am" value="models" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="2wSfKqy9lsp" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+        <node concept="3rtmxn" id="2oWhy0wGLxN" role="3bR31x">
+          <node concept="3LXTmp" id="2oWhy0wGLxO" role="3rtmxm">
+            <node concept="398BVA" id="2oWhy0wGLxP" role="3LXTmr">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="2oWhy0wGLxQ" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="2oWhy0wGLxR" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.jira" />
+                  <node concept="2Ry0Ak" id="2oWhy0wGITY" role="2Ry0An">
+                    <property role="2Ry0Am" value="source_gen" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="2oWhy0wGLxS" role="3LXTna">
+              <property role="3qWCbO" value="com/mpsbasics/jira/structure/*.png" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtD" id="4lJSf3LkfPw" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="com.mpsbasics.core" />
+        <property role="3LESm3" value="792be022-0a7a-4b28-bfd8-b1b2d347b772" />
+        <node concept="398BVA" id="4lJSf3Lkg39" role="3LF7KH">
+          <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+          <node concept="2Ry0Ak" id="4lJSf3LkggM" role="iGT6I">
+            <property role="2Ry0Am" value="languages" />
+            <node concept="2Ry0Ak" id="4lJSf3LkgFZ" role="2Ry0An">
+              <property role="2Ry0Am" value="com.mpsbasics.core" />
+              <node concept="2Ry0Ak" id="4lJSf3Lkh7c" role="2Ry0An">
+                <property role="2Ry0Am" value="com.mpsbasics.core.mpl" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="4lJSf3Lkhx6" role="3bR37C">
+          <node concept="3bR9La" id="4lJSf3Lkhx7" role="1SiIV1">
+            <ref role="3bR37D" to="90a9:6SVXTgIejl1" resolve="de.itemis.mps.editor.celllayout.runtime" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="4lJSf3Lkhx8" role="3bR37C">
+          <node concept="3bR9La" id="4lJSf3Lkhx9" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1TaHNgiIbJt" resolve="jetbrains.mps.ide.platform" />
+          </node>
+        </node>
+        <node concept="1BupzO" id="4lJSf3Lkhxl" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="4lJSf3Lkhxm" role="1HemKq">
+            <node concept="398BVA" id="4lJSf3Lkhxa" role="3LXTmr">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="4lJSf3Lkhxb" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="4lJSf3Lkhxc" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.core" />
+                  <node concept="2Ry0Ak" id="4lJSf3Lkhxd" role="2Ry0An">
+                    <property role="2Ry0Am" value="models" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="4lJSf3Lkhxn" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+        <node concept="3rtmxn" id="4lJSf3LkibE" role="3bR31x">
+          <node concept="3LXTmp" id="4lJSf3LkibF" role="3rtmxm">
+            <node concept="398BVA" id="4lJSf3LkibG" role="3LXTmr">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="4lJSf3LkibH" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="4lJSf3LkibI" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.core" />
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="4lJSf3LkibK" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="vYco6EFYgp" role="3bR37C">
+          <node concept="3bR9La" id="vYco6EFYgq" role="1SiIV1">
+            <ref role="3bR37D" node="2u7UHDCnRuK" resolve="com.mpsbasics.editor.utils" />
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtD" id="6FJpOMBsZUh" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="com.mpsbasics.words.generic" />
+        <property role="3LESm3" value="e4b230e7-8e1a-4a05-8148-8713530572c1" />
+        <node concept="398BVA" id="6FJpOMBt05F" role="3LF7KH">
+          <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+          <node concept="2Ry0Ak" id="6FJpOMBt1vp" role="iGT6I">
+            <property role="2Ry0Am" value="languages" />
+            <node concept="2Ry0Ak" id="6FJpOMBt2cO" role="2Ry0An">
+              <property role="2Ry0Am" value="com.mpsbasics.words.generic" />
+              <node concept="2Ry0Ak" id="6FJpOMBt2zz" role="2Ry0An">
+                <property role="2Ry0Am" value="com.mpsbasics.words.generic.mpl" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6FJpOMBt2V$" role="3bR37C">
+          <node concept="3bR9La" id="6FJpOMBt2V_" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6LfQ" resolve="jetbrains.mps.kernel" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6FJpOMBt2VA" role="3bR37C">
+          <node concept="3bR9La" id="6FJpOMBt2VB" role="1SiIV1">
+            <ref role="3bR37D" node="4lJSf3LkfPw" resolve="com.mpsbasics.core" />
+          </node>
+        </node>
+        <node concept="1BupzO" id="6FJpOMBt2VN" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="6FJpOMBt2VO" role="1HemKq">
+            <node concept="398BVA" id="6FJpOMBt2VC" role="3LXTmr">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="6FJpOMBt2VD" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="6FJpOMBt2VE" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.words.generic" />
+                  <node concept="2Ry0Ak" id="6FJpOMBt2VF" role="2Ry0An">
+                    <property role="2Ry0Am" value="models" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="6FJpOMBt2VP" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6FJpOMBt2VQ" role="3bR37C">
+          <node concept="1Busua" id="6FJpOMBt2VR" role="1SiIV1">
+            <ref role="1Busuk" to="90a9:1sO539bGQvB" resolve="de.slisson.mps.richtext" />
+          </node>
+        </node>
+        <node concept="3rtmxn" id="6FJpOMBt3Sx" role="3bR31x">
+          <node concept="3LXTmp" id="6FJpOMBt3Sy" role="3rtmxm">
+            <node concept="398BVA" id="6FJpOMBt3Sz" role="3LXTmr">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="6FJpOMBt3S$" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="6FJpOMBt3S_" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.words.generic" />
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="6FJpOMBt3SB" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtD" id="4m8f5php_QJ" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="com.mpsbasics.plaintext.yaml" />
+        <property role="3LESm3" value="4556fd77-6edd-4716-8b05-e35fd684d04d" />
+        <node concept="398BVA" id="4m8f5php_QK" role="3LF7KH">
+          <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+          <node concept="2Ry0Ak" id="4m8f5php_QL" role="iGT6I">
+            <property role="2Ry0Am" value="languages" />
+            <node concept="2Ry0Ak" id="4m8f5php_QM" role="2Ry0An">
+              <property role="2Ry0Am" value="com.mpsbasics.plaintext.yaml" />
+              <node concept="2Ry0Ak" id="4m8f5phpAua" role="2Ry0An">
+                <property role="2Ry0Am" value="com.mpsbasics.plaintext.yaml.mpl" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1BupzO" id="4m8f5php_QS" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="4m8f5phpAR3" role="1HemKq">
+            <node concept="398BVA" id="4m8f5phpAQS" role="3LXTmr">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="4m8f5phpAQT" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="4m8f5phpAQU" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.plaintext.yaml" />
+                  <node concept="2Ry0Ak" id="4m8f5phpAQV" role="2Ry0An">
+                    <property role="2Ry0Am" value="models" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="4m8f5phpAR4" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+        <node concept="3rtmxn" id="4m8f5php_R1" role="3bR31x">
+          <node concept="3LXTmp" id="4m8f5php_R2" role="3rtmxm">
+            <node concept="398BVA" id="4m8f5php_R3" role="3LXTmr">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="4m8f5php_R4" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="4m8f5phpBR3" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.plaintext.yaml" />
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="4m8f5php_R6" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="4m8f5phpAQK" role="3bR37C">
+          <node concept="3bR9La" id="4m8f5phpAQL" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="4m8f5phpAQM" role="3bR37C">
+          <node concept="3bR9La" id="4m8f5phpAQN" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1TaHNgiIbIZ" resolve="MPS.Editor" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="4m8f5phpAQO" role="3bR37C">
+          <node concept="3bR9La" id="4m8f5phpAQP" role="1SiIV1">
+            <ref role="3bR37D" to="90a9:3$A0JaN5bpX" resolve="MPS.ThirdParty" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="4m8f5phpAQQ" role="3bR37C">
+          <node concept="3bR9La" id="4m8f5phpAQR" role="1SiIV1">
+            <ref role="3bR37D" to="90a9:PE3B26QCrP" resolve="org.apache.commons" />
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtD" id="5C1tqSGWeiw" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="com.mpsbasics.plaintext.yaml.dsl.base" />
+        <property role="3LESm3" value="91ea57f8-7d6f-44b2-9328-d39a2e01a88b" />
+        <node concept="398BVA" id="5C1tqSGWew_" role="3LF7KH">
+          <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+          <node concept="2Ry0Ak" id="5C1tqSGWeIE" role="iGT6I">
+            <property role="2Ry0Am" value="languages" />
+            <node concept="2Ry0Ak" id="5C1tqSGWfoK" role="2Ry0An">
+              <property role="2Ry0Am" value="com.mpsbasics.plaintext.yaml.dsl.base" />
+              <node concept="2Ry0Ak" id="5C1tqSGWfOP" role="2Ry0An">
+                <property role="2Ry0Am" value="com.mpsbasics.plaintext.yaml.dsl.base.mpl" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="5C1tqSGWgiJ" role="3bR37C">
+          <node concept="3bR9La" id="5C1tqSGWgiK" role="1SiIV1">
+            <ref role="3bR37D" node="4m8f5php_QJ" resolve="com.mpsbasics.plaintext.yaml" />
+          </node>
+        </node>
+        <node concept="1BupzO" id="5C1tqSGWgiW" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="5C1tqSGWgiX" role="1HemKq">
+            <node concept="398BVA" id="5C1tqSGWgiL" role="3LXTmr">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="5C1tqSGWgiM" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="5C1tqSGWgiN" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.plaintext.yaml.dsl.base" />
+                  <node concept="2Ry0Ak" id="5C1tqSGWgiO" role="2Ry0An">
+                    <property role="2Ry0Am" value="models" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="5C1tqSGWgiY" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="5C1tqSGWgiZ" role="3bR37C">
+          <node concept="1Busua" id="5C1tqSGWgj0" role="1SiIV1">
+            <ref role="1Busuk" node="4m8f5php_QJ" resolve="com.mpsbasics.plaintext.yaml" />
+          </node>
+        </node>
+        <node concept="3rtmxn" id="5C1tqSGWgGk" role="3bR31x">
+          <node concept="3LXTmp" id="5C1tqSGWgGl" role="3rtmxm">
+            <node concept="398BVA" id="5C1tqSGWgGm" role="3LXTmr">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="5C1tqSGWgGn" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="5C1tqSGWgGo" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.plaintext.yaml.dsl.base" />
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="5C1tqSGWgGq" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtA" id="36zCbqqq9fZ" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="com.mpsbasics.langchain4j" />
+        <property role="3LESm3" value="033ccb15-c42a-4e5a-82f2-5fe5cdc5fd43" />
+        <node concept="398BVA" id="36zCbqqq9yc" role="3LF7KH">
+          <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+          <node concept="2Ry0Ak" id="36zCbqqqa1c" role="iGT6I">
+            <property role="2Ry0Am" value="solutions" />
+            <node concept="2Ry0Ak" id="36zCbqqqa_x" role="2Ry0An">
+              <property role="2Ry0Am" value="com.mpsbasics.langchain4j" />
+              <node concept="2Ry0Ak" id="36zCbqqqb4w" role="2Ry0An">
+                <property role="2Ry0Am" value="com.mpsbasics.langchain4j.msd" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="36zCbqqqb$F" role="3bR37C">
+          <node concept="3bR9La" id="36zCbqqqb$G" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="36zCbqqqb$H" role="3bR37C">
+          <node concept="3bR9La" id="36zCbqqqb$I" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:3HV74$ebibC" resolve="jetbrains.mps.lang.text" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="36zCbqqqb$J" role="3bR37C">
+          <node concept="3bR9La" id="36zCbqqqb$K" role="1SiIV1">
+            <ref role="3bR37D" node="36zCbqqq6a9" resolve="com.mpsbasics.genai" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="36zCbqqqb$L" role="3bR37C">
+          <node concept="3bR9La" id="36zCbqqqb$M" role="1SiIV1">
+            <ref role="3bR37D" node="2u7UHDC1RNf" resolve="com.mpsbasics.pdfbox" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="36zCbqqqb$N" role="3bR37C">
+          <node concept="3bR9La" id="36zCbqqqb$O" role="1SiIV1">
+            <ref role="3bR37D" to="al5i:6o5cjw5gEyi" resolve="com.mbeddr.mpsutil.json" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="36zCbqqqb_2" role="3bR37C">
+          <node concept="1BurEX" id="36zCbqqqb_3" role="1SiIV1">
+            <node concept="398BVA" id="36zCbqqqb$P" role="1BurEY">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="36zCbqqqb$Q" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="36zCbqqqb$R" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.langchain4j" />
+                  <node concept="2Ry0Ak" id="36zCbqqqb$S" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="36zCbqqqb$T" role="2Ry0An">
+                      <property role="2Ry0Am" value="langchain4j.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="36zCbqqqb_h" role="3bR37C">
+          <node concept="1BurEX" id="36zCbqqqb_i" role="1SiIV1">
+            <node concept="398BVA" id="36zCbqqqb_4" role="1BurEY">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="36zCbqqqb_5" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="36zCbqqqb_6" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.langchain4j" />
+                  <node concept="2Ry0Ak" id="36zCbqqqb_7" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="36zCbqqqb_8" role="2Ry0An">
+                      <property role="2Ry0Am" value="opennlp-tools.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="36zCbqqqb_w" role="3bR37C">
+          <node concept="1BurEX" id="36zCbqqqb_x" role="1SiIV1">
+            <node concept="398BVA" id="36zCbqqqb_j" role="1BurEY">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="36zCbqqqb_k" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="36zCbqqqb_l" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.langchain4j" />
+                  <node concept="2Ry0Ak" id="36zCbqqqb_m" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="36zCbqqqb_n" role="2Ry0An">
+                      <property role="2Ry0Am" value="jackson-annotations.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="36zCbqqqb_J" role="3bR37C">
+          <node concept="1BurEX" id="36zCbqqqb_K" role="1SiIV1">
+            <node concept="398BVA" id="36zCbqqqb_y" role="1BurEY">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="36zCbqqqb_z" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="36zCbqqqb_$" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.langchain4j" />
+                  <node concept="2Ry0Ak" id="36zCbqqqb__" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="36zCbqqqb_A" role="2Ry0An">
+                      <property role="2Ry0Am" value="jackson-core.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="36zCbqqqb_Y" role="3bR37C">
+          <node concept="1BurEX" id="36zCbqqqb_Z" role="1SiIV1">
+            <node concept="398BVA" id="36zCbqqqb_L" role="1BurEY">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="36zCbqqqb_M" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="36zCbqqqb_N" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.langchain4j" />
+                  <node concept="2Ry0Ak" id="36zCbqqqb_O" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="36zCbqqqb_P" role="2Ry0An">
+                      <property role="2Ry0Am" value="jackson-databind.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="36zCbqqqbAd" role="3bR37C">
+          <node concept="1BurEX" id="36zCbqqqbAe" role="1SiIV1">
+            <node concept="398BVA" id="36zCbqqqbA0" role="1BurEY">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="36zCbqqqbA1" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="36zCbqqqbA2" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.langchain4j" />
+                  <node concept="2Ry0Ak" id="36zCbqqqbA3" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="36zCbqqqbA4" role="2Ry0An">
+                      <property role="2Ry0Am" value="jspecify.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="36zCbqqqbAs" role="3bR37C">
+          <node concept="1BurEX" id="36zCbqqqbAt" role="1SiIV1">
+            <node concept="398BVA" id="36zCbqqqbAf" role="1BurEY">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="36zCbqqqbAg" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="36zCbqqqbAh" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.langchain4j" />
+                  <node concept="2Ry0Ak" id="36zCbqqqbAi" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="36zCbqqqbAj" role="2Ry0An">
+                      <property role="2Ry0Am" value="jtokkit.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="36zCbqqqbAF" role="3bR37C">
+          <node concept="1BurEX" id="36zCbqqqbAG" role="1SiIV1">
+            <node concept="398BVA" id="36zCbqqqbAu" role="1BurEY">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="36zCbqqqbAv" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="36zCbqqqbAw" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.langchain4j" />
+                  <node concept="2Ry0Ak" id="36zCbqqqbAx" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="36zCbqqqbAy" role="2Ry0An">
+                      <property role="2Ry0Am" value="langchain4j-core.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="36zCbqqqbAU" role="3bR37C">
+          <node concept="1BurEX" id="36zCbqqqbAV" role="1SiIV1">
+            <node concept="398BVA" id="36zCbqqqbAH" role="1BurEY">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="36zCbqqqbAI" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="36zCbqqqbAJ" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.langchain4j" />
+                  <node concept="2Ry0Ak" id="36zCbqqqbAK" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="36zCbqqqbAL" role="2Ry0An">
+                      <property role="2Ry0Am" value="langchain4j-http-client-jdk.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="36zCbqqqbB9" role="3bR37C">
+          <node concept="1BurEX" id="36zCbqqqbBa" role="1SiIV1">
+            <node concept="398BVA" id="36zCbqqqbAW" role="1BurEY">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="36zCbqqqbAX" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="36zCbqqqbAY" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.langchain4j" />
+                  <node concept="2Ry0Ak" id="36zCbqqqbAZ" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="36zCbqqqbB0" role="2Ry0An">
+                      <property role="2Ry0Am" value="langchain4j-http-client.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="36zCbqqqbBo" role="3bR37C">
+          <node concept="1BurEX" id="36zCbqqqbBp" role="1SiIV1">
+            <node concept="398BVA" id="36zCbqqqbBb" role="1BurEY">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="36zCbqqqbBc" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="36zCbqqqbBd" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.langchain4j" />
+                  <node concept="2Ry0Ak" id="36zCbqqqbBe" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="36zCbqqqbBf" role="2Ry0An">
+                      <property role="2Ry0Am" value="langchain4j-open-ai.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1BupzO" id="36zCbqqqbBO" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="36zCbqqqbBP" role="1HemKq">
+            <node concept="398BVA" id="36zCbqqqbBD" role="3LXTmr">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="36zCbqqqbBE" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="36zCbqqqbBF" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.langchain4j" />
+                  <node concept="2Ry0Ak" id="36zCbqqqbBG" role="2Ry0An">
+                    <property role="2Ry0Am" value="models" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="36zCbqqqbBQ" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+        <node concept="3rtmxn" id="3d7CvMnNV2Q" role="3bR31x">
+          <node concept="3LXTmp" id="3d7CvMnNV2R" role="3rtmxm">
+            <node concept="3qWCbU" id="3d7CvMnNV2S" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="3d7CvMnNV2T" role="3LXTmr">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="3d7CvMnNV2U" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="3d7CvMnNV2V" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.langchain4j" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtD" id="36zCbqqq6a9" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="com.mpsbasics.genai" />
+        <property role="3LESm3" value="e49ae71b-b7a6-4321-84b6-ac9a82e13853" />
+        <node concept="398BVA" id="36zCbqqq6sm" role="3LF7KH">
+          <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+          <node concept="2Ry0Ak" id="36zCbqqq70G" role="iGT6I">
+            <property role="2Ry0Am" value="languages" />
+            <node concept="2Ry0Ak" id="36zCbqqq7vF" role="2Ry0An">
+              <property role="2Ry0Am" value="com.mpsbasics.genai" />
+              <node concept="2Ry0Ak" id="36zCbqqq840" role="2Ry0An">
+                <property role="2Ry0Am" value="com.mpsbasics.genai.mpl" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="36zCbqqq8uP" role="3bR37C">
+          <node concept="3bR9La" id="36zCbqqq8uQ" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:3HV74$ebibC" resolve="jetbrains.mps.lang.text" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="36zCbqqq8uR" role="3bR37C">
+          <node concept="3bR9La" id="36zCbqqq8uS" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:4SM2EuqHUPF" resolve="jetbrains.mps.lang.modelapi" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="36zCbqqq8uT" role="3bR37C">
+          <node concept="3bR9La" id="36zCbqqq8uU" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1TaHNgiIbIZ" resolve="MPS.Editor" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="36zCbqqq8uV" role="3bR37C">
+          <node concept="3bR9La" id="36zCbqqq8uW" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6LfQ" resolve="jetbrains.mps.kernel" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="36zCbqqq8uX" role="3bR37C">
+          <node concept="3bR9La" id="36zCbqqq8uY" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6L9O" resolve="jetbrains.mps.lang.smodel" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="36zCbqqq8uZ" role="3bR37C">
+          <node concept="3bR9La" id="36zCbqqq8v0" role="1SiIV1">
+            <ref role="3bR37D" to="al5i:6o5cjw5gEyi" resolve="com.mbeddr.mpsutil.json" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="36zCbqqq8v1" role="3bR37C">
+          <node concept="3bR9La" id="36zCbqqq8v2" role="1SiIV1">
+            <ref role="3bR37D" to="al5i:Vtr7jyAKU4" resolve="com.mbeddr.mpsutil.filepicker" />
+          </node>
+        </node>
+        <node concept="1BupzO" id="36zCbqqq8ve" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="36zCbqqq8vf" role="1HemKq">
+            <node concept="398BVA" id="36zCbqqq8v3" role="3LXTmr">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="36zCbqqq8v4" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="36zCbqqq8v5" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.genai" />
+                  <node concept="2Ry0Ak" id="36zCbqqq8v6" role="2Ry0An">
+                    <property role="2Ry0Am" value="models" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="36zCbqqq8vg" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="36zCbqqqcpD" role="3bR37C">
+          <node concept="3bR9La" id="36zCbqqqcpE" role="1SiIV1">
+            <ref role="3bR37D" node="36zCbqqq9fZ" resolve="com.mpsbasics.langchain4j" />
+          </node>
+        </node>
+        <node concept="3rtmxn" id="3d7CvMnNV2X" role="3bR31x">
+          <node concept="3LXTmp" id="3d7CvMnNV2Y" role="3rtmxm">
+            <node concept="3qWCbU" id="3d7CvMnNV2Z" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="3d7CvMnNV30" role="3LXTmr">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="3d7CvMnNV31" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="3d7CvMnNV32" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.genai" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2G$12M" id="2MrvZqtGQDM" role="3989C9">
+      <property role="TrG5h" value="com.mpsbasics.testutils" />
+      <node concept="1E1JtA" id="5gFsbf33R6e" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="com.mpsbasics.docx4j.testutils" />
+        <property role="3LESm3" value="5f04c496-eb21-4501-981b-4e5fc2ab46ec" />
+        <node concept="398BVA" id="5gFsbf33R6f" role="3LF7KH">
+          <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+          <node concept="2Ry0Ak" id="5gFsbf33R6g" role="iGT6I">
+            <property role="2Ry0Am" value="solutions" />
+            <node concept="2Ry0Ak" id="5gFsbf33R6h" role="2Ry0An">
+              <property role="2Ry0Am" value="com.mpsbasics.docx4j.testutils" />
+              <node concept="2Ry0Ak" id="5gFsbf33R6i" role="2Ry0An">
+                <property role="2Ry0Am" value="com.mpsbasics.docx4j.testutils.msd" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="5gFsbf33R6j" role="3bR37C">
+          <node concept="3bR9La" id="5gFsbf33R6k" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="5gFsbf33R6l" role="3bR37C">
+          <node concept="3bR9La" id="5gFsbf33R6m" role="1SiIV1">
+            <ref role="3bR37D" node="6hyv0iVPlFI" resolve="com.mpsbasics.docx4j.lib" />
+          </node>
+        </node>
+        <node concept="1BupzO" id="5gFsbf33R6n" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="5gFsbf33R6o" role="1HemKq">
+            <node concept="398BVA" id="5gFsbf33R6p" role="3LXTmr">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="5gFsbf33R6q" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="5gFsbf33R6r" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.testutils" />
+                  <node concept="2Ry0Ak" id="5gFsbf33R6s" role="2Ry0An">
+                    <property role="2Ry0Am" value="models" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="5gFsbf33R6t" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+        <node concept="3rtmxn" id="4euqtkrusDT" role="3bR31x">
+          <node concept="3LXTmp" id="4euqtkrusDU" role="3rtmxm">
+            <node concept="3qWCbU" id="4euqtkrusDV" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="4euqtkrusDW" role="3LXTmr">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="4euqtkrusDX" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="4euqtkrusDY" role="2Ry0An">
                   <property role="2Ry0Am" value="com.mpsbasics.docx4j.testutils" />
                 </node>
               </node>
@@ -1288,6 +3059,33 @@
               <property role="2Ry0Am" value="solutions" />
               <node concept="2Ry0Ak" id="4euqtkrlyTG" role="2Ry0An">
                 <property role="2Ry0Am" value="com.mpsbasics.build" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1SiIV0" id="5gFsbf33ZS6" role="3bR37C">
+        <node concept="3bR9La" id="5gFsbf33ZS7" role="1SiIV1">
+          <ref role="3bR37D" to="90a9:PE3B26VOkn" resolve="de.itemis.mps.extensions.build" />
+        </node>
+      </node>
+      <node concept="1SiIV0" id="5gFsbf33ZS8" role="3bR37C">
+        <node concept="3bR9La" id="5gFsbf33ZS9" role="1SiIV1">
+          <ref role="3bR37D" to="al5i:7Pr7tifzlku" resolve="com.mbeddr.platform" />
+        </node>
+      </node>
+    </node>
+    <node concept="55IIr" id="5gFsbf33T6f" role="auvoZ">
+      <node concept="2Ry0Ak" id="5gFsbf33T6h" role="iGT6I">
+        <property role="2Ry0Am" value=".." />
+        <node concept="2Ry0Ak" id="5gFsbf33T6j" role="2Ry0An">
+          <property role="2Ry0Am" value=".." />
+          <node concept="2Ry0Ak" id="5gFsbf33T6l" role="2Ry0An">
+            <property role="2Ry0Am" value=".." />
+            <node concept="2Ry0Ak" id="5gFsbf33T6o" role="2Ry0An">
+              <property role="2Ry0Am" value="build" />
+              <node concept="2Ry0Ak" id="5gFsbf33T6q" role="2Ry0An">
+                <property role="2Ry0Am" value="scripts" />
               </node>
             </node>
           </node>

--- a/code/languages/com.mpsbasics/solutions/com.mpsbasics.build/models/com.mpsbasics.build.build.mps
+++ b/code/languages/com.mpsbasics/solutions/com.mpsbasics.build/models/com.mpsbasics.build.build.mps
@@ -423,11 +423,6 @@
             <ref role="3bR37D" to="ffeo:1TaHNgiIbJb" resolve="MPS.Platform" />
           </node>
         </node>
-        <node concept="1SiIV0" id="6oMDOnZjq5H" role="3bR37C">
-          <node concept="3bR9La" id="6oMDOnZjq5I" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:7Kfy9QB6L4p" resolve="jetbrains.mps.lang.behavior" />
-          </node>
-        </node>
       </node>
       <node concept="1E1JtA" id="42jqVeFkUuP" role="2G$12L">
         <property role="BnDLt" value="true" />
@@ -448,11 +443,6 @@
         <node concept="1SiIV0" id="42jqVeFl1HO" role="3bR37C">
           <node concept="3bR9La" id="42jqVeFl1HP" role="1SiIV1">
             <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="3jaLROLwp0d" role="3bR37C">
-          <node concept="3bR9La" id="3jaLROLwp0e" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1TaHNgiHrmy" resolve="jetbrains.mps.java.stub" />
           </node>
         </node>
         <node concept="1SiIV0" id="2fGryx5rwdQ" role="3bR37C">
@@ -740,25 +730,6 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="2fGryx5rwhn" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rwho" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rwha" role="1BurEY">
-              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rwhb" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rwhc" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rwhd" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rwhe" role="2Ry0An">
-                      <property role="2Ry0Am" value="jakarta.activation.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
         <node concept="1SiIV0" id="2fGryx5rwhA" role="3bR37C">
           <node concept="1BurEX" id="2fGryx5rwhB" role="1SiIV1">
             <node concept="398BVA" id="2fGryx5rwhp" role="1BurEY">
@@ -771,25 +742,6 @@
                     <property role="2Ry0Am" value="lib" />
                     <node concept="2Ry0Ak" id="2fGryx5rwht" role="2Ry0An">
                       <property role="2Ry0Am" value="jakarta.mail-api.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fGryx5rwhP" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rwhQ" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rwhC" role="1BurEY">
-              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rwhD" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rwhE" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rwhF" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rwhG" role="2Ry0An">
-                      <property role="2Ry0Am" value="jakarta.mail.jar" />
                     </node>
                   </node>
                 </node>
@@ -949,25 +901,6 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="2fGryx5rwjW" role="3bR37C">
-          <node concept="1BurEX" id="2fGryx5rwjX" role="1SiIV1">
-            <node concept="398BVA" id="2fGryx5rwjJ" role="1BurEY">
-              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
-              <node concept="2Ry0Ak" id="2fGryx5rwjK" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2fGryx5rwjL" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
-                  <node concept="2Ry0Ak" id="2fGryx5rwjM" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2fGryx5rwjN" role="2Ry0An">
-                      <property role="2Ry0Am" value="slf4j-api.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
         <node concept="1SiIV0" id="2fGryx5rwkb" role="3bR37C">
           <node concept="1BurEX" id="2fGryx5rwkc" role="1SiIV1">
             <node concept="398BVA" id="2fGryx5rwjY" role="1BurEY">
@@ -1072,6 +1005,158 @@
                     <property role="2Ry0Am" value="lib" />
                     <node concept="2Ry0Ak" id="2fGryx5rwkY" role="2Ry0An">
                       <property role="2Ry0Am" value="xmlgraphics-commons.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6CRJe3tfAxU" role="3bR37C">
+          <node concept="1BurEX" id="6CRJe3tfAxV" role="1SiIV1">
+            <node concept="398BVA" id="6CRJe3tfAxH" role="1BurEY">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="6CRJe3tfAxI" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="6CRJe3tfAxJ" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
+                  <node concept="2Ry0Ak" id="6CRJe3tfAxK" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="6CRJe3tfAxL" role="2Ry0An">
+                      <property role="2Ry0Am" value="angus-activation.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6CRJe3tfAy9" role="3bR37C">
+          <node concept="1BurEX" id="6CRJe3tfAya" role="1SiIV1">
+            <node concept="398BVA" id="6CRJe3tfAxW" role="1BurEY">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="6CRJe3tfAxX" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="6CRJe3tfAxY" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
+                  <node concept="2Ry0Ak" id="6CRJe3tfAxZ" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="6CRJe3tfAy0" role="2Ry0An">
+                      <property role="2Ry0Am" value="angus-mail.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6CRJe3tfAzc" role="3bR37C">
+          <node concept="1BurEX" id="6CRJe3tfAzd" role="1SiIV1">
+            <node concept="398BVA" id="6CRJe3tfAyZ" role="1BurEY">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="6CRJe3tfAz0" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="6CRJe3tfAz1" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
+                  <node concept="2Ry0Ak" id="6CRJe3tfAz2" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="6CRJe3tfAz3" role="2Ry0An">
+                      <property role="2Ry0Am" value="commons-collections4.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6CRJe3tfA$2" role="3bR37C">
+          <node concept="1BurEX" id="6CRJe3tfA$3" role="1SiIV1">
+            <node concept="398BVA" id="6CRJe3tfAzP" role="1BurEY">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="6CRJe3tfAzQ" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="6CRJe3tfAzR" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
+                  <node concept="2Ry0Ak" id="6CRJe3tfAzS" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="6CRJe3tfAzT" role="2Ry0An">
+                      <property role="2Ry0Am" value="commons-logging.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6CRJe3tfAAy" role="3bR37C">
+          <node concept="1BurEX" id="6CRJe3tfAAz" role="1SiIV1">
+            <node concept="398BVA" id="6CRJe3tfAAl" role="1BurEY">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="6CRJe3tfAAm" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="6CRJe3tfAAn" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
+                  <node concept="2Ry0Ak" id="6CRJe3tfAAo" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="6CRJe3tfAAp" role="2Ry0An">
+                      <property role="2Ry0Am" value="jaxb-core.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6CRJe3tfABd" role="3bR37C">
+          <node concept="1BurEX" id="6CRJe3tfABe" role="1SiIV1">
+            <node concept="398BVA" id="6CRJe3tfAB0" role="1BurEY">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="6CRJe3tfAB1" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="6CRJe3tfAB2" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
+                  <node concept="2Ry0Ak" id="6CRJe3tfAB3" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="6CRJe3tfAB4" role="2Ry0An">
+                      <property role="2Ry0Am" value="jaxb-xjc.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6CRJe3tfACt" role="3bR37C">
+          <node concept="1BurEX" id="6CRJe3tfACu" role="1SiIV1">
+            <node concept="398BVA" id="6CRJe3tfACg" role="1BurEY">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="6CRJe3tfACh" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="6CRJe3tfACi" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
+                  <node concept="2Ry0Ak" id="6CRJe3tfACj" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="6CRJe3tfACk" role="2Ry0An">
+                      <property role="2Ry0Am" value="pdfbox-io.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6CRJe3tfACT" role="3bR37C">
+          <node concept="1BurEX" id="6CRJe3tfACU" role="1SiIV1">
+            <node concept="398BVA" id="6CRJe3tfACG" role="1BurEY">
+              <ref role="398BVh" node="6mm$FLYQyYs" resolve="mpsbasics.code" />
+              <node concept="2Ry0Ak" id="6CRJe3tfACH" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="6CRJe3tfACI" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.lib" />
+                  <node concept="2Ry0Ak" id="6CRJe3tfACJ" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="6CRJe3tfACK" role="2Ry0An">
+                      <property role="2Ry0Am" value="SparseBitSet.jar" />
                     </node>
                   </node>
                 </node>

--- a/code/languages/com.mpsbasics/solutions/com.mpsbasics.docx4j.core/models/com.mpsbasics.docx4j.core.mps
+++ b/code/languages/com.mpsbasics/solutions/com.mpsbasics.docx4j.core/models/com.mpsbasics.docx4j.core.mps
@@ -1,0 +1,340 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:085b85cb-e7c0-47a8-a09c-179bb5398b5c(com.mpsbasics.docx4j.core)">
+  <persistence version="9" />
+  <languages>
+    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
+    <use id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc" version="2" />
+  </languages>
+  <imports>
+    <import index="5zyv" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util.concurrent(JDK/)" />
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
+  </imports>
+  <registry>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
+        <child id="1082485599096" name="statements" index="9aQI4" />
+      </concept>
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1081236700938" name="jetbrains.mps.baseLanguage.structure.StaticMethodDeclaration" flags="ig" index="2YIFZL" />
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
+      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu">
+        <property id="1221565133444" name="isFinal" index="1EXbeo" />
+      </concept>
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1109279763828" name="jetbrains.mps.baseLanguage.structure.TypeVariableDeclaration" flags="ng" index="16euLQ" />
+      <concept id="1109279851642" name="jetbrains.mps.baseLanguage.structure.GenericDeclaration" flags="ng" index="16eOlS">
+        <child id="1109279881614" name="typeVariableDeclaration" index="16eVyc" />
+      </concept>
+      <concept id="1109283449304" name="jetbrains.mps.baseLanguage.structure.TypeVariableReference" flags="in" index="16syzq">
+        <reference id="1109283546497" name="typeVariableDeclaration" index="16sUi3" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
+      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1164879685961" name="throwsItem" index="Sfmx6" />
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123134" name="parameter" index="3clF46" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
+        <child id="1082485599094" name="ifFalseStatement" index="9aQIa" />
+        <child id="1068580123160" name="condition" index="3clFbw" />
+        <child id="1068580123161" name="ifTrue" index="3clFbx" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580123140" name="jetbrains.mps.baseLanguage.structure.ConstructorDeclaration" flags="ig" index="3clFbW" />
+      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
+        <child id="1068581517676" name="expression" index="3cqZAk" />
+      </concept>
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
+        <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
+      </concept>
+      <concept id="7812454656619025412" name="jetbrains.mps.baseLanguage.structure.LocalMethodCall" flags="nn" index="1rXfSq" />
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+        <child id="1109201940907" name="parameter" index="11_B2D" />
+      </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
+      <concept id="8276990574909231788" name="jetbrains.mps.baseLanguage.structure.FinallyClause" flags="ng" index="1wplmZ">
+        <child id="8276990574909234106" name="finallyBody" index="1wplMD" />
+      </concept>
+      <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="5351203823916750322" name="jetbrains.mps.baseLanguage.structure.TryUniversalStatement" flags="nn" index="3J1_TO">
+        <child id="8276990574886367509" name="finallyClause" index="1zxBo6" />
+        <child id="8276990574886367508" name="body" index="1zxBo7" />
+      </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+      <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
+    </language>
+    <language id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc">
+      <concept id="5349172909345501395" name="jetbrains.mps.baseLanguage.javadoc.structure.BaseDocComment" flags="ng" index="P$AiS">
+        <child id="8465538089690331502" name="body" index="TZ5H$" />
+      </concept>
+      <concept id="5349172909345532724" name="jetbrains.mps.baseLanguage.javadoc.structure.MethodDocComment" flags="ng" index="P$JXv" />
+      <concept id="8465538089690331500" name="jetbrains.mps.baseLanguage.javadoc.structure.CommentLine" flags="ng" index="TZ5HA">
+        <child id="8970989240999019149" name="part" index="1dT_Ay" />
+      </concept>
+      <concept id="2217234381367049075" name="jetbrains.mps.baseLanguage.javadoc.structure.CodeInlineDocTag" flags="ng" index="VVOAv">
+        <child id="3106559687488741665" name="line" index="2Xj1qM" />
+      </concept>
+      <concept id="8970989240999019145" name="jetbrains.mps.baseLanguage.javadoc.structure.InlineTagCommentLinePart" flags="ng" index="1dT_AA">
+        <child id="6962838954693749192" name="tag" index="qph3F" />
+      </concept>
+      <concept id="8970989240999019143" name="jetbrains.mps.baseLanguage.javadoc.structure.TextCommentLinePart" flags="ng" index="1dT_AC">
+        <property id="8970989240999019144" name="text" index="1dT_AB" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="312cEu" id="7yOrhoDzQ2f">
+    <property role="TrG5h" value="Docx4j" />
+    <property role="1EXbeo" value="true" />
+    <node concept="3clFbW" id="7yOrhoDzQ41" role="jymVt">
+      <node concept="3cqZAl" id="7yOrhoDzQ42" role="3clF45" />
+      <node concept="3clFbS" id="7yOrhoDzQ44" role="3clF47" />
+      <node concept="3Tm6S6" id="7yOrhoDzQ3P" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="7yOrhoD$tA2" role="jymVt" />
+    <node concept="2YIFZL" id="7yOrhoD$tn1" role="jymVt">
+      <property role="TrG5h" value="runWithDocx4j" />
+      <node concept="16euLQ" id="7yOrhoD$tn2" role="16eVyc">
+        <property role="TrG5h" value="T" />
+      </node>
+      <node concept="37vLTG" id="7yOrhoD$tn3" role="3clF46">
+        <property role="TrG5h" value="action" />
+        <node concept="3uibUv" id="7yOrhoD$tn4" role="1tU5fm">
+          <ref role="3uigEE" to="5zyv:~Callable" resolve="Callable" />
+          <node concept="16syzq" id="7yOrhoD$tn5" role="11_B2D">
+            <ref role="16sUi3" node="7yOrhoD$tn2" resolve="T" />
+          </node>
+        </node>
+      </node>
+      <node concept="3uibUv" id="7yOrhoD$tn6" role="Sfmx6">
+        <ref role="3uigEE" to="wyt6:~Exception" resolve="Exception" />
+      </node>
+      <node concept="3clFbS" id="7yOrhoD$tn7" role="3clF47">
+        <node concept="3cpWs8" id="7yOrhoD$tn9" role="3cqZAp">
+          <node concept="3cpWsn" id="7yOrhoD$tn8" role="3cpWs9">
+            <property role="TrG5h" value="origJaxb" />
+            <node concept="17QB3L" id="7yOrhoD$tEu" role="1tU5fm" />
+            <node concept="2YIFZM" id="7yOrhoD$tsF" role="33vP2m">
+              <ref role="1Pybhc" to="wyt6:~System" resolve="System" />
+              <ref role="37wK5l" to="wyt6:~System.getProperty(java.lang.String)" resolve="getProperty" />
+              <node concept="Xl_RD" id="7yOrhoD$tsG" role="37wK5m">
+                <property role="Xl_RC" value="jakarta.xml.bind.JAXBContextFactory" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7yOrhoD$tne" role="3cqZAp">
+          <node concept="3cpWsn" id="7yOrhoD$tnd" role="3cpWs9">
+            <property role="TrG5h" value="origStax" />
+            <node concept="17QB3L" id="7yOrhoD$tJ4" role="1tU5fm" />
+            <node concept="2YIFZM" id="7yOrhoD$tsz" role="33vP2m">
+              <ref role="1Pybhc" to="wyt6:~System" resolve="System" />
+              <ref role="37wK5l" to="wyt6:~System.getProperty(java.lang.String)" resolve="getProperty" />
+              <node concept="Xl_RD" id="7yOrhoD$ts$" role="37wK5m">
+                <property role="Xl_RC" value="javax.xml.stream.XMLInputFactory" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3J1_TO" id="7yOrhoD$tnC" role="3cqZAp">
+          <node concept="1wplmZ" id="7yOrhoD$tnD" role="1zxBo6">
+            <node concept="3clFbS" id="7yOrhoD$tnv" role="1wplMD">
+              <node concept="3clFbF" id="7yOrhoD$tnw" role="3cqZAp">
+                <node concept="1rXfSq" id="7yOrhoD$tnx" role="3clFbG">
+                  <ref role="37wK5l" node="7yOrhoD$tnG" resolve="restoreProperty" />
+                  <node concept="Xl_RD" id="7yOrhoD$tny" role="37wK5m">
+                    <property role="Xl_RC" value="jakarta.xml.bind.JAXBContextFactory" />
+                  </node>
+                  <node concept="37vLTw" id="7yOrhoD$tnz" role="37wK5m">
+                    <ref role="3cqZAo" node="7yOrhoD$tn8" resolve="origJaxb" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="7yOrhoD$tn$" role="3cqZAp">
+                <node concept="1rXfSq" id="7yOrhoD$tn_" role="3clFbG">
+                  <ref role="37wK5l" node="7yOrhoD$tnG" resolve="restoreProperty" />
+                  <node concept="Xl_RD" id="7yOrhoD$tnA" role="37wK5m">
+                    <property role="Xl_RC" value="javax.xml.stream.XMLInputFactory" />
+                  </node>
+                  <node concept="37vLTw" id="7yOrhoD$tnB" role="37wK5m">
+                    <ref role="3cqZAo" node="7yOrhoD$tnd" resolve="origStax" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbS" id="7yOrhoD$tnj" role="1zxBo7">
+            <node concept="3clFbF" id="7yOrhoD$tnk" role="3cqZAp">
+              <node concept="2YIFZM" id="7yOrhoD$tsq" role="3clFbG">
+                <ref role="1Pybhc" to="wyt6:~System" resolve="System" />
+                <ref role="37wK5l" to="wyt6:~System.setProperty(java.lang.String,java.lang.String)" resolve="setProperty" />
+                <node concept="Xl_RD" id="7yOrhoD$tsr" role="37wK5m">
+                  <property role="Xl_RC" value="jakarta.xml.bind.JAXBContextFactory" />
+                </node>
+                <node concept="Xl_RD" id="7yOrhoD$tss" role="37wK5m">
+                  <property role="Xl_RC" value="org.eclipse.persistence.jaxb.JAXBContextFactory" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="7yOrhoD$tno" role="3cqZAp">
+              <node concept="2YIFZM" id="7yOrhoD$tsh" role="3clFbG">
+                <ref role="1Pybhc" to="wyt6:~System" resolve="System" />
+                <ref role="37wK5l" to="wyt6:~System.setProperty(java.lang.String,java.lang.String)" resolve="setProperty" />
+                <node concept="Xl_RD" id="7yOrhoD$tsi" role="37wK5m">
+                  <property role="Xl_RC" value="javax.xml.stream.XMLInputFactory" />
+                </node>
+                <node concept="Xl_RD" id="7yOrhoD$tsj" role="37wK5m">
+                  <property role="Xl_RC" value="com.sun.xml.internal.stream.XMLInputFactoryImpl" />
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs6" id="7yOrhoD$tns" role="3cqZAp">
+              <node concept="2OqwBi" id="7yOrhoD$twU" role="3cqZAk">
+                <node concept="37vLTw" id="7yOrhoD$trW" role="2Oq$k0">
+                  <ref role="3cqZAo" node="7yOrhoD$tn3" resolve="action" />
+                </node>
+                <node concept="liA8E" id="7yOrhoD$twV" role="2OqNvi">
+                  <ref role="37wK5l" to="5zyv:~Callable.call()" resolve="call" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="7yOrhoD$tnE" role="1B3o_S" />
+      <node concept="16syzq" id="7yOrhoD$tnF" role="3clF45">
+        <ref role="16sUi3" node="7yOrhoD$tn2" resolve="T" />
+      </node>
+      <node concept="P$JXv" id="6yl8m87fFor" role="lGtFl">
+        <node concept="TZ5HA" id="6yl8m87fFos" role="TZ5H$">
+          <node concept="1dT_AC" id="6yl8m87fFot" role="1dT_Ay">
+            <property role="1dT_AB" value="Run " />
+          </node>
+          <node concept="1dT_AA" id="6yl8m87fFFZ" role="1dT_Ay">
+            <node concept="VVOAv" id="6yl8m87fFG1" role="qph3F">
+              <node concept="TZ5HA" id="6yl8m87fFG3" role="2Xj1qM">
+                <node concept="1dT_AC" id="6yl8m87fFGl" role="1dT_Ay">
+                  <property role="1dT_AB" value="action" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1dT_AC" id="6yl8m87fFFY" role="1dT_Ay">
+            <property role="1dT_AB" value=" while temporarily setting system properties that let JAXB find the correct factory" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="6yl8m87fG0O" role="TZ5H$">
+          <node concept="1dT_AC" id="6yl8m87fG0P" role="1dT_Ay">
+            <property role="1dT_AB" value="and XML parser for docx4j to work." />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2YIFZL" id="7yOrhoD$tnG" role="jymVt">
+      <property role="TrG5h" value="restoreProperty" />
+      <node concept="37vLTG" id="7yOrhoD$tnH" role="3clF46">
+        <property role="TrG5h" value="key" />
+        <node concept="3uibUv" id="7yOrhoD$tnI" role="1tU5fm">
+          <ref role="3uigEE" to="wyt6:~String" resolve="String" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="7yOrhoD$tnJ" role="3clF46">
+        <property role="TrG5h" value="original" />
+        <node concept="3uibUv" id="7yOrhoD$tnK" role="1tU5fm">
+          <ref role="3uigEE" to="wyt6:~String" resolve="String" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="7yOrhoD$tnL" role="3clF47">
+        <node concept="3clFbJ" id="7yOrhoD$tnM" role="3cqZAp">
+          <node concept="3y3z36" id="7yOrhoD$tnN" role="3clFbw">
+            <node concept="37vLTw" id="7yOrhoD$tnO" role="3uHU7B">
+              <ref role="3cqZAo" node="7yOrhoD$tnJ" resolve="original" />
+            </node>
+            <node concept="10Nm6u" id="7yOrhoD$tnP" role="3uHU7w" />
+          </node>
+          <node concept="3clFbS" id="7yOrhoD$tnX" role="3clFbx">
+            <node concept="3clFbF" id="7yOrhoD$tnQ" role="3cqZAp">
+              <node concept="2YIFZM" id="7yOrhoD$ts8" role="3clFbG">
+                <ref role="1Pybhc" to="wyt6:~System" resolve="System" />
+                <ref role="37wK5l" to="wyt6:~System.setProperty(java.lang.String,java.lang.String)" resolve="setProperty" />
+                <node concept="37vLTw" id="7yOrhoD$ts9" role="37wK5m">
+                  <ref role="3cqZAo" node="7yOrhoD$tnH" resolve="key" />
+                </node>
+                <node concept="37vLTw" id="7yOrhoD$tsa" role="37wK5m">
+                  <ref role="3cqZAo" node="7yOrhoD$tnJ" resolve="original" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="9aQIb" id="6yl8m87fHiv" role="9aQIa">
+            <node concept="3clFbS" id="6yl8m87fHiw" role="9aQI4">
+              <node concept="3clFbF" id="6yl8m87fG_p" role="3cqZAp">
+                <node concept="2YIFZM" id="7yOrhoD$ts0" role="3clFbG">
+                  <ref role="1Pybhc" to="wyt6:~System" resolve="System" />
+                  <ref role="37wK5l" to="wyt6:~System.clearProperty(java.lang.String)" resolve="clearProperty" />
+                  <node concept="37vLTw" id="7yOrhoD$ts1" role="37wK5m">
+                    <ref role="3cqZAo" node="7yOrhoD$tnH" resolve="key" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="7yOrhoD$tnY" role="1B3o_S" />
+      <node concept="3cqZAl" id="7yOrhoD$tnZ" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="7yOrhoDzQ4s" role="jymVt" />
+    <node concept="3Tm1VV" id="7yOrhoDzQ2g" role="1B3o_S" />
+  </node>
+</model>
+

--- a/code/languages/com.mpsbasics/solutions/com.mpsbasics.docx4j.core/models/com.mpsbasics.docx4j.core.word.mps
+++ b/code/languages/com.mpsbasics/solutions/com.mpsbasics.docx4j.core/models/com.mpsbasics.docx4j.core.word.mps
@@ -52,6 +52,7 @@
     <import index="1dej" ref="71bb25aa-20fa-4c18-8954-1b176576f52d/java:org.docx4j.model.table(com.mpsbasics.docx4j.lib/)" />
     <import index="ifn4" ref="71bb25aa-20fa-4c18-8954-1b176576f52d/java:jakarta.xml.bind(com.mpsbasics.docx4j.lib/)" />
     <import index="9anm" ref="r:6f374023-1b4e-4a80-8bf6-2cc3148faa52(jetbrains.mps.lang.editor.plugin)" />
+    <import index="i1lw" ref="r:085b85cb-e7c0-47a8-a09c-179bb5398b5c(com.mpsbasics.docx4j.core)" />
     <import index="2uyo" ref="71bb25aa-20fa-4c18-8954-1b176576f52d/java:org.docx4j.model.structure(com.mpsbasics.docx4j.lib/)" implicit="true" />
   </imports>
   <registry>
@@ -417,23 +418,6 @@
       <property role="DiZV1" value="false" />
       <property role="2aFKle" value="false" />
       <node concept="3clFbS" id="6OYO23koTTd" role="3clF47">
-        <node concept="3cpWs8" id="6fO82$FsRM5" role="3cqZAp">
-          <node concept="3cpWsn" id="6fO82$FsRM6" role="3cpWs9">
-            <property role="TrG5h" value="initialLoader" />
-            <node concept="3uibUv" id="6fO82$FsRM3" role="1tU5fm">
-              <ref role="3uigEE" to="wyt6:~ClassLoader" resolve="ClassLoader" />
-            </node>
-            <node concept="2OqwBi" id="6fO82$FsRM7" role="33vP2m">
-              <node concept="2YIFZM" id="6fO82$FsRM8" role="2Oq$k0">
-                <ref role="37wK5l" to="wyt6:~Thread.currentThread()" resolve="currentThread" />
-                <ref role="1Pybhc" to="wyt6:~Thread" resolve="Thread" />
-              </node>
-              <node concept="liA8E" id="6fO82$FsRM9" role="2OqNvi">
-                <ref role="37wK5l" to="wyt6:~Thread.getContextClassLoader()" resolve="getContextClassLoader" />
-              </node>
-            </node>
-          </node>
-        </node>
         <node concept="3cpWs8" id="8rr1id7Ion" role="3cqZAp">
           <node concept="3cpWsn" id="8rr1id7Ioo" role="3cpWs9">
             <property role="TrG5h" value="repo" />
@@ -450,102 +434,89 @@
             </node>
           </node>
         </node>
+        <node concept="3cpWs8" id="2w5Gq4UsmFu" role="3cqZAp">
+          <node concept="3cpWsn" id="2w5Gq4UsmFv" role="3cpWs9">
+            <property role="3TUv4t" value="true" />
+            <property role="TrG5h" value="wordFile" />
+            <node concept="3uibUv" id="2w5Gq4UsmFw" role="1tU5fm">
+              <ref role="3uigEE" to="guwi:~File" resolve="File" />
+            </node>
+            <node concept="2ShNRf" id="2w5Gq4UsmFx" role="33vP2m">
+              <node concept="1pGfFk" id="2w5Gq4UsmFy" role="2ShVmc">
+                <ref role="37wK5l" to="guwi:~File.&lt;init&gt;(java.lang.String)" resolve="File" />
+                <node concept="37vLTw" id="2w5Gq4Usndj" role="37wK5m">
+                  <ref role="3cqZAo" node="6fO82$Fr5qq" resolve="pathToWordFile" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="3J1_TO" id="6fO82$FsSrs" role="3cqZAp">
           <node concept="3clFbS" id="4L3e0yQSC0e" role="1zxBo7">
-            <node concept="3clFbF" id="6fO82$FsTrZ" role="3cqZAp">
-              <node concept="2OqwBi" id="6fO82$FsTKu" role="3clFbG">
-                <node concept="2YIFZM" id="6fO82$FsTCC" role="2Oq$k0">
-                  <ref role="37wK5l" to="wyt6:~Thread.currentThread()" resolve="currentThread" />
-                  <ref role="1Pybhc" to="wyt6:~Thread" resolve="Thread" />
-                </node>
-                <node concept="liA8E" id="6fO82$FsTUr" role="2OqNvi">
-                  <ref role="37wK5l" to="wyt6:~Thread.setContextClassLoader(java.lang.ClassLoader)" resolve="setContextClassLoader" />
-                  <node concept="2OqwBi" id="6fO82$FsVgj" role="37wK5m">
-                    <node concept="2OqwBi" id="6fO82$FsUK8" role="2Oq$k0">
-                      <node concept="2ShNRf" id="6fO82$FsUmt" role="2Oq$k0">
-                        <node concept="1pGfFk" id="2N6uepFeM2a" role="2ShVmc">
-                          <ref role="37wK5l" to="5zxs:~WordprocessingMLPackage.&lt;init&gt;()" resolve="WordprocessingMLPackage" />
+            <node concept="3clFbF" id="7yOrhoD$uOh" role="3cqZAp">
+              <node concept="2YIFZM" id="7yOrhoD$vaM" role="3clFbG">
+                <ref role="37wK5l" to="i1lw:7yOrhoD$tn1" resolve="runWithDocx4j" />
+                <ref role="1Pybhc" to="i1lw:7yOrhoDzQ2f" resolve="Docx4j" />
+                <node concept="1bVj0M" id="7yOrhoD$vsi" role="37wK5m">
+                  <node concept="3clFbS" id="7yOrhoD$vsn" role="1bW5cS">
+                    <node concept="3cpWs8" id="6fO82$Fsbeq" role="3cqZAp">
+                      <node concept="3cpWsn" id="6fO82$Fsber" role="3cpWs9">
+                        <property role="TrG5h" value="wordPackage" />
+                        <node concept="3uibUv" id="2N6uepFeN3z" role="1tU5fm">
+                          <ref role="3uigEE" to="5zxs:~WordprocessingMLPackage" resolve="WordprocessingMLPackage" />
+                        </node>
+                        <node concept="2YIFZM" id="2N6uepFeNgV" role="33vP2m">
+                          <ref role="37wK5l" to="5zxs:~WordprocessingMLPackage.createPackage()" resolve="createPackage" />
+                          <ref role="1Pybhc" to="5zxs:~WordprocessingMLPackage" resolve="WordprocessingMLPackage" />
                         </node>
                       </node>
-                      <node concept="liA8E" id="6fO82$FsV0q" role="2OqNvi">
-                        <ref role="37wK5l" to="wyt6:~Object.getClass()" resolve="getClass" />
+                    </node>
+                    <node concept="3clFbF" id="38aFq1jq91L" role="3cqZAp">
+                      <node concept="2YIFZM" id="38aFq1jq9bO" role="3clFbG">
+                        <ref role="37wK5l" node="38aFq1jq0Vc" resolve="setStyles" />
+                        <ref role="1Pybhc" node="38aFq1jq0ud" resolve="WordStyle" />
+                        <node concept="37vLTw" id="38aFq1jq9ks" role="37wK5m">
+                          <ref role="3cqZAo" node="6fO82$Fsber" resolve="wordPackage" />
+                        </node>
                       </node>
                     </node>
-                    <node concept="liA8E" id="6fO82$FsVGB" role="2OqNvi">
-                      <ref role="37wK5l" to="wyt6:~Class.getClassLoader()" resolve="getClassLoader" />
+                    <node concept="3clFbH" id="38aFq1jq8KJ" role="3cqZAp" />
+                    <node concept="3clFbF" id="6fO82$Fsaeg" role="3cqZAp">
+                      <node concept="1rXfSq" id="6fO82$Fsaee" role="3clFbG">
+                        <ref role="37wK5l" node="6fO82$Framj" resolve="writeNode" />
+                        <node concept="37vLTw" id="2IlB7EiFZqN" role="37wK5m">
+                          <ref role="3cqZAo" node="6fO82$Fsber" resolve="wordPackage" />
+                        </node>
+                        <node concept="37vLTw" id="4K8dCO7y_Ka" role="37wK5m">
+                          <ref role="3cqZAo" node="4K8dCO7yz_P" resolve="nodeToSerialize" />
+                        </node>
+                        <node concept="37vLTw" id="8rr1id7JYV" role="37wK5m">
+                          <ref role="3cqZAo" node="8rr1id7Ioo" resolve="repo" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbH" id="7TkGv4j2liO" role="3cqZAp" />
+                    <node concept="3clFbF" id="2w5Gq4UsmF$" role="3cqZAp">
+                      <node concept="2OqwBi" id="2w5Gq4UsmF_" role="3clFbG">
+                        <node concept="37vLTw" id="2w5Gq4UsmFA" role="2Oq$k0">
+                          <ref role="3cqZAo" node="6fO82$Fsber" resolve="wordPackage" />
+                        </node>
+                        <node concept="liA8E" id="2w5Gq4UsmFB" role="2OqNvi">
+                          <ref role="37wK5l" to="5zxs:~OpcPackage.save(java.io.File)" resolve="save" />
+                          <node concept="37vLTw" id="2w5Gq4UsmFC" role="37wK5m">
+                            <ref role="3cqZAo" node="2w5Gq4UsmFv" resolve="wordFile" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3cpWs6" id="42CSvZahGMR" role="3cqZAp">
+                      <node concept="10Nm6u" id="1rK48R2URdg" role="3cqZAk" />
                     </node>
                   </node>
                 </node>
               </node>
             </node>
-            <node concept="3cpWs8" id="6fO82$Fsbeq" role="3cqZAp">
-              <node concept="3cpWsn" id="6fO82$Fsber" role="3cpWs9">
-                <property role="TrG5h" value="wordPackage" />
-                <node concept="3uibUv" id="2N6uepFeN3z" role="1tU5fm">
-                  <ref role="3uigEE" to="5zxs:~WordprocessingMLPackage" resolve="WordprocessingMLPackage" />
-                </node>
-                <node concept="2YIFZM" id="2N6uepFeNgV" role="33vP2m">
-                  <ref role="37wK5l" to="5zxs:~WordprocessingMLPackage.createPackage()" resolve="createPackage" />
-                  <ref role="1Pybhc" to="5zxs:~WordprocessingMLPackage" resolve="WordprocessingMLPackage" />
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbF" id="38aFq1jq91L" role="3cqZAp">
-              <node concept="2YIFZM" id="38aFq1jq9bO" role="3clFbG">
-                <ref role="37wK5l" node="38aFq1jq0Vc" resolve="setStyles" />
-                <ref role="1Pybhc" node="38aFq1jq0ud" resolve="WordStyle" />
-                <node concept="37vLTw" id="38aFq1jq9ks" role="37wK5m">
-                  <ref role="3cqZAo" node="6fO82$Fsber" resolve="wordPackage" />
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbH" id="38aFq1jq8KJ" role="3cqZAp" />
-            <node concept="3clFbF" id="6fO82$Fsaeg" role="3cqZAp">
-              <node concept="1rXfSq" id="6fO82$Fsaee" role="3clFbG">
-                <ref role="37wK5l" node="6fO82$Framj" resolve="writeNode" />
-                <node concept="37vLTw" id="2IlB7EiFZqN" role="37wK5m">
-                  <ref role="3cqZAo" node="6fO82$Fsber" resolve="wordPackage" />
-                </node>
-                <node concept="37vLTw" id="4K8dCO7y_Ka" role="37wK5m">
-                  <ref role="3cqZAo" node="4K8dCO7yz_P" resolve="nodeToSerialize" />
-                </node>
-                <node concept="37vLTw" id="8rr1id7JYV" role="37wK5m">
-                  <ref role="3cqZAo" node="8rr1id7Ioo" resolve="repo" />
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbH" id="7TkGv4j2liO" role="3cqZAp" />
-            <node concept="3cpWs8" id="2w5Gq4UsmFu" role="3cqZAp">
-              <node concept="3cpWsn" id="2w5Gq4UsmFv" role="3cpWs9">
-                <property role="3TUv4t" value="false" />
-                <property role="TrG5h" value="wordFile" />
-                <node concept="3uibUv" id="2w5Gq4UsmFw" role="1tU5fm">
-                  <ref role="3uigEE" to="guwi:~File" resolve="File" />
-                </node>
-                <node concept="2ShNRf" id="2w5Gq4UsmFx" role="33vP2m">
-                  <node concept="1pGfFk" id="2w5Gq4UsmFy" role="2ShVmc">
-                    <ref role="37wK5l" to="guwi:~File.&lt;init&gt;(java.lang.String)" resolve="File" />
-                    <node concept="37vLTw" id="2w5Gq4Usndj" role="37wK5m">
-                      <ref role="3cqZAo" node="6fO82$Fr5qq" resolve="pathToWordFile" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbF" id="2w5Gq4UsmF$" role="3cqZAp">
-              <node concept="2OqwBi" id="2w5Gq4UsmF_" role="3clFbG">
-                <node concept="37vLTw" id="2w5Gq4UsmFA" role="2Oq$k0">
-                  <ref role="3cqZAo" node="6fO82$Fsber" resolve="wordPackage" />
-                </node>
-                <node concept="liA8E" id="2w5Gq4UsmFB" role="2OqNvi">
-                  <ref role="37wK5l" to="5zxs:~OpcPackage.save(java.io.File)" resolve="save" />
-                  <node concept="37vLTw" id="2w5Gq4UsmFC" role="37wK5m">
-                    <ref role="3cqZAo" node="2w5Gq4UsmFv" resolve="wordFile" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbH" id="3AvLcZoWias" role="3cqZAp" />
+            <node concept="3clFbH" id="1rK48R2UQv4" role="3cqZAp" />
             <node concept="3clFbF" id="8rr1id71zV" role="3cqZAp">
               <node concept="2YIFZM" id="xCk$O6mZNq" role="3clFbG">
                 <ref role="1Pybhc" node="xCk$O6mgDu" resolve="WordNotificationHelper" />
@@ -643,41 +614,16 @@
                               </node>
                             </node>
                             <node concept="3clFbS" id="2kYdJbxbfjh" role="1zxBo7">
-                              <node concept="3cpWs8" id="2kYdJbxbhUk" role="3cqZAp">
-                                <node concept="3cpWsn" id="2kYdJbxbhUi" role="3cpWs9">
-                                  <property role="TrG5h" value="runtimeCommand" />
-                                  <node concept="17QB3L" id="2kYdJbxbiCn" role="1tU5fm" />
-                                  <node concept="3cpWs3" id="2kYdJbxbj_f" role="33vP2m">
-                                    <node concept="Xl_RD" id="2kYdJbxbji5" role="3uHU7B">
-                                      <property role="Xl_RC" value="explorer /select, " />
-                                    </node>
-                                    <node concept="2OqwBi" id="2kYdJbxc278" role="3uHU7w">
-                                      <node concept="37vLTw" id="8rr1id7r16" role="2Oq$k0">
-                                        <ref role="3cqZAo" node="6fO82$Fr5qq" resolve="pathToWordFile" />
-                                      </node>
-                                      <node concept="liA8E" id="2kYdJbxc2sG" role="2OqNvi">
-                                        <ref role="37wK5l" to="wyt6:~String.replace(java.lang.CharSequence,java.lang.CharSequence)" resolve="replace" />
-                                        <node concept="Xl_RD" id="2kYdJbxc341" role="37wK5m">
-                                          <property role="Xl_RC" value="/" />
-                                        </node>
-                                        <node concept="Xl_RD" id="2kYdJbxc49G" role="37wK5m">
-                                          <property role="Xl_RC" value="\\" />
-                                        </node>
-                                      </node>
-                                    </node>
+                              <node concept="3clFbF" id="1rK48R2TRTE" role="3cqZAp">
+                                <node concept="2OqwBi" id="1rK48R2TTnI" role="3clFbG">
+                                  <node concept="2YIFZM" id="1rK48R2TSZK" role="2Oq$k0">
+                                    <ref role="37wK5l" to="z60i:~Desktop.getDesktop()" resolve="getDesktop" />
+                                    <ref role="1Pybhc" to="z60i:~Desktop" resolve="Desktop" />
                                   </node>
-                                </node>
-                              </node>
-                              <node concept="3clFbF" id="2kYdJbxb8Db" role="3cqZAp">
-                                <node concept="2OqwBi" id="2kYdJbxb8Lh" role="3clFbG">
-                                  <node concept="2YIFZM" id="2kYdJbxb8EJ" role="2Oq$k0">
-                                    <ref role="37wK5l" to="wyt6:~Runtime.getRuntime()" resolve="getRuntime" />
-                                    <ref role="1Pybhc" to="wyt6:~Runtime" resolve="Runtime" />
-                                  </node>
-                                  <node concept="liA8E" id="2kYdJbxb8RW" role="2OqNvi">
-                                    <ref role="37wK5l" to="wyt6:~Runtime.exec(java.lang.String)" resolve="exec" />
-                                    <node concept="37vLTw" id="2kYdJbxbmol" role="37wK5m">
-                                      <ref role="3cqZAo" node="2kYdJbxbhUi" resolve="runtimeCommand" />
+                                  <node concept="liA8E" id="1rK48R2TTX4" role="2OqNvi">
+                                    <ref role="37wK5l" to="z60i:~Desktop.browseFileDirectory(java.io.File)" resolve="browseFileDirectory" />
+                                    <node concept="37vLTw" id="1rK48R2UVeq" role="37wK5m">
+                                      <ref role="3cqZAo" node="2w5Gq4UsmFv" resolve="wordFile" />
                                     </node>
                                   </node>
                                 </node>
@@ -813,24 +759,6 @@
                   </node>
                   <node concept="liA8E" id="6fO82$Fr8O3" role="2OqNvi">
                     <ref role="37wK5l" to="wyt6:~Throwable.printStackTrace()" resolve="printStackTrace" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="1wplmZ" id="882InoUALTP" role="1zxBo6">
-            <node concept="3clFbS" id="6fO82$FsSrv" role="1wplMD">
-              <node concept="3clFbF" id="6fO82$FsSJs" role="3cqZAp">
-                <node concept="2OqwBi" id="6fO82$FsSSU" role="3clFbG">
-                  <node concept="2YIFZM" id="6fO82$FsSLb" role="2Oq$k0">
-                    <ref role="1Pybhc" to="wyt6:~Thread" resolve="Thread" />
-                    <ref role="37wK5l" to="wyt6:~Thread.currentThread()" resolve="currentThread" />
-                  </node>
-                  <node concept="liA8E" id="6fO82$FsTaP" role="2OqNvi">
-                    <ref role="37wK5l" to="wyt6:~Thread.setContextClassLoader(java.lang.ClassLoader)" resolve="setContextClassLoader" />
-                    <node concept="37vLTw" id="6fO82$FsTd5" role="37wK5m">
-                      <ref role="3cqZAo" node="6fO82$FsRM6" resolve="initialLoader" />
-                    </node>
                   </node>
                 </node>
               </node>

--- a/code/languages/com.mpsbasics/solutions/com.mpsbasics.docx4j.lib/com.mpsbasics.docx4j.lib.msd
+++ b/code/languages/com.mpsbasics/solutions/com.mpsbasics.docx4j.lib/com.mpsbasics.docx4j.lib.msd
@@ -2,71 +2,81 @@
 <solution name="com.mpsbasics.docx4j.lib" uuid="71bb25aa-20fa-4c18-8954-1b176576f52d" moduleVersion="0">
   <models>
     <modelRoot contentPath="${module}/lib" type="java_classes">
-      <sourceRoot location="docx4j-core.jar" />
-      <sourceRoot location="docx4j-openxml-objects-pml.jar" />
-      <sourceRoot location="docx4j-openxml-objects-sml.jar" />
-      <sourceRoot location="docx4j-openxml-objects.jar" />
-      <sourceRoot location="antlr-runtime.jar" />
+      <sourceRoot location="angus-activation.jar" />
+      <sourceRoot location="angus-mail.jar" />
       <sourceRoot location="antlr.jar" />
+      <sourceRoot location="antlr-runtime.jar" />
       <sourceRoot location="checker-qual.jar" />
       <sourceRoot location="commons-codec.jar" />
+      <sourceRoot location="commons-collections4.jar" />
       <sourceRoot location="commons-compress.jar" />
       <sourceRoot location="commons-io.jar" />
       <sourceRoot location="commons-lang3.jar" />
+      <sourceRoot location="commons-logging.jar" />
+      <sourceRoot location="docx4j-core.jar" />
+      <sourceRoot location="docx4j-JAXB-MOXy.jar" />
+      <sourceRoot location="docx4j-openxml-objects.jar" />
+      <sourceRoot location="docx4j-openxml-objects-pml.jar" />
+      <sourceRoot location="docx4j-openxml-objects-sml.jar" />
       <sourceRoot location="error_prone_annotations.jar" />
       <sourceRoot location="fontbox.jar" />
-      <sourceRoot location="jakarta.activation.jar" />
+      <sourceRoot location="jakarta.activation-api.jar" />
+      <sourceRoot location="jakarta.mail-api.jar" />
       <sourceRoot location="jakarta.xml.bind-api.jar" />
+      <sourceRoot location="jaxb-core.jar" />
       <sourceRoot location="jaxb-svg11.jar" />
+      <sourceRoot location="jaxb-xjc.jar" />
       <sourceRoot location="jcl-over-slf4j.jar" />
       <sourceRoot location="mbassador.jar" />
+      <sourceRoot location="org.eclipse.persistence.asm.jar" />
+      <sourceRoot location="org.eclipse.persistence.core.jar" />
+      <sourceRoot location="org.eclipse.persistence.moxy.jar" />
+      <sourceRoot location="pdfbox-io.jar" />
       <sourceRoot location="qdox.jar" />
-      <sourceRoot location="slf4j-api.jar" />
+      <sourceRoot location="SparseBitSet.jar" />
       <sourceRoot location="stringtemplate.jar" />
       <sourceRoot location="wmf2svg.jar" />
       <sourceRoot location="xalan-interpretive.jar" />
       <sourceRoot location="xalan-serializer.jar" />
       <sourceRoot location="xmlgraphics-commons.jar" />
-      <sourceRoot location="jakarta.mail.jar" />
-      <sourceRoot location="jakarta.mail-api.jar" />
-      <sourceRoot location="docx4j-JAXB-MOXy.jar" />
-      <sourceRoot location="org.eclipse.persistence.asm.jar" />
-      <sourceRoot location="org.eclipse.persistence.core.jar" />
-      <sourceRoot location="org.eclipse.persistence.moxy.jar" />
-      <sourceRoot location="jakarta.activation-api.jar" />
     </modelRoot>
     <modelRoot contentPath="${module}/lib" type="java_classes" />
   </models>
   <facets>
     <facet type="java" languageLevel="JAVA_8" compile="mps" classes="mps" ext="yes">
       <classes generated="true" path="${module}/classes_gen" />
-      <library location="${module}/lib/antlr-runtime.jar" />
+      <library location="${module}/lib/angus-activation.jar" />
+      <library location="${module}/lib/angus-mail.jar" />
       <library location="${module}/lib/antlr.jar" />
+      <library location="${module}/lib/antlr-runtime.jar" />
       <library location="${module}/lib/checker-qual.jar" />
       <library location="${module}/lib/commons-codec.jar" />
+      <library location="${module}/lib/commons-collections4.jar" />
       <library location="${module}/lib/commons-compress.jar" />
       <library location="${module}/lib/commons-io.jar" />
       <library location="${module}/lib/commons-lang3.jar" />
+      <library location="${module}/lib/commons-logging.jar" />
       <library location="${module}/lib/docx4j-core.jar" />
       <library location="${module}/lib/docx4j-JAXB-MOXy.jar" />
+      <library location="${module}/lib/docx4j-openxml-objects.jar" />
       <library location="${module}/lib/docx4j-openxml-objects-pml.jar" />
       <library location="${module}/lib/docx4j-openxml-objects-sml.jar" />
-      <library location="${module}/lib/docx4j-openxml-objects.jar" />
       <library location="${module}/lib/error_prone_annotations.jar" />
       <library location="${module}/lib/fontbox.jar" />
       <library location="${module}/lib/jakarta.activation-api.jar" />
-      <library location="${module}/lib/jakarta.activation.jar" />
       <library location="${module}/lib/jakarta.mail-api.jar" />
-      <library location="${module}/lib/jakarta.mail.jar" />
       <library location="${module}/lib/jakarta.xml.bind-api.jar" />
+      <library location="${module}/lib/jaxb-core.jar" />
       <library location="${module}/lib/jaxb-svg11.jar" />
+      <library location="${module}/lib/jaxb-xjc.jar" />
       <library location="${module}/lib/jcl-over-slf4j.jar" />
       <library location="${module}/lib/mbassador.jar" />
       <library location="${module}/lib/org.eclipse.persistence.asm.jar" />
       <library location="${module}/lib/org.eclipse.persistence.core.jar" />
       <library location="${module}/lib/org.eclipse.persistence.moxy.jar" />
+      <library location="${module}/lib/pdfbox-io.jar" />
       <library location="${module}/lib/qdox.jar" />
-      <library location="${module}/lib/slf4j-api.jar" />
+      <library location="${module}/lib/SparseBitSet.jar" />
       <library location="${module}/lib/stringtemplate.jar" />
       <library location="${module}/lib/wmf2svg.jar" />
       <library location="${module}/lib/xalan-interpretive.jar" />

--- a/code/languages/com.mpsbasics/solutions/com.mpsbasics.docx4j.tests/com.mpsbasics.docx4j.tests.msd
+++ b/code/languages/com.mpsbasics/solutions/com.mpsbasics.docx4j.tests/com.mpsbasics.docx4j.tests.msd
@@ -13,17 +13,21 @@
   <dependencies>
     <dependency reexport="false">71bb25aa-20fa-4c18-8954-1b176576f52d(com.mpsbasics.docx4j.lib)</dependency>
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
+    <dependency reexport="false">fdd69818-de3d-4ebf-9ec6-17ea152db151(com.mpsbasics.docx4j.core)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
     <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
+    <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
     <language slang="l:f61473f9-130f-42f6-b98d-6c438812c2f6:jetbrains.mps.baseLanguage.unitTest" version="1" />
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
     <language slang="l:8585453e-6bfb-4d80-98de-b16074f1d86c:jetbrains.mps.lang.test" version="6" />
+    <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
   </languageVersions>
   <dependencyVersions>
     <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+    <module reference="fdd69818-de3d-4ebf-9ec6-17ea152db151(com.mpsbasics.docx4j.core)" version="0" />
     <module reference="71bb25aa-20fa-4c18-8954-1b176576f52d(com.mpsbasics.docx4j.lib)" version="0" />
     <module reference="1e9e4d00-20c7-41ef-ad63-cc74ec78938c(com.mpsbasics.docx4j.tests)" version="0" />
   </dependencyVersions>

--- a/code/languages/com.mpsbasics/solutions/com.mpsbasics.docx4j.tests/com.mpsbasics.docx4j.tests.msd
+++ b/code/languages/com.mpsbasics/solutions/com.mpsbasics.docx4j.tests/com.mpsbasics.docx4j.tests.msd
@@ -9,6 +9,7 @@
     <facet type="java" compile="mps" classes="mps" ext="no">
       <classes generated="true" path="${module}/classes_gen" />
     </facet>
+    <facet type="tests" />
   </facets>
   <dependencies>
     <dependency reexport="false">71bb25aa-20fa-4c18-8954-1b176576f52d(com.mpsbasics.docx4j.lib)</dependency>

--- a/code/languages/com.mpsbasics/solutions/com.mpsbasics.docx4j.tests/com.mpsbasics.docx4j.tests.msd
+++ b/code/languages/com.mpsbasics/solutions/com.mpsbasics.docx4j.tests/com.mpsbasics.docx4j.tests.msd
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<solution name="com.mpsbasics.docx4j.tests" uuid="1e9e4d00-20c7-41ef-ad63-cc74ec78938c" moduleVersion="0">
+  <models>
+    <modelRoot contentPath="${module}" type="default">
+      <sourceRoot path="${module}/models" />
+    </modelRoot>
+  </models>
+  <facets>
+    <facet type="java" compile="mps" classes="mps" ext="no">
+      <classes generated="true" path="${module}/classes_gen" />
+    </facet>
+  </facets>
+  <dependencies>
+    <dependency reexport="false">71bb25aa-20fa-4c18-8954-1b176576f52d(com.mpsbasics.docx4j.lib)</dependency>
+    <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
+  </dependencies>
+  <languageVersions>
+    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
+    <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
+    <language slang="l:f61473f9-130f-42f6-b98d-6c438812c2f6:jetbrains.mps.baseLanguage.unitTest" version="1" />
+    <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+    <language slang="l:8585453e-6bfb-4d80-98de-b16074f1d86c:jetbrains.mps.lang.test" version="6" />
+    <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
+  </languageVersions>
+  <dependencyVersions>
+    <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+    <module reference="71bb25aa-20fa-4c18-8954-1b176576f52d(com.mpsbasics.docx4j.lib)" version="0" />
+    <module reference="1e9e4d00-20c7-41ef-ad63-cc74ec78938c(com.mpsbasics.docx4j.tests)" version="0" />
+  </dependencyVersions>
+</solution>
+

--- a/code/languages/com.mpsbasics/solutions/com.mpsbasics.docx4j.tests/models/com.mpsbasics.docx4j.tests@tests.mps
+++ b/code/languages/com.mpsbasics/solutions/com.mpsbasics.docx4j.tests/models/com.mpsbasics.docx4j.tests@tests.mps
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:4eadd2d3-e6dd-4cb0-a914-63ddfe1a9c7d(com.mpsbasics.docx4j.tests@tests)">
+  <persistence version="9" />
+  <languages>
+    <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
+    <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
+  </languages>
+  <imports>
+    <import index="5zxs" ref="71bb25aa-20fa-4c18-8954-1b176576f52d/java:org.docx4j.openpackaging.packages(com.mpsbasics.docx4j.lib/)" />
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
+        <property id="2616911529524314943" name="accessMode" index="3DII0k" />
+        <child id="1217501895093" name="testMethods" index="1SL9yI" />
+      </concept>
+      <concept id="1225978065297" name="jetbrains.mps.lang.test.structure.SimpleNodeTest" flags="ng" index="1LZb2c" />
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1164879685961" name="throwsItem" index="Sfmx6" />
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+      </concept>
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="1lH9Xt" id="5gFsbf32MsU">
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
+    <property role="TrG5h" value="Docx4jClassesAreAvailable" />
+    <node concept="1LZb2c" id="5gFsbf33v11" role="1SL9yI">
+      <property role="TrG5h" value="simple" />
+      <node concept="3cqZAl" id="5gFsbf33v12" role="3clF45" />
+      <node concept="3clFbS" id="5gFsbf33v16" role="3clF47">
+        <node concept="3clFbF" id="5gFsbf33zQu" role="3cqZAp">
+          <node concept="2YIFZM" id="2wDfdce8BqK" role="3clFbG">
+            <ref role="1Pybhc" to="5zxs:~WordprocessingMLPackage" resolve="WordprocessingMLPackage" />
+            <ref role="37wK5l" to="5zxs:~WordprocessingMLPackage.createPackage()" resolve="createPackage" />
+          </node>
+        </node>
+      </node>
+      <node concept="3uibUv" id="5gFsbf33ynA" role="Sfmx6">
+        <ref role="3uigEE" to="wyt6:~Exception" resolve="Exception" />
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/code/languages/com.mpsbasics/solutions/com.mpsbasics.docx4j.tests/models/com.mpsbasics.docx4j.tests@tests.mps
+++ b/code/languages/com.mpsbasics/solutions/com.mpsbasics.docx4j.tests/models/com.mpsbasics.docx4j.tests@tests.mps
@@ -4,10 +4,16 @@
   <languages>
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
+    <use id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text" version="0" />
+    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
+    <use id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures" version="0" />
   </languages>
   <imports>
     <import index="5zxs" ref="71bb25aa-20fa-4c18-8954-1b176576f52d/java:org.docx4j.openpackaging.packages(com.mpsbasics.docx4j.lib/)" />
-    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
+    <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
+    <import index="zf81" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.net(JDK/)" />
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
+    <import index="i1lw" ref="r:085b85cb-e7c0-47a8-a09c-179bb5398b5c(com.mpsbasics.docx4j.core)" />
   </imports>
   <registry>
     <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
@@ -35,9 +41,15 @@
       <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
+      </concept>
+    </language>
+    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569916463" name="body" index="1bW5cS" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -53,10 +65,20 @@
       <property role="TrG5h" value="simple" />
       <node concept="3cqZAl" id="5gFsbf33v12" role="3clF45" />
       <node concept="3clFbS" id="5gFsbf33v16" role="3clF47">
-        <node concept="3clFbF" id="5gFsbf33zQu" role="3cqZAp">
-          <node concept="2YIFZM" id="2wDfdce8BqK" role="3clFbG">
-            <ref role="1Pybhc" to="5zxs:~WordprocessingMLPackage" resolve="WordprocessingMLPackage" />
-            <ref role="37wK5l" to="5zxs:~WordprocessingMLPackage.createPackage()" resolve="createPackage" />
+        <node concept="3clFbF" id="7yOrhoD$uOh" role="3cqZAp">
+          <node concept="2YIFZM" id="7yOrhoD$vaM" role="3clFbG">
+            <ref role="37wK5l" to="i1lw:7yOrhoD$tn1" resolve="runWithDocx4j" />
+            <ref role="1Pybhc" to="i1lw:7yOrhoDzQ2f" resolve="Docx4j" />
+            <node concept="1bVj0M" id="7yOrhoD$vsi" role="37wK5m">
+              <node concept="3clFbS" id="7yOrhoD$vsn" role="1bW5cS">
+                <node concept="3clFbF" id="7yOrhoD$vCr" role="3cqZAp">
+                  <node concept="2YIFZM" id="7yOrhoD$vCt" role="3clFbG">
+                    <ref role="1Pybhc" to="5zxs:~WordprocessingMLPackage" resolve="WordprocessingMLPackage" />
+                    <ref role="37wK5l" to="5zxs:~WordprocessingMLPackage.createPackage()" resolve="createPackage" />
+                  </node>
+                </node>
+              </node>
+            </node>
           </node>
         </node>
       </node>

--- a/code/languages/com.mpsbasics/solutions/com.mpsbasics.jira.pluginSolution/com.mpsbasics.jira.pluginSolution.msd
+++ b/code/languages/com.mpsbasics/solutions/com.mpsbasics.jira.pluginSolution/com.mpsbasics.jira.pluginSolution.msd
@@ -5,7 +5,6 @@
       <sourceRoot location="models" />
     </modelRoot>
     <modelRoot contentPath="${module}/lib" type="java_classes">
-      <sourceRoot location="jackson-core-asl.jar" />
       <sourceRoot location="joda-time.jar" />
       <sourceRoot location="jsr305.jar" />
       <sourceRoot location="httpasyncclient.jar" />

--- a/code/languages/com.mpsbasics/solutions/com.mpsbasics.jira.pluginSolution/com.mpsbasics.jira.pluginSolution.msd
+++ b/code/languages/com.mpsbasics/solutions/com.mpsbasics.jira.pluginSolution/com.mpsbasics.jira.pluginSolution.msd
@@ -16,7 +16,6 @@
       <sourceRoot location="atlassian-event.jar" />
       <sourceRoot location="httpcore.jar" />
       <sourceRoot location="jira-rest-java-client-core.jar" />
-      <sourceRoot location="slf4j-api.jar" />
       <sourceRoot location="guava.jar" />
       <sourceRoot location="httpclient.jar" />
       <sourceRoot location="atlassian-util-concurrent.jar" />
@@ -50,7 +49,6 @@
       <library location="${module}/lib/jira-rest-java-client-core.jar" />
       <library location="${module}/lib/joda-time.jar" />
       <library location="${module}/lib/jsr305.jar" />
-      <library location="${module}/lib/slf4j-api.jar" />
       <library location="${module}/lib/spring-beans.jar" />
       <library location="${module}/lib/spring-core.jar" />
     </facet>

--- a/code/languages/com.mpsbasics/solutions/com.mpsbasics.langchain4j/com.mpsbasics.langchain4j.msd
+++ b/code/languages/com.mpsbasics/solutions/com.mpsbasics.langchain4j/com.mpsbasics.langchain4j.msd
@@ -5,20 +5,17 @@
       <sourceRoot path="${module}/models" />
     </modelRoot>
     <modelRoot contentPath="${module}/lib" type="java_classes">
-      <sourceRoot location="." />
-      <sourceRoot path="${module}/lib/jackson-annotations.jar" />
-      <sourceRoot path="${module}/lib/jackson-core.jar" />
-      <sourceRoot path="${module}/lib/jackson-databind.jar" />
-      <sourceRoot path="${module}/lib/jspecify.jar" />
-      <sourceRoot path="${module}/lib/jtokkit.jar" />
-      <sourceRoot path="${module}/lib/langchain4j-core.jar" />
-      <sourceRoot path="${module}/lib/langchain4j-http-client-jdk.jar" />
-      <sourceRoot path="${module}/lib/langchain4j-http-client.jar" />
-      <sourceRoot path="${module}/lib/langchain4j-open-ai.jar" />
-    </modelRoot>
-    <modelRoot contentPath="${module}/lib" type="java_classes">
       <sourceRoot location="langchain4j.jar" />
       <sourceRoot location="opennlp-tools.jar" />
+      <sourceRoot location="jackson-annotations.jar" />
+      <sourceRoot location="jackson-core.jar" />
+      <sourceRoot location="jackson-databind.jar" />
+      <sourceRoot location="jspecify.jar" />
+      <sourceRoot location="jtokkit.jar" />
+      <sourceRoot location="langchain4j-core.jar" />
+      <sourceRoot location="langchain4j-http-client-jdk.jar" />
+      <sourceRoot location="langchain4j-http-client.jar" />
+      <sourceRoot location="langchain4j-open-ai.jar" />
     </modelRoot>
   </models>
   <facets>

--- a/code/languages/com.mpsbasics/solutions/com.mpsbasics.langchain4j/com.mpsbasics.langchain4j.msd
+++ b/code/languages/com.mpsbasics/solutions/com.mpsbasics.langchain4j/com.mpsbasics.langchain4j.msd
@@ -15,7 +15,6 @@
       <sourceRoot path="${module}/lib/langchain4j-http-client-jdk.jar" />
       <sourceRoot path="${module}/lib/langchain4j-http-client.jar" />
       <sourceRoot path="${module}/lib/langchain4j-open-ai.jar" />
-      <sourceRoot path="${module}/lib/slf4j-api.jar" />
     </modelRoot>
     <modelRoot contentPath="${module}/lib" type="java_classes">
       <sourceRoot location="langchain4j.jar" />
@@ -36,7 +35,6 @@
       <library location="${module}/lib/langchain4j-http-client-jdk.jar" />
       <library location="${module}/lib/langchain4j-http-client.jar" />
       <library location="${module}/lib/langchain4j-open-ai.jar" />
-      <library location="${module}/lib/slf4j-api.jar" />
     </facet>
   </facets>
   <dependencies>

--- a/code/languages/com.mpsbasics/solutions/com.mpsbasics.tests.build/com.mpsbasics.tests.build.msd
+++ b/code/languages/com.mpsbasics/solutions/com.mpsbasics.tests.build/com.mpsbasics.tests.build.msd
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<solution name="com.fasten.assurance.build" uuid="7301161d-854c-45d9-b0d7-121b4fb52625" moduleVersion="0">
+<solution name="com.mpsbasics.tests.build" uuid="501fd540-aef3-4d7b-b289-4bdbc8b5a74a" moduleVersion="0">
   <models>
     <modelRoot contentPath="${module}" type="default">
-      <sourceRoot location="models" />
+      <sourceRoot path="${module}/models" />
     </modelRoot>
   </models>
   <facets>
@@ -11,24 +11,21 @@
     </facet>
   </facets>
   <dependencies>
-    <dependency reexport="false">3ae9cfda-f938-4524-b4ca-fbcba3b0525b(com.mbeddr.platform)</dependency>
     <dependency reexport="false">422c2909-59d6-41a9-b318-40e6256b250f(jetbrains.mps.ide.build)</dependency>
-    <dependency reexport="false">f1fb7b1c-ce0d-423c-9369-4a661d600029(de.itemis.mps.extensions.build)</dependency>
-    <dependency reexport="false">5e8cea6b-997f-49b1-a8d8-dc2a7a6fa657(org.mpsqa.base.build)</dependency>
     <dependency reexport="false">ff2a102e-f030-4756-a6c9-02da709c686f(com.mpsbasics.build)</dependency>
+    <dependency reexport="false">3ae9cfda-f938-4524-b4ca-fbcba3b0525b(com.mbeddr.platform)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:798100da-4f0a-421a-b991-71f8c50ce5d2:jetbrains.mps.build" version="0" />
     <language slang="l:0cf935df-4699-4e9c-a132-fa109541cba3:jetbrains.mps.build.mps" version="8" />
+    <language slang="l:3600cb0a-44dd-4a5b-9968-22924406419e:jetbrains.mps.build.mps.tests" version="1" />
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
   </languageVersions>
   <dependencyVersions>
-    <module reference="7301161d-854c-45d9-b0d7-121b4fb52625(com.fasten.assurance.build)" version="0" />
     <module reference="3ae9cfda-f938-4524-b4ca-fbcba3b0525b(com.mbeddr.platform)" version="0" />
     <module reference="ff2a102e-f030-4756-a6c9-02da709c686f(com.mpsbasics.build)" version="0" />
-    <module reference="f1fb7b1c-ce0d-423c-9369-4a661d600029(de.itemis.mps.extensions.build)" version="0" />
+    <module reference="501fd540-aef3-4d7b-b289-4bdbc8b5a74a(com.mpsbasics.tests.build)" version="0" />
     <module reference="422c2909-59d6-41a9-b318-40e6256b250f(jetbrains.mps.ide.build)" version="0" />
-    <module reference="5e8cea6b-997f-49b1-a8d8-dc2a7a6fa657(org.mpsqa.base.build)" version="0" />
   </dependencyVersions>
 </solution>
 

--- a/code/languages/com.mpsbasics/solutions/com.mpsbasics.tests.build/models/com.mpsbasics.tests.build.mps
+++ b/code/languages/com.mpsbasics/solutions/com.mpsbasics.tests.build/models/com.mpsbasics.tests.build.mps
@@ -1,0 +1,258 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:0de5d22c-3d8d-4a88-ab47-a5fb3fb25721(com.mpsbasics.tests.build)">
+  <persistence version="9" />
+  <languages>
+    <use id="0cf935df-4699-4e9c-a132-fa109541cba3" name="jetbrains.mps.build.mps" version="8" />
+    <use id="798100da-4f0a-421a-b991-71f8c50ce5d2" name="jetbrains.mps.build" version="0" />
+    <use id="3600cb0a-44dd-4a5b-9968-22924406419e" name="jetbrains.mps.build.mps.tests" version="1" />
+  </languages>
+  <imports>
+    <import index="ffeo" ref="r:874d959d-e3b4-4d04-b931-ca849af130dd(jetbrains.mps.ide.build)" />
+    <import index="k3fp" ref="r:ef07c49a-32d8-46ff-a533-57b4dbca7bb4(com.mpsbasics.build.build)" />
+    <import index="al5i" ref="r:742f344d-4dc4-4862-992c-4bc94b094870(com.mbeddr.mpsutil.dev.build)" />
+  </imports>
+  <registry>
+    <language id="3600cb0a-44dd-4a5b-9968-22924406419e" name="jetbrains.mps.build.mps.tests">
+      <concept id="4560297596904469355" name="jetbrains.mps.build.mps.tests.structure.BuildMps_TestModuleGroup" flags="ng" index="22LTRF">
+        <reference id="4560297596904469356" name="group" index="22LTRG" />
+      </concept>
+      <concept id="4560297596904469357" name="jetbrains.mps.build.mps.tests.structure.BuildAspect_MpsTestModules" flags="nn" index="22LTRH">
+        <child id="4560297596904469360" name="modules" index="22LTRK" />
+        <child id="6593674873639474544" name="options" index="24cAkG" />
+      </concept>
+      <concept id="6593674873639474400" name="jetbrains.mps.build.mps.tests.structure.BuildMps_TestModules_Options" flags="ng" index="24cAiW">
+        <child id="6593674873639478221" name="haltonfailure" index="24c_eh" />
+        <child id="7978162869575635130" name="projectPath" index="1RZ71A" />
+      </concept>
+      <concept id="4005526075820600484" name="jetbrains.mps.build.mps.tests.structure.BuildModuleTestsPlugin" flags="ng" index="1gjT0q" />
+    </language>
+    <language id="798100da-4f0a-421a-b991-71f8c50ce5d2" name="jetbrains.mps.build">
+      <concept id="5481553824944787378" name="jetbrains.mps.build.structure.BuildSourceProjectRelativePath" flags="ng" index="55IIr" />
+      <concept id="7321017245476976379" name="jetbrains.mps.build.structure.BuildRelativePath" flags="ng" index="iG8Mu">
+        <child id="7321017245477039051" name="compositePart" index="iGT6I" />
+      </concept>
+      <concept id="4993211115183325728" name="jetbrains.mps.build.structure.BuildProjectDependency" flags="ng" index="2sgV4H">
+        <reference id="5617550519002745380" name="script" index="1l3spb" />
+        <child id="4129895186893471026" name="artifacts" index="2JcizS" />
+      </concept>
+      <concept id="4380385936562003279" name="jetbrains.mps.build.structure.BuildString" flags="ng" index="NbPM2">
+        <child id="4903714810883783243" name="parts" index="3MwsjC" />
+      </concept>
+      <concept id="8618885170173601777" name="jetbrains.mps.build.structure.BuildCompositePath" flags="nn" index="2Ry0Ak">
+        <property id="8618885170173601779" name="head" index="2Ry0Am" />
+        <child id="8618885170173601778" name="tail" index="2Ry0An" />
+      </concept>
+      <concept id="6647099934206700647" name="jetbrains.mps.build.structure.BuildJavaPlugin" flags="ng" index="10PD9b" />
+      <concept id="7389400916848136194" name="jetbrains.mps.build.structure.BuildFolderMacro" flags="ng" index="398rNT">
+        <child id="7389400916848144618" name="defaultPath" index="398pKh" />
+      </concept>
+      <concept id="7389400916848153117" name="jetbrains.mps.build.structure.BuildSourceMacroRelativePath" flags="ng" index="398BVA">
+        <reference id="7389400916848153130" name="macro" index="398BVh" />
+      </concept>
+      <concept id="5617550519002745364" name="jetbrains.mps.build.structure.BuildLayout" flags="ng" index="1l3spV" />
+      <concept id="5617550519002745363" name="jetbrains.mps.build.structure.BuildProject" flags="ng" index="1l3spW">
+        <property id="4915877860348071612" name="fileName" index="turDy" />
+        <property id="5204048710541015587" name="internalBaseDirectory" index="2DA0ip" />
+        <child id="4796668409958418110" name="scriptsDir" index="auvoZ" />
+        <child id="6647099934206700656" name="plugins" index="10PD9s" />
+        <child id="7389400916848080626" name="parts" index="3989C9" />
+        <child id="3542413272732620719" name="aspects" index="1hWBAP" />
+        <child id="5617550519002745381" name="dependencies" index="1l3spa" />
+        <child id="5617550519002745378" name="macros" index="1l3spd" />
+        <child id="5617550519002745372" name="layout" index="1l3spN" />
+      </concept>
+      <concept id="8654221991637384182" name="jetbrains.mps.build.structure.BuildFileIncludesSelector" flags="ng" index="3qWCbU">
+        <property id="8654221991637384184" name="pattern" index="3qWCbO" />
+      </concept>
+      <concept id="4701820937132344003" name="jetbrains.mps.build.structure.BuildLayout_Container" flags="ngI" index="1y1bJS">
+        <child id="7389400916848037006" name="children" index="39821P" />
+      </concept>
+      <concept id="5248329904287794596" name="jetbrains.mps.build.structure.BuildInputFiles" flags="ng" index="3LXTmp">
+        <child id="5248329904287794598" name="dir" index="3LXTmr" />
+        <child id="5248329904287794679" name="selectors" index="3LXTna" />
+      </concept>
+      <concept id="4903714810883702019" name="jetbrains.mps.build.structure.BuildTextStringPart" flags="ng" index="3Mxwew">
+        <property id="4903714810883755350" name="text" index="3MwjfP" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+    <language id="0cf935df-4699-4e9c-a132-fa109541cba3" name="jetbrains.mps.build.mps">
+      <concept id="1500819558095907805" name="jetbrains.mps.build.mps.structure.BuildMps_Group" flags="ng" index="2G$12M">
+        <child id="1500819558095907806" name="modules" index="2G$12L" />
+      </concept>
+      <concept id="1265949165890536423" name="jetbrains.mps.build.mps.structure.BuildMpsLayout_ModuleJars" flags="ng" index="L2wRC">
+        <reference id="1265949165890536425" name="module" index="L2wRA" />
+      </concept>
+      <concept id="868032131020265945" name="jetbrains.mps.build.mps.structure.BuildMPSPlugin" flags="ng" index="3b7kt6" />
+      <concept id="5253498789149381388" name="jetbrains.mps.build.mps.structure.BuildMps_Module" flags="ng" index="3bQrTs">
+        <child id="5253498789149547825" name="sources" index="3bR31x" />
+        <child id="5253498789149547704" name="dependencies" index="3bR37C" />
+      </concept>
+      <concept id="5253498789149585690" name="jetbrains.mps.build.mps.structure.BuildMps_ModuleDependencyOnModule" flags="ng" index="3bR9La">
+        <reference id="5253498789149547705" name="module" index="3bR37D" />
+      </concept>
+      <concept id="4278635856200817744" name="jetbrains.mps.build.mps.structure.BuildMps_ModuleModelRoot" flags="ng" index="1BupzO">
+        <property id="8137134783396907368" name="convert2binary" index="1Hdu6h" />
+        <property id="8137134783396676838" name="extracted" index="1HemKv" />
+        <property id="2889113830911481881" name="deployFolderName" index="3ZfqAx" />
+        <child id="8137134783396676835" name="location" index="1HemKq" />
+      </concept>
+      <concept id="3189788309731840247" name="jetbrains.mps.build.mps.structure.BuildMps_Solution" flags="ng" index="1E1JtA">
+        <property id="269707337715731330" name="sourcesKind" index="aoJFB" />
+      </concept>
+      <concept id="322010710375871467" name="jetbrains.mps.build.mps.structure.BuildMps_AbstractModule" flags="ng" index="3LEN3z">
+        <property id="8369506495128725901" name="compact" index="BnDLt" />
+        <property id="322010710375892619" name="uuid" index="3LESm3" />
+        <child id="322010710375956261" name="path" index="3LF7KH" />
+      </concept>
+      <concept id="7259033139236285166" name="jetbrains.mps.build.mps.structure.BuildMps_ExtractedModuleDependency" flags="nn" index="1SiIV0">
+        <child id="7259033139236285167" name="dependency" index="1SiIV1" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="1l3spW" id="5gFsbf33$3R">
+    <property role="2DA0ip" value="../.." />
+    <property role="TrG5h" value="com.mpsbasics.tests" />
+    <property role="turDy" value="test-mpsbasics-languages.xml" />
+    <node concept="55IIr" id="5gFsbf33$3S" role="auvoZ">
+      <node concept="2Ry0Ak" id="5gFsbf33IdS" role="iGT6I">
+        <property role="2Ry0Am" value=".." />
+        <node concept="2Ry0Ak" id="5gFsbf33IdV" role="2Ry0An">
+          <property role="2Ry0Am" value=".." />
+          <node concept="2Ry0Ak" id="5gFsbf33IdY" role="2Ry0An">
+            <property role="2Ry0Am" value=".." />
+            <node concept="2Ry0Ak" id="5gFsbf33Ie1" role="2Ry0An">
+              <property role="2Ry0Am" value="build" />
+              <node concept="2Ry0Ak" id="5gFsbf33Ie4" role="2Ry0An">
+                <property role="2Ry0Am" value="scripts" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1l3spV" id="5gFsbf33$3T" role="1l3spN">
+      <node concept="L2wRC" id="5gFsbf33ATa" role="39821P">
+        <ref role="L2wRA" node="5gFsbf33ASO" resolve="com.mpsbasics.docx4j.tests" />
+      </node>
+    </node>
+    <node concept="10PD9b" id="5gFsbf33$tD" role="10PD9s" />
+    <node concept="3b7kt6" id="5gFsbf33$tF" role="10PD9s" />
+    <node concept="1gjT0q" id="5gFsbf33_vq" role="10PD9s" />
+    <node concept="398rNT" id="5gFsbf33_AC" role="1l3spd">
+      <property role="TrG5h" value="mps.home" />
+    </node>
+    <node concept="398rNT" id="5gFsbf3gzSJ" role="1l3spd">
+      <property role="TrG5h" value="dependencies.root" />
+      <node concept="55IIr" id="5gFsbf3gzSL" role="398pKh">
+        <node concept="2Ry0Ak" id="5gFsbf3gzSN" role="iGT6I">
+          <property role="2Ry0Am" value=".." />
+          <node concept="2Ry0Ak" id="5gFsbf3gzSQ" role="2Ry0An">
+            <property role="2Ry0Am" value=".." />
+            <node concept="2Ry0Ak" id="5gFsbf3gzST" role="2Ry0An">
+              <property role="2Ry0Am" value=".." />
+              <node concept="2Ry0Ak" id="5gFsbf3gzSW" role="2Ry0An">
+                <property role="2Ry0Am" value="build" />
+                <node concept="2Ry0Ak" id="5gFsbf3gzSZ" role="2Ry0An">
+                  <property role="2Ry0Am" value="dependencies" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="398rNT" id="5cuOg6jCZjf" role="1l3spd">
+      <property role="TrG5h" value="mps.macro.mbeddr.formal.home" />
+      <node concept="55IIr" id="5cuOg6jD1oR" role="398pKh" />
+    </node>
+    <node concept="2sgV4H" id="5gFsbf33_AD" role="1l3spa">
+      <ref role="1l3spb" to="ffeo:3IKDaVZmzS6" resolve="mps" />
+      <node concept="398BVA" id="5gFsbf33ASJ" role="2JcizS">
+        <ref role="398BVh" node="5gFsbf33_AC" resolve="mps.home" />
+      </node>
+    </node>
+    <node concept="2sgV4H" id="5gFsbf33ASL" role="1l3spa">
+      <ref role="1l3spb" to="k3fp:42jqVeFkUtb" resolve="com.mpsbasics" />
+    </node>
+    <node concept="2sgV4H" id="5gFsbf3gzSG" role="1l3spa">
+      <ref role="1l3spb" to="al5i:3AVJcIMlF8l" resolve="com.mbeddr.platform" />
+      <node concept="398BVA" id="5gFsbf3gzT0" role="2JcizS">
+        <ref role="398BVh" node="5gFsbf3gzSJ" resolve="dependencies.root" />
+        <node concept="2Ry0Ak" id="5gFsbf3gzT3" role="iGT6I">
+          <property role="2Ry0Am" value="com.mbeddr.platform" />
+        </node>
+      </node>
+    </node>
+    <node concept="2G$12M" id="5gFsbf33ASN" role="3989C9">
+      <property role="TrG5h" value="tests" />
+      <node concept="1E1JtA" id="5gFsbf33ASO" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="com.mpsbasics.docx4j.tests" />
+        <property role="3LESm3" value="1e9e4d00-20c7-41ef-ad63-cc74ec78938c" />
+        <property role="aoJFB" value="eYcmk9QOlj/sources_and_tests" />
+        <node concept="55IIr" id="5gFsbf33ASP" role="3LF7KH">
+          <node concept="2Ry0Ak" id="5gFsbf33ASS" role="iGT6I">
+            <property role="2Ry0Am" value="solutions" />
+            <node concept="2Ry0Ak" id="5gFsbf33ASV" role="2Ry0An">
+              <property role="2Ry0Am" value="com.mpsbasics.docx4j.tests" />
+              <node concept="2Ry0Ak" id="5gFsbf33ASY" role="2Ry0An">
+                <property role="2Ry0Am" value="com.mpsbasics.docx4j.tests.msd" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="5gFsbf33ASZ" role="3bR37C">
+          <node concept="3bR9La" id="5gFsbf33AT0" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+          </node>
+        </node>
+        <node concept="1BupzO" id="5gFsbf33AT7" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="5gFsbf33AT8" role="1HemKq">
+            <node concept="55IIr" id="5gFsbf33AT3" role="3LXTmr">
+              <node concept="2Ry0Ak" id="5gFsbf33AT4" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="5gFsbf33AT5" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.tests" />
+                  <node concept="2Ry0Ak" id="5gFsbf33AT6" role="2Ry0An">
+                    <property role="2Ry0Am" value="models" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="5gFsbf33AT9" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="5gFsbf3g7RO" role="3bR37C">
+          <node concept="3bR9La" id="5gFsbf3g7RP" role="1SiIV1">
+            <ref role="3bR37D" to="k3fp:6hyv0iVPlFI" resolve="com.mpsbasics.docx4j.lib" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="22LTRH" id="5gFsbf33ATb" role="1hWBAP">
+      <property role="TrG5h" value="tests" />
+      <node concept="22LTRF" id="5gFsbf33ATd" role="22LTRK">
+        <ref role="22LTRG" node="5gFsbf33ASN" resolve="tests" />
+      </node>
+      <node concept="24cAiW" id="5gFsbf33ATf" role="24cAkG">
+        <node concept="55IIr" id="5gFsbf33ATg" role="1RZ71A" />
+        <node concept="NbPM2" id="5gFsbf33ATi" role="24c_eh">
+          <node concept="3Mxwew" id="5gFsbf33ATj" role="3MwsjC">
+            <property role="3MwjfP" value="true" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/code/languages/com.mpsbasics/solutions/com.mpsbasics.tests.build/models/com.mpsbasics.tests.build.mps
+++ b/code/languages/com.mpsbasics/solutions/com.mpsbasics.tests.build/models/com.mpsbasics.tests.build.mps
@@ -215,19 +215,20 @@
           <property role="3ZfqAx" value="models" />
           <property role="1Hdu6h" value="true" />
           <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="5gFsbf33AT8" role="1HemKq">
-            <node concept="55IIr" id="5gFsbf33AT3" role="3LXTmr">
-              <node concept="2Ry0Ak" id="5gFsbf33AT4" role="iGT6I">
+          <node concept="3LXTmp" id="7yOrhoD_zUa" role="1HemKq">
+            <node concept="398BVA" id="7yOrhoD_zU2" role="3LXTmr">
+              <ref role="398BVh" node="5cuOg6jCZjf" resolve="mps.macro.mbeddr.formal.home" />
+              <node concept="2Ry0Ak" id="7yOrhoD_zU3" role="iGT6I">
                 <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="5gFsbf33AT5" role="2Ry0An">
+                <node concept="2Ry0Ak" id="7yOrhoD_zU4" role="2Ry0An">
                   <property role="2Ry0Am" value="com.mpsbasics.docx4j.tests" />
-                  <node concept="2Ry0Ak" id="5gFsbf33AT6" role="2Ry0An">
+                  <node concept="2Ry0Ak" id="7yOrhoD_zU5" role="2Ry0An">
                     <property role="2Ry0Am" value="models" />
                   </node>
                 </node>
               </node>
             </node>
-            <node concept="3qWCbU" id="5gFsbf33AT9" role="3LXTna">
+            <node concept="3qWCbU" id="7yOrhoD_zUb" role="3LXTna">
               <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
             </node>
           </node>
@@ -235,6 +236,11 @@
         <node concept="1SiIV0" id="5gFsbf3g7RO" role="3bR37C">
           <node concept="3bR9La" id="5gFsbf3g7RP" role="1SiIV1">
             <ref role="3bR37D" to="k3fp:6hyv0iVPlFI" resolve="com.mpsbasics.docx4j.lib" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="7yOrhoD_zU0" role="3bR37C">
+          <node concept="3bR9La" id="7yOrhoD_zU1" role="1SiIV1">
+            <ref role="3bR37D" to="k3fp:6hyv0iVPlFH" resolve="com.mpsbasics.docx4j.core" />
           </node>
         </node>
       </node>

--- a/code/languages/com.mpsbasics/solutions/com.mpsbasics.tests.build/models/com.mpsbasics.tests.build.mps
+++ b/code/languages/com.mpsbasics/solutions/com.mpsbasics.tests.build/models/com.mpsbasics.tests.build.mps
@@ -95,6 +95,9 @@
       <concept id="5253498789149585690" name="jetbrains.mps.build.mps.structure.BuildMps_ModuleDependencyOnModule" flags="ng" index="3bR9La">
         <reference id="5253498789149547705" name="module" index="3bR37D" />
       </concept>
+      <concept id="763829979718664966" name="jetbrains.mps.build.mps.structure.BuildMps_ModuleResources" flags="ng" index="3rtmxn">
+        <child id="763829979718664967" name="files" index="3rtmxm" />
+      </concept>
       <concept id="4278635856200817744" name="jetbrains.mps.build.mps.structure.BuildMps_ModuleModelRoot" flags="ng" index="1BupzO">
         <property id="8137134783396907368" name="convert2binary" index="1Hdu6h" />
         <property id="8137134783396676838" name="extracted" index="1HemKv" />
@@ -241,6 +244,21 @@
         <node concept="1SiIV0" id="7yOrhoD_zU0" role="3bR37C">
           <node concept="3bR9La" id="7yOrhoD_zU1" role="1SiIV1">
             <ref role="3bR37D" to="k3fp:6hyv0iVPlFH" resolve="com.mpsbasics.docx4j.core" />
+          </node>
+        </node>
+        <node concept="3rtmxn" id="7VF2e44q0RK" role="3bR31x">
+          <node concept="3LXTmp" id="7VF2e44q0RL" role="3rtmxm">
+            <node concept="3qWCbU" id="7VF2e44q0RM" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="55IIr" id="7VF2e44q0RN" role="3LXTmr">
+              <node concept="2Ry0Ak" id="7VF2e44q0RO" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="7VF2e44q0RP" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mpsbasics.docx4j.tests" />
+                </node>
+              </node>
+            </node>
           </node>
         </node>
       </node>

--- a/gradle.lockfile
+++ b/gradle.lockfile
@@ -122,4 +122,4 @@ org.springframework:spring-core:5.3.36=jira
 org.springframework:spring-jcl:5.3.36=jira
 tools.aqua:z3-turnkey:4.11.2=z3
 xml-apis:xml-apis-ext:1.3.04=plantUML
-empty=annotationProcessor,compileClasspath,runtimeClasspath,testAnnotationProcessor,testCompileClasspath,testRuntimeClasspath
+empty=annotationProcessor,compileClasspath,cyclonedxBom,runtimeClasspath,testAnnotationProcessor,testCompileClasspath,testRuntimeClasspath


### PR DESCRIPTION
Introduce Docx4j.runWithDocx4j wrapper.

Docx4j 11.5 upgrades to a newer version of JAXB which changes how providers are looked up. The mechanism now looks for it in the thread context classloader first and in our case it can't find an implementation there so it falls back to Glassfish reference implementation. However, that implementation is also not present so the code throws a ClassNotFoundException.

To fix this, code using Docx4j should use the runWithDocx4j wrapper to set the necessary environment for docx4j to work.