### PR TITLE
base.styles: fix invisible diagram connections in dark theme (backport)

### DIFF
--- a/code/languages/com.mbeddr.formal.nusmv/languages/com.mbeddr.formal.base/models/com.mbeddr.formal.base.styles.mps
+++ b/code/languages/com.mbeddr.formal.nusmv/languages/com.mbeddr.formal.base/models/com.mbeddr.formal.base.styles.mps
@@ -274,7 +274,7 @@
               </node>
               <node concept="10M0yZ" id="8xY_Ih_9qv" role="37wK5m">
                 <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                <ref role="3cqZAo" to="z60i:~Color.BLACK" resolve="BLACK" />
+                <ref role="3cqZAo" to="z60i:~Color.LIGHT_GRAY" resolve="LIGHT_GRAY" />
               </node>
             </node>
           </node>


### PR DESCRIPTION
## Summary
Backport of #274 to `maintenance/MPS-2025.1`.

- `EditorDynamicStyleBase.getLineColor()` returned `Color.BLACK` for both the light and dark theme slots, so diagram connections (GSN, and any other diagram using this default styling) rendered as black lines on a dark background and were nearly invisible in dark IDE themes.
- Changed the dark-theme slot to `Color.LIGHT_GRAY` for contrast.

Clean cherry-pick of bbfef5ab, no conflicts.

## Test plan
- [ ] Open a GSN goal structure diagram in MPS with a dark theme and confirm connection lines are now visible
- [ ] Confirm light theme connections remain black (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)