### PR TITLE
Speed up large GSN GoalStructure editors (VCS gutter + textual-fast toggle)

### DIFF
--- a/code/languages/com.mbeddr.formal.safety/languages/com.mbeddr.formal.safety.gsn/models/com.mbeddr.formal.safety.gsn.editor.mps
+++ b/code/languages/com.mbeddr.formal.safety/languages/com.mbeddr.formal.safety.gsn/models/com.mbeddr.formal.safety.gsn.editor.mps
@@ -15,6 +15,8 @@
     <use id="1919c723-b60b-4592-9318-9ce96d91da44" name="de.itemis.mps.editor.celllayout" version="0" />
     <use id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior" version="2" />
     <use id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core" version="2" />
+    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -11306,142 +11308,11 @@
         <node concept="3EZMnI" id="7olAlesPn9O" role="3EZMnx">
           <node concept="3EZMnI" id="7olAlesPob8" role="3EZMnx">
             <node concept="2iRfu4" id="7olAlesPob9" role="2iSdaV" />
-            <node concept="3gTLQM" id="7olAlesPo0e" role="3EZMnx">
-              <node concept="3Fmcul" id="7olAlesPo0g" role="3FoqZy">
-                <node concept="3clFbS" id="7olAlesPo0i" role="2VODD2">
-                  <node concept="3cpWs8" id="7olAlesPGkh" role="3cqZAp">
-                    <node concept="3cpWsn" id="7olAlesPGki" role="3cpWs9">
-                      <property role="TrG5h" value="button" />
-                      <node concept="3uibUv" id="7olAlesPGbq" role="1tU5fm">
-                        <ref role="3uigEE" to="dxuu:~JButton" resolve="JButton" />
-                      </node>
-                      <node concept="2ShNRf" id="7olAlesPGkj" role="33vP2m">
-                        <node concept="1pGfFk" id="7olAlesPGkk" role="2ShVmc">
-                          <ref role="37wK5l" to="dxuu:~JButton.&lt;init&gt;(java.lang.String)" resolve="JButton" />
-                          <node concept="Xl_RD" id="7olAlesPGkl" role="37wK5m">
-                            <property role="Xl_RC" value="+" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3clFbF" id="7olAlesTnub" role="3cqZAp">
-                    <node concept="2OqwBi" id="7olAlesTo6t" role="3clFbG">
-                      <node concept="37vLTw" id="7olAlesTnu9" role="2Oq$k0">
-                        <ref role="3cqZAo" node="7olAlesPGki" resolve="button" />
-                      </node>
-                      <node concept="liA8E" id="7olAlesTpkV" role="2OqNvi">
-                        <ref role="37wK5l" to="dxuu:~JComponent.setPreferredSize(java.awt.Dimension)" resolve="setPreferredSize" />
-                        <node concept="2ShNRf" id="7olAlesTpof" role="37wK5m">
-                          <node concept="1pGfFk" id="7olAlesTqsi" role="2ShVmc">
-                            <ref role="37wK5l" to="z60i:~Dimension.&lt;init&gt;(int,int)" resolve="Dimension" />
-                            <node concept="3cmrfG" id="7olAlesTqxy" role="37wK5m">
-                              <property role="3cmrfH" value="15" />
-                            </node>
-                            <node concept="3cmrfG" id="7olAlesTqI4" role="37wK5m">
-                              <property role="3cmrfH" value="15" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3clFbF" id="7olAlesPGlP" role="3cqZAp">
-                    <node concept="2OqwBi" id="7olAlesPGVC" role="3clFbG">
-                      <node concept="37vLTw" id="7olAlesPGlN" role="2Oq$k0">
-                        <ref role="3cqZAo" node="7olAlesPGki" resolve="button" />
-                      </node>
-                      <node concept="liA8E" id="7olAlesPIOp" role="2OqNvi">
-                        <ref role="37wK5l" to="dxuu:~AbstractButton.addActionListener(java.awt.event.ActionListener)" resolve="addActionListener" />
-                        <node concept="2ShNRf" id="7olAlesPIRw" role="37wK5m">
-                          <node concept="YeOm9" id="7olAlesPJF4" role="2ShVmc">
-                            <node concept="1Y3b0j" id="7olAlesPJF7" role="YeSDq">
-                              <property role="2bfB8j" value="true" />
-                              <ref role="1Y3XeK" to="hyam:~ActionListener" resolve="ActionListener" />
-                              <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
-                              <node concept="3Tm1VV" id="7olAlesPJF8" role="1B3o_S" />
-                              <node concept="3clFb_" id="7olAlesPJFd" role="jymVt">
-                                <property role="TrG5h" value="actionPerformed" />
-                                <node concept="3Tm1VV" id="7olAlesPJFe" role="1B3o_S" />
-                                <node concept="3cqZAl" id="7olAlesPJFg" role="3clF45" />
-                                <node concept="37vLTG" id="7olAlesPJFh" role="3clF46">
-                                  <property role="TrG5h" value="p0" />
-                                  <node concept="3uibUv" id="7olAlesPJFi" role="1tU5fm">
-                                    <ref role="3uigEE" to="hyam:~ActionEvent" resolve="ActionEvent" />
-                                  </node>
-                                </node>
-                                <node concept="3clFbS" id="7olAlesPJFj" role="3clF47">
-                                  <node concept="3cpWs8" id="6hlfxCL6tb2" role="3cqZAp">
-                                    <node concept="3cpWsn" id="6hlfxCL6tb3" role="3cpWs9">
-                                      <property role="TrG5h" value="gs" />
-                                      <node concept="3Tqbb2" id="6hlfxCL6tb4" role="1tU5fm">
-                                        <ref role="ehGHo" to="py52:3GRi4m$qNsQ" resolve="GoalStructure" />
-                                      </node>
-                                      <node concept="1PxgMI" id="6hlfxCL6tb5" role="33vP2m">
-                                        <property role="1BlNFB" value="true" />
-                                        <node concept="chp4Y" id="6hlfxCL6tb6" role="3oSUPX">
-                                          <ref role="cht4Q" to="py52:3GRi4m$qNsQ" resolve="GoalStructure" />
-                                        </node>
-                                        <node concept="2OqwBi" id="6hlfxCL6tb7" role="1m5AlR">
-                                          <node concept="2OqwBi" id="6hlfxCL6tb8" role="2Oq$k0">
-                                            <node concept="2OqwBi" id="6hlfxCL6tb9" role="2Oq$k0">
-                                              <node concept="1Q80Hx" id="6hlfxCL6tba" role="2Oq$k0" />
-                                              <node concept="liA8E" id="6hlfxCL6tbb" role="2OqNvi">
-                                                <ref role="37wK5l" to="cj4x:~EditorContext.getEditorComponent()" resolve="getEditorComponent" />
-                                              </node>
-                                            </node>
-                                            <node concept="liA8E" id="6hlfxCL6tbc" role="2OqNvi">
-                                              <ref role="37wK5l" to="cj4x:~EditorComponent.getRootCell()" resolve="getRootCell" />
-                                            </node>
-                                          </node>
-                                          <node concept="liA8E" id="6hlfxCL6tbd" role="2OqNvi">
-                                            <ref role="37wK5l" to="f4zo:~EditorCell.getSNode()" resolve="getSNode" />
-                                          </node>
-                                        </node>
-                                      </node>
-                                    </node>
-                                  </node>
-                                  <node concept="3clFbF" id="7olAlesPT5x" role="3cqZAp">
-                                    <node concept="2YIFZM" id="7olAlesPT6K" role="3clFbG">
-                                      <ref role="37wK5l" node="7olAlesPRVR" resolve="setCollapsed" />
-                                      <ref role="1Pybhc" node="7olAlesPJUl" resolve="TextualFastProjectionUtils" />
-                                      <node concept="37vLTw" id="6hlfxCL6tLy" role="37wK5m">
-                                        <ref role="3cqZAo" node="6hlfxCL6tb3" resolve="gs" />
-                                      </node>
-                                      <node concept="pncrf" id="7olAlesPTrx" role="37wK5m" />
-                                      <node concept="3clFbT" id="7olAlesPTBh" role="37wK5m" />
-                                    </node>
-                                  </node>
-                                  <node concept="3clFbF" id="7olAlesV1Rr" role="3cqZAp">
-                                    <node concept="2OqwBi" id="7olAlesV2ub" role="3clFbG">
-                                      <node concept="2OqwBi" id="7olAlesV2ai" role="2Oq$k0">
-                                        <node concept="1Q80Hx" id="7olAlesV1Rq" role="2Oq$k0" />
-                                        <node concept="liA8E" id="7olAlesV2nH" role="2OqNvi">
-                                          <ref role="37wK5l" to="cj4x:~EditorContext.getEditorComponent()" resolve="getEditorComponent" />
-                                        </node>
-                                      </node>
-                                      <node concept="liA8E" id="7olAlesV2D2" role="2OqNvi">
-                                        <ref role="37wK5l" to="cj4x:~EditorComponent.update()" resolve="update" />
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                                <node concept="2AHcQZ" id="7olAlesPJFl" role="2AJF6D">
-                                  <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3clFbF" id="7olAlesPoE0" role="3cqZAp">
-                    <node concept="37vLTw" id="7olAlesPGkm" role="3clFbG">
-                      <ref role="3cqZAo" node="7olAlesPGki" resolve="button" />
-                    </node>
-                  </node>
-                </node>
+            <node concept="3F0ifn" id="4tlZZBq8FZA" role="3EZMnx">
+              <property role="3F0ifm" value="+" />
+              <ref role="1ERwB7" node="4tlZZBq7LHr" resolve="GoalStructureElement_ExpandClickMap" />
+              <node concept="Vb9p2" id="67s_eyKX4$S" role="3F10Kt">
+                <property role="Vbekb" value="g1_k_vY/BOLD" />
               </node>
             </node>
             <node concept="1HlG4h" id="7olAlesPV_G" role="3EZMnx">
@@ -11544,144 +11415,11 @@
           </node>
           <node concept="3EZMnI" id="7olAlesPWNB" role="3EZMnx">
             <node concept="2iRfu4" id="7olAlesPWNC" role="2iSdaV" />
-            <node concept="3gTLQM" id="7olAlesPWND" role="3EZMnx">
-              <node concept="3Fmcul" id="7olAlesPWNE" role="3FoqZy">
-                <node concept="3clFbS" id="7olAlesPWNF" role="2VODD2">
-                  <node concept="3cpWs8" id="7olAlesPWNG" role="3cqZAp">
-                    <node concept="3cpWsn" id="7olAlesPWNH" role="3cpWs9">
-                      <property role="TrG5h" value="button" />
-                      <node concept="3uibUv" id="7olAlesPWNI" role="1tU5fm">
-                        <ref role="3uigEE" to="dxuu:~JButton" resolve="JButton" />
-                      </node>
-                      <node concept="2ShNRf" id="7olAlesPWNJ" role="33vP2m">
-                        <node concept="1pGfFk" id="7olAlesPWNK" role="2ShVmc">
-                          <ref role="37wK5l" to="dxuu:~JButton.&lt;init&gt;(java.lang.String)" resolve="JButton" />
-                          <node concept="Xl_RD" id="7olAlesPWNL" role="37wK5m">
-                            <property role="Xl_RC" value="-" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3clFbF" id="7olAlesTqNj" role="3cqZAp">
-                    <node concept="2OqwBi" id="7olAlesTqNk" role="3clFbG">
-                      <node concept="37vLTw" id="7olAlesTqNl" role="2Oq$k0">
-                        <ref role="3cqZAo" node="7olAlesPWNH" resolve="button" />
-                      </node>
-                      <node concept="liA8E" id="7olAlesTqNm" role="2OqNvi">
-                        <ref role="37wK5l" to="dxuu:~JComponent.setPreferredSize(java.awt.Dimension)" resolve="setPreferredSize" />
-                        <node concept="2ShNRf" id="7olAlesTqNn" role="37wK5m">
-                          <node concept="1pGfFk" id="7olAlesTqNo" role="2ShVmc">
-                            <ref role="37wK5l" to="z60i:~Dimension.&lt;init&gt;(int,int)" resolve="Dimension" />
-                            <node concept="3cmrfG" id="7olAlesTqNp" role="37wK5m">
-                              <property role="3cmrfH" value="15" />
-                            </node>
-                            <node concept="3cmrfG" id="7olAlesTqNq" role="37wK5m">
-                              <property role="3cmrfH" value="15" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3clFbF" id="7olAlesPWNM" role="3cqZAp">
-                    <node concept="2OqwBi" id="7olAlesPWNN" role="3clFbG">
-                      <node concept="37vLTw" id="7olAlesPWNO" role="2Oq$k0">
-                        <ref role="3cqZAo" node="7olAlesPWNH" resolve="button" />
-                      </node>
-                      <node concept="liA8E" id="7olAlesPWNP" role="2OqNvi">
-                        <ref role="37wK5l" to="dxuu:~AbstractButton.addActionListener(java.awt.event.ActionListener)" resolve="addActionListener" />
-                        <node concept="2ShNRf" id="7olAlesPWNQ" role="37wK5m">
-                          <node concept="YeOm9" id="7olAlesPWNR" role="2ShVmc">
-                            <node concept="1Y3b0j" id="7olAlesPWNS" role="YeSDq">
-                              <property role="2bfB8j" value="true" />
-                              <ref role="1Y3XeK" to="hyam:~ActionListener" resolve="ActionListener" />
-                              <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
-                              <node concept="3Tm1VV" id="7olAlesPWNT" role="1B3o_S" />
-                              <node concept="3clFb_" id="7olAlesPWNU" role="jymVt">
-                                <property role="TrG5h" value="actionPerformed" />
-                                <node concept="3Tm1VV" id="7olAlesPWNV" role="1B3o_S" />
-                                <node concept="3cqZAl" id="7olAlesPWNW" role="3clF45" />
-                                <node concept="37vLTG" id="7olAlesPWNX" role="3clF46">
-                                  <property role="TrG5h" value="p0" />
-                                  <node concept="3uibUv" id="7olAlesPWNY" role="1tU5fm">
-                                    <ref role="3uigEE" to="hyam:~ActionEvent" resolve="ActionEvent" />
-                                  </node>
-                                </node>
-                                <node concept="3clFbS" id="7olAlesPWNZ" role="3clF47">
-                                  <node concept="3cpWs8" id="6hlfxCL6tSi" role="3cqZAp">
-                                    <node concept="3cpWsn" id="6hlfxCL6tSj" role="3cpWs9">
-                                      <property role="TrG5h" value="gs" />
-                                      <node concept="3Tqbb2" id="6hlfxCL6tSk" role="1tU5fm">
-                                        <ref role="ehGHo" to="py52:3GRi4m$qNsQ" resolve="GoalStructure" />
-                                      </node>
-                                      <node concept="1PxgMI" id="6hlfxCL6tSl" role="33vP2m">
-                                        <property role="1BlNFB" value="true" />
-                                        <node concept="chp4Y" id="6hlfxCL6tSm" role="3oSUPX">
-                                          <ref role="cht4Q" to="py52:3GRi4m$qNsQ" resolve="GoalStructure" />
-                                        </node>
-                                        <node concept="2OqwBi" id="6hlfxCL6tSn" role="1m5AlR">
-                                          <node concept="2OqwBi" id="6hlfxCL6tSo" role="2Oq$k0">
-                                            <node concept="2OqwBi" id="6hlfxCL6tSp" role="2Oq$k0">
-                                              <node concept="1Q80Hx" id="6hlfxCL6tSq" role="2Oq$k0" />
-                                              <node concept="liA8E" id="6hlfxCL6tSr" role="2OqNvi">
-                                                <ref role="37wK5l" to="cj4x:~EditorContext.getEditorComponent()" resolve="getEditorComponent" />
-                                              </node>
-                                            </node>
-                                            <node concept="liA8E" id="6hlfxCL6tSs" role="2OqNvi">
-                                              <ref role="37wK5l" to="cj4x:~EditorComponent.getRootCell()" resolve="getRootCell" />
-                                            </node>
-                                          </node>
-                                          <node concept="liA8E" id="6hlfxCL6tSt" role="2OqNvi">
-                                            <ref role="37wK5l" to="f4zo:~EditorCell.getSNode()" resolve="getSNode" />
-                                          </node>
-                                        </node>
-                                      </node>
-                                    </node>
-                                  </node>
-                                  <node concept="3clFbF" id="7olAlesPWO0" role="3cqZAp">
-                                    <node concept="2YIFZM" id="7olAlesPWO1" role="3clFbG">
-                                      <ref role="37wK5l" node="7olAlesPRVR" resolve="setCollapsed" />
-                                      <ref role="1Pybhc" node="7olAlesPJUl" resolve="TextualFastProjectionUtils" />
-                                      <node concept="37vLTw" id="6hlfxCL6utY" role="37wK5m">
-                                        <ref role="3cqZAo" node="6hlfxCL6tSj" resolve="gs" />
-                                      </node>
-                                      <node concept="pncrf" id="7olAlesPWO2" role="37wK5m" />
-                                      <node concept="3clFbT" id="7olAlesPWO3" role="37wK5m">
-                                        <property role="3clFbU" value="true" />
-                                      </node>
-                                    </node>
-                                  </node>
-                                  <node concept="3clFbF" id="7olAlesV2Gc" role="3cqZAp">
-                                    <node concept="2OqwBi" id="7olAlesV2Gd" role="3clFbG">
-                                      <node concept="2OqwBi" id="7olAlesV2Ge" role="2Oq$k0">
-                                        <node concept="1Q80Hx" id="7olAlesV2Gf" role="2Oq$k0" />
-                                        <node concept="liA8E" id="7olAlesV2Gg" role="2OqNvi">
-                                          <ref role="37wK5l" to="cj4x:~EditorContext.getEditorComponent()" resolve="getEditorComponent" />
-                                        </node>
-                                      </node>
-                                      <node concept="liA8E" id="7olAlesV2Gh" role="2OqNvi">
-                                        <ref role="37wK5l" to="cj4x:~EditorComponent.update()" resolve="update" />
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                                <node concept="2AHcQZ" id="7olAlesPWO4" role="2AJF6D">
-                                  <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3clFbF" id="7olAlesPWO5" role="3cqZAp">
-                    <node concept="37vLTw" id="7olAlesPWO6" role="3clFbG">
-                      <ref role="3cqZAo" node="7olAlesPWNH" resolve="button" />
-                    </node>
-                  </node>
-                </node>
+            <node concept="3F0ifn" id="4tlZZBq8HXt" role="3EZMnx">
+              <property role="3F0ifm" value="-" />
+              <ref role="1ERwB7" node="4tlZZBq7NFi" resolve="GoalStructureElement_CollapseClickMap" />
+              <node concept="Vb9p2" id="67s_eyKX4$T" role="3F10Kt">
+                <property role="Vbekb" value="g1_k_vY/BOLD" />
               </node>
             </node>
             <node concept="s8t4o" id="7olAlesPYfv" role="3EZMnx">
@@ -16611,6 +16349,160 @@
       </node>
     </node>
     <node concept="3Tm1VV" id="6P2k_NGBPz4" role="1B3o_S" />
+  </node>
+  <node concept="1h_SRR" id="4tlZZBq7LHr">
+    <property role="TrG5h" value="GoalStructureElement_ExpandClickMap" />
+    <ref role="1h_SK9" to="py52:3GRi4m$qS5k" resolve="GoalStructureElementBase" />
+    <node concept="1hA7zw" id="4tlZZBq7Pzq" role="1h_SK8">
+      <property role="1hAc7j" value="1FSxSwWqMNJ/click_action_id" />
+      <node concept="1hAIg9" id="4tlZZBq7T8m" role="1hA7z_">
+        <node concept="3clFbS" id="4tlZZBq7T8o" role="2VODD2">
+          <node concept="3cpWs8" id="4tlZZBq8lVL" role="3cqZAp">
+            <node concept="3cpWsn" id="4tlZZBq8lVK" role="3cpWs9">
+              <property role="TrG5h" value="ec" />
+              <node concept="3uibUv" id="4tlZZBq8lVM" role="1tU5fm">
+                <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+              </node>
+              <node concept="1Q80Hx" id="4tlZZBq8npR" role="33vP2m" />
+            </node>
+          </node>
+          <node concept="3cpWs8" id="4tlZZBq8lVP" role="3cqZAp">
+            <node concept="3cpWsn" id="4tlZZBq8lVO" role="3cpWs9">
+              <property role="TrG5h" value="gs" />
+              <node concept="3Tqbb2" id="4tlZZBq8wTm" role="1tU5fm">
+                <ref role="ehGHo" to="py52:3GRi4m$qNsQ" resolve="GoalStructure" />
+              </node>
+              <node concept="1PxgMI" id="6hlfxCL6tb5" role="33vP2m">
+                <property role="1BlNFB" value="true" />
+                <node concept="chp4Y" id="6hlfxCL6tb6" role="3oSUPX">
+                  <ref role="cht4Q" to="py52:3GRi4m$qNsQ" resolve="GoalStructure" />
+                </node>
+                <node concept="2OqwBi" id="6hlfxCL6tb7" role="1m5AlR">
+                  <node concept="2OqwBi" id="6hlfxCL6tb8" role="2Oq$k0">
+                    <node concept="2OqwBi" id="6hlfxCL6tb9" role="2Oq$k0">
+                      <node concept="1Q80Hx" id="6hlfxCL6tba" role="2Oq$k0" />
+                      <node concept="liA8E" id="6hlfxCL6tbb" role="2OqNvi">
+                        <ref role="37wK5l" to="cj4x:~EditorContext.getEditorComponent()" resolve="getEditorComponent" />
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="6hlfxCL6tbc" role="2OqNvi">
+                      <ref role="37wK5l" to="cj4x:~EditorComponent.getRootCell()" resolve="getRootCell" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="6hlfxCL6tbd" role="2OqNvi">
+                    <ref role="37wK5l" to="f4zo:~EditorCell.getSNode()" resolve="getSNode" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="4tlZZBq8lVU" role="3cqZAp">
+            <node concept="2YIFZM" id="4tlZZBq8m5c" role="3clFbG">
+              <ref role="1Pybhc" node="7olAlesPJUl" resolve="TextualFastProjectionUtils" />
+              <ref role="37wK5l" node="7olAlesPRVR" resolve="setCollapsed" />
+              <node concept="37vLTw" id="4tlZZBq8m5d" role="37wK5m">
+                <ref role="3cqZAo" node="4tlZZBq8lVO" resolve="gs" />
+              </node>
+              <node concept="0IXxy" id="4tlZZBq8p7i" role="37wK5m" />
+              <node concept="3clFbT" id="4tlZZBq8m5f" role="37wK5m" />
+            </node>
+          </node>
+          <node concept="3clFbF" id="4tlZZBq8lVZ" role="3cqZAp">
+            <node concept="2OqwBi" id="4tlZZBq8m6S" role="3clFbG">
+              <node concept="2OqwBi" id="4tlZZBq8m68" role="2Oq$k0">
+                <node concept="37vLTw" id="4tlZZBq8m5o" role="2Oq$k0">
+                  <ref role="3cqZAo" node="4tlZZBq8lVK" resolve="ec" />
+                </node>
+                <node concept="liA8E" id="4tlZZBq8m69" role="2OqNvi">
+                  <ref role="37wK5l" to="cj4x:~EditorContext.getEditorComponent()" resolve="getEditorComponent" />
+                </node>
+              </node>
+              <node concept="liA8E" id="4tlZZBq8m6T" role="2OqNvi">
+                <ref role="37wK5l" to="cj4x:~EditorComponent.update()" resolve="update" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1h_SRR" id="4tlZZBq7NFi">
+    <property role="TrG5h" value="GoalStructureElement_CollapseClickMap" />
+    <ref role="1h_SK9" to="py52:3GRi4m$qS5k" resolve="GoalStructureElementBase" />
+    <node concept="1hA7zw" id="4tlZZBq7RkR" role="1h_SK8">
+      <property role="1hAc7j" value="1FSxSwWqMNJ/click_action_id" />
+      <node concept="1hAIg9" id="4tlZZBq7UV_" role="1hA7z_">
+        <node concept="3clFbS" id="4tlZZBq7UVB" role="2VODD2">
+          <node concept="3cpWs8" id="4tlZZBq8mJg" role="3cqZAp">
+            <node concept="3cpWsn" id="4tlZZBq8mJf" role="3cpWs9">
+              <property role="TrG5h" value="ec" />
+              <node concept="3uibUv" id="4tlZZBq8mJh" role="1tU5fm">
+                <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+              </node>
+              <node concept="1Q80Hx" id="4tlZZBq8qVc" role="33vP2m" />
+            </node>
+          </node>
+          <node concept="3cpWs8" id="4tlZZBq8mJk" role="3cqZAp">
+            <node concept="3cpWsn" id="4tlZZBq8mJj" role="3cpWs9">
+              <property role="TrG5h" value="gs" />
+              <node concept="3Tqbb2" id="4tlZZBq8ywn" role="1tU5fm">
+                <ref role="ehGHo" to="py52:3GRi4m$qNsQ" resolve="GoalStructure" />
+              </node>
+              <node concept="1PxgMI" id="6hlfxCL6tSl" role="33vP2m">
+                <property role="1BlNFB" value="true" />
+                <node concept="chp4Y" id="6hlfxCL6tSm" role="3oSUPX">
+                  <ref role="cht4Q" to="py52:3GRi4m$qNsQ" resolve="GoalStructure" />
+                </node>
+                <node concept="2OqwBi" id="6hlfxCL6tSn" role="1m5AlR">
+                  <node concept="2OqwBi" id="6hlfxCL6tSo" role="2Oq$k0">
+                    <node concept="2OqwBi" id="6hlfxCL6tSp" role="2Oq$k0">
+                      <node concept="1Q80Hx" id="6hlfxCL6tSq" role="2Oq$k0" />
+                      <node concept="liA8E" id="6hlfxCL6tSr" role="2OqNvi">
+                        <ref role="37wK5l" to="cj4x:~EditorContext.getEditorComponent()" resolve="getEditorComponent" />
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="6hlfxCL6tSs" role="2OqNvi">
+                      <ref role="37wK5l" to="cj4x:~EditorComponent.getRootCell()" resolve="getRootCell" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="6hlfxCL6tSt" role="2OqNvi">
+                    <ref role="37wK5l" to="f4zo:~EditorCell.getSNode()" resolve="getSNode" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="4tlZZBq8mJp" role="3cqZAp">
+            <node concept="2YIFZM" id="4tlZZBq8mJP" role="3clFbG">
+              <ref role="1Pybhc" node="7olAlesPJUl" resolve="TextualFastProjectionUtils" />
+              <ref role="37wK5l" node="7olAlesPRVR" resolve="setCollapsed" />
+              <node concept="37vLTw" id="4tlZZBq8mJQ" role="37wK5m">
+                <ref role="3cqZAo" node="4tlZZBq8mJj" resolve="gs" />
+              </node>
+              <node concept="0IXxy" id="4tlZZBq8suL" role="37wK5m" />
+              <node concept="3clFbT" id="4tlZZBq8mJS" role="37wK5m">
+                <property role="3clFbU" value="true" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="4tlZZBq8mJu" role="3cqZAp">
+            <node concept="2OqwBi" id="4tlZZBq8mLx" role="3clFbG">
+              <node concept="2OqwBi" id="4tlZZBq8mKL" role="2Oq$k0">
+                <node concept="37vLTw" id="4tlZZBq8mK1" role="2Oq$k0">
+                  <ref role="3cqZAo" node="4tlZZBq8mJf" resolve="ec" />
+                </node>
+                <node concept="liA8E" id="4tlZZBq8mKM" role="2OqNvi">
+                  <ref role="37wK5l" to="cj4x:~EditorContext.getEditorComponent()" resolve="getEditorComponent" />
+                </node>
+              </node>
+              <node concept="liA8E" id="4tlZZBq8mLy" role="2OqNvi">
+                <ref role="37wK5l" to="cj4x:~EditorComponent.update()" resolve="update" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
   </node>
 </model>
 

--- a/code/languages/com.mbeddr.formal.safety/languages/com.mbeddr.formal.safety.gsn/models/com.mbeddr.formal.safety.gsn.editor.mps
+++ b/code/languages/com.mbeddr.formal.safety/languages/com.mbeddr.formal.safety.gsn/models/com.mbeddr.formal.safety.gsn.editor.mps
@@ -13,6 +13,8 @@
     <use id="aee9cad2-acd4-4608-aef2-0004f6a1cdbd" name="jetbrains.mps.lang.actions" version="4" />
     <use id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc" version="3" />
     <use id="1919c723-b60b-4592-9318-9ce96d91da44" name="de.itemis.mps.editor.celllayout" version="0" />
+    <use id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior" version="2" />
+    <use id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core" version="2" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -53,10 +55,13 @@
     <import index="b19z" ref="r:11a68676-9d63-4e1c-b920-59aefe77def3(com.mbeddr.formal.base.structure)" />
     <import index="tbr6" ref="r:6a005c26-87c0-43c4-8cf3-49ffba1099df(de.slisson.mps.richtext.behavior)" />
     <import index="oroz" ref="r:dba7efaf-6d1d-4f64-8546-01563c9e7aae(com.mpsbasics.editor.utils.editor_cells)" />
-    <import index="88j9" ref="r:20c4aa5c-ab36-4815-af32-01895ee9c2f5(de.itemis.mps.editor.diagram.editor)" implicit="true" />
-    <import index="tpco" ref="r:00000000-0000-4000-0000-011c89590284(jetbrains.mps.lang.core.editor)" implicit="true" />
-    <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" implicit="true" />
-    <import index="w873" ref="r:0de03bcd-6ad8-423c-b85e-ae3dd18ed2b3(com.mbeddr.formal.base.behavior)" implicit="true" />
+    <import index="4p95" ref="r:567b5936-84e7-4bfd-a79c-452e2eb73b3c(com.mpsbasics.editor.utils.performance)" />
+    <import index="tpco" ref="r:00000000-0000-4000-0000-011c89590284(jetbrains.mps.lang.core.editor)" />
+    <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" />
+    <import index="w873" ref="r:0de03bcd-6ad8-423c-b85e-ae3dd18ed2b3(com.mbeddr.formal.base.behavior)" />
+    <import index="88j9" ref="r:20c4aa5c-ab36-4815-af32-01895ee9c2f5(de.itemis.mps.editor.diagram.editor)" />
+    <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" />
+    <import index="uzhr" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.diagnostic(MPS.IDEA/)" />
   </imports>
   <registry>
     <language id="a247e09e-2435-45ba-b8d2-07e93feba96a" name="jetbrains.mps.baseLanguage.tuples">
@@ -834,6 +839,7 @@
         <child id="4611582986551314344" name="requestedType" index="UnYnz" />
       </concept>
       <concept id="1160666733551" name="jetbrains.mps.baseLanguage.collections.structure.AddAllElementsOperation" flags="nn" index="X8dFx" />
+      <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
       <concept id="3055999550620853964" name="jetbrains.mps.baseLanguage.collections.structure.RemoveWhereOperation" flags="nn" index="1aUR6E" />
       <concept id="1201792049884" name="jetbrains.mps.baseLanguage.collections.structure.TranslateOperation" flags="nn" index="3goQfb" />
       <concept id="1201872418428" name="jetbrains.mps.baseLanguage.collections.structure.GetKeysOperation" flags="nn" index="3lbrtF" />
@@ -932,6 +938,40 @@
         </node>
       </node>
       <node concept="2iRkQZ" id="3GRi4m$qQ5t" role="2iSdaV" />
+      <node concept="pkWqt" id="7OFgsunKnYL" role="pqm2j">
+        <node concept="3clFbS" id="7OFgsunKnYM" role="2VODD2">
+          <node concept="3clFbJ" id="7OFgsunKoev" role="3cqZAp">
+            <node concept="3clFbS" id="7OFgsunKoex" role="3clFbx">
+              <node concept="3clFbF" id="7OFgsunKoEb" role="3cqZAp">
+                <node concept="2YIFZM" id="7OFgsunKoUt" role="3clFbG">
+                  <ref role="37wK5l" to="4p95:5n$6p7WN70j" resolve="disableVcsHighlighter" />
+                  <ref role="1Pybhc" to="4p95:5n$6p7WMZoz" resolve="VcsHighlighterDisabler" />
+                  <node concept="1Q80Hx" id="7OFgsunKqsz" role="37wK5m" />
+                </node>
+              </node>
+            </node>
+            <node concept="3eOSWO" id="7OFgsunKEkv" role="3clFbw">
+              <node concept="3cmrfG" id="7OFgsunKEp8" role="3uHU7w">
+                <property role="3cmrfH" value="100" />
+              </node>
+              <node concept="2OqwBi" id="7OFgsunK$9I" role="3uHU7B">
+                <node concept="2OqwBi" id="7OFgsunKqQU" role="2Oq$k0">
+                  <node concept="pncrf" id="7OFgsunKqyo" role="2Oq$k0" />
+                  <node concept="3Tsc0h" id="7OFgsunKwVv" role="2OqNvi">
+                    <ref role="3TtcxE" to="py52:3GRi4m$qPV0" resolve="content" />
+                  </node>
+                </node>
+                <node concept="34oBXx" id="7OFgsunKCCA" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="7OFgsunKELV" role="3cqZAp">
+            <node concept="3clFbT" id="7OFgsunKELU" role="3clFbG">
+              <property role="3clFbU" value="true" />
+            </node>
+          </node>
+        </node>
+      </node>
     </node>
     <node concept="PMmxH" id="3ydH56R7Q$p" role="6VMZX">
       <ref role="PMmxG" node="3ydH56R7QiE" resolve="GoalStructureInInspector_EditorComponent" />
@@ -6534,6 +6574,40 @@
         <ref role="PMmxG" node="4UQF4xbK33B" resolve="GoalStructureQueryListBasedEditorComponent" />
       </node>
       <node concept="2iRkQZ" id="5uFV_KKBj0q" role="2iSdaV" />
+      <node concept="pkWqt" id="7OFgsunOgX7" role="pqm2j">
+        <node concept="3clFbS" id="7OFgsunOgX8" role="2VODD2">
+          <node concept="3clFbJ" id="5n$6p7WPTKy" role="3cqZAp">
+            <node concept="3clFbS" id="5n$6p7WPTK$" role="3clFbx">
+              <node concept="3clFbF" id="5n$6p7WQoX7" role="3cqZAp">
+                <node concept="2YIFZM" id="5n$6p7WQprA" role="3clFbG">
+                  <ref role="37wK5l" to="4p95:5n$6p7WN70j" resolve="disableVcsHighlighter" />
+                  <ref role="1Pybhc" to="4p95:5n$6p7WMZoz" resolve="VcsHighlighterDisabler" />
+                  <node concept="1Q80Hx" id="5n$6p7WQpGU" role="37wK5m" />
+                </node>
+              </node>
+            </node>
+            <node concept="3eOSWO" id="5n$6p7WQ3qL" role="3clFbw">
+              <node concept="3cmrfG" id="5n$6p7WQ3uS" role="3uHU7w">
+                <property role="3cmrfH" value="100" />
+              </node>
+              <node concept="2OqwBi" id="5n$6p7WPXtM" role="3uHU7B">
+                <node concept="2OqwBi" id="5n$6p7WPU9T" role="2Oq$k0">
+                  <node concept="pncrf" id="5n$6p7WPTNa" role="2Oq$k0" />
+                  <node concept="3Tsc0h" id="5n$6p7WTYFx" role="2OqNvi">
+                    <ref role="3TtcxE" to="py52:3GRi4m$qPV0" resolve="content" />
+                  </node>
+                </node>
+                <node concept="34oBXx" id="5n$6p7WQ1Zt" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="5n$6p7WQpPY" role="3cqZAp">
+            <node concept="3clFbT" id="5n$6p7WQpPX" role="3clFbG">
+              <property role="3clFbU" value="true" />
+            </node>
+          </node>
+        </node>
+      </node>
     </node>
     <node concept="2aJ2om" id="5uFV_KKBkOT" role="CpUAK">
       <ref role="2$4xQ3" node="5uFV_KKBhnn" resolve="GOAL_STRUCTURE_TEXTUAL" />
@@ -11044,6 +11118,40 @@
         <ref role="PMmxG" node="4UQF4xbK33B" resolve="GoalStructureQueryListBasedEditorComponent" />
       </node>
       <node concept="2iRkQZ" id="7olAlesPk0L" role="2iSdaV" />
+      <node concept="pkWqt" id="7OFgsunPwGQ" role="pqm2j">
+        <node concept="3clFbS" id="7OFgsunPwGR" role="2VODD2">
+          <node concept="3clFbJ" id="7OFgsunPwSp" role="3cqZAp">
+            <node concept="3clFbS" id="7OFgsunPwSq" role="3clFbx">
+              <node concept="3clFbF" id="7OFgsunPwSr" role="3cqZAp">
+                <node concept="2YIFZM" id="7OFgsunPwSs" role="3clFbG">
+                  <ref role="37wK5l" to="4p95:5n$6p7WN70j" resolve="disableVcsHighlighter" />
+                  <ref role="1Pybhc" to="4p95:5n$6p7WMZoz" resolve="VcsHighlighterDisabler" />
+                  <node concept="1Q80Hx" id="7OFgsunPwSt" role="37wK5m" />
+                </node>
+              </node>
+            </node>
+            <node concept="3eOSWO" id="7OFgsunPwSu" role="3clFbw">
+              <node concept="3cmrfG" id="7OFgsunPwSv" role="3uHU7w">
+                <property role="3cmrfH" value="100" />
+              </node>
+              <node concept="2OqwBi" id="7OFgsunPwSw" role="3uHU7B">
+                <node concept="2OqwBi" id="7OFgsunPwSx" role="2Oq$k0">
+                  <node concept="pncrf" id="7OFgsunPwSy" role="2Oq$k0" />
+                  <node concept="3Tsc0h" id="7OFgsunPwSz" role="2OqNvi">
+                    <ref role="3TtcxE" to="py52:3GRi4m$qPV0" resolve="content" />
+                  </node>
+                </node>
+                <node concept="34oBXx" id="7OFgsunPwS$" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="7OFgsunPwS_" role="3cqZAp">
+            <node concept="3clFbT" id="7OFgsunPwSA" role="3clFbG">
+              <property role="3clFbU" value="true" />
+            </node>
+          </node>
+        </node>
+      </node>
     </node>
     <node concept="PMmxH" id="3ydH56R8Uk2" role="6VMZX">
       <ref role="PMmxG" node="3ydH56R7QiE" resolve="GoalStructureInInspector_EditorComponent" />
@@ -12398,6 +12506,40 @@
         </node>
       </node>
       <node concept="2iRkQZ" id="4Cms47V7bQG" role="2iSdaV" />
+      <node concept="pkWqt" id="7OFgsunPyk6" role="pqm2j">
+        <node concept="3clFbS" id="7OFgsunPyk7" role="2VODD2">
+          <node concept="3clFbJ" id="7OFgsunPys4" role="3cqZAp">
+            <node concept="3clFbS" id="7OFgsunPys5" role="3clFbx">
+              <node concept="3clFbF" id="7OFgsunPys6" role="3cqZAp">
+                <node concept="2YIFZM" id="7OFgsunPys7" role="3clFbG">
+                  <ref role="37wK5l" to="4p95:5n$6p7WN70j" resolve="disableVcsHighlighter" />
+                  <ref role="1Pybhc" to="4p95:5n$6p7WMZoz" resolve="VcsHighlighterDisabler" />
+                  <node concept="1Q80Hx" id="7OFgsunPys8" role="37wK5m" />
+                </node>
+              </node>
+            </node>
+            <node concept="3eOSWO" id="7OFgsunPys9" role="3clFbw">
+              <node concept="3cmrfG" id="7OFgsunPysa" role="3uHU7w">
+                <property role="3cmrfH" value="100" />
+              </node>
+              <node concept="2OqwBi" id="7OFgsunPysb" role="3uHU7B">
+                <node concept="2OqwBi" id="7OFgsunPysc" role="2Oq$k0">
+                  <node concept="pncrf" id="7OFgsunPysd" role="2Oq$k0" />
+                  <node concept="3Tsc0h" id="7OFgsunPyse" role="2OqNvi">
+                    <ref role="3TtcxE" to="py52:3GRi4m$qPV0" resolve="content" />
+                  </node>
+                </node>
+                <node concept="34oBXx" id="7OFgsunPysf" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="7OFgsunPysg" role="3cqZAp">
+            <node concept="3clFbT" id="7OFgsunPysh" role="3clFbG">
+              <property role="3clFbU" value="true" />
+            </node>
+          </node>
+        </node>
+      </node>
     </node>
     <node concept="2aJ2om" id="4Cms47V7voF" role="CpUAK">
       <ref role="2$4xQ3" node="4Cms47V74xp" resolve="GOAL_STRUCTURE_TREE_TABLE" />

--- a/code/languages/com.mbeddr.formal.safety/solutions/com.mbeddr.formal.safety.argument.genai.sandbox/com.mbeddr.formal.safety.argument.genai.sandbox.msd
+++ b/code/languages/com.mbeddr.formal.safety/solutions/com.mbeddr.formal.safety.argument.genai.sandbox/com.mbeddr.formal.safety.argument.genai.sandbox.msd
@@ -25,7 +25,6 @@
   </languageVersions>
   <dependencyVersions>
     <module reference="d2b33f3e-5932-45b5-b063-f3e859abfbe3(com.mbeddr.formal.safety.argument.genai.sandbox)" version="0" />
-    <module reference="7a642ffb-bd05-4e8c-b81a-08fde9a204ba(com.mbeddr.formal.safety.tutorial)" version="0" />
   </dependencyVersions>
 </solution>
 

--- a/code/languages/com.mpsbasics/solutions/com.mpsbasics.build/models/com.mpsbasics.build.build.mps
+++ b/code/languages/com.mpsbasics/solutions/com.mpsbasics.build/models/com.mpsbasics.build.build.mps
@@ -1497,11 +1497,6 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="16dr8Qynset" role="3bR37C">
-          <node concept="3bR9La" id="16dr8Qynseu" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1ia2VB5guYy" resolve="MPS.IDEA" />
-          </node>
-        </node>
         <node concept="1SiIV0" id="16dr8Qynsex" role="3bR37C">
           <node concept="3bR9La" id="16dr8Qynsey" role="1SiIV1">
             <ref role="3bR37D" to="ffeo:1TaHNgiIbIQ" resolve="MPS.Core" />
@@ -1638,6 +1633,11 @@
         <node concept="1SiIV0" id="2i2e8U1mEgx" role="3bR37C">
           <node concept="3bR9La" id="2i2e8U1mEgy" role="1SiIV1">
             <ref role="3bR37D" to="90a9:6bkzxtWPDx1" resolve="de.itemis.stubs.batik" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="4tlZZBq6GA8" role="3bR37C">
+          <node concept="3bR9La" id="4tlZZBq6GA9" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:39HJr_hyEzS" resolve="jetbrains.mps.ide.vcs.platform" />
           </node>
         </node>
       </node>
@@ -3354,15 +3354,6 @@
               </node>
             </node>
           </node>
-        </node>
-      </node>
-    </node>
-    <node concept="2sgV4H" id="4oT$_WGcUdW" role="1l3spa">
-      <ref role="1l3spb" to="al5i:3AVJcIMlF8l" resolve="com.mbeddr.platform" />
-      <node concept="398BVA" id="4oT$_WGcUdX" role="2JcizS">
-        <ref role="398BVh" node="5gFsbf33UIa" resolve="dependencies.root" />
-        <node concept="2Ry0Ak" id="4oT$_WGcUdY" role="iGT6I">
-          <property role="2Ry0Am" value="com.mbeddr.platform" />
         </node>
       </node>
     </node>

--- a/code/languages/com.mpsbasics/solutions/com.mpsbasics.editor.utils/com.mpsbasics.editor.utils.msd
+++ b/code/languages/com.mpsbasics/solutions/com.mpsbasics.editor.utils/com.mpsbasics.editor.utils.msd
@@ -17,6 +17,7 @@
     <dependency reexport="false">1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)</dependency>
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
     <dependency reexport="false">563a0770-eb88-4f4f-83ed-f708776fc2fe(de.itemis.stubs.batik)</dependency>
+    <dependency reexport="false">6fd1293f-7f65-4ffd-99dc-4719eca7c171(jetbrains.mps.ide.vcs.platform)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
@@ -43,6 +44,7 @@
     <module reference="1f4710e9-f074-4732-a0bd-6fa896d282b7(com.mpsbasics.project.utils)" version="0" />
     <module reference="563a0770-eb88-4f4f-83ed-f708776fc2fe(de.itemis.stubs.batik)" version="0" />
     <module reference="34e84b8f-afa8-4364-abcd-a279fddddbe7(jetbrains.mps.editor.runtime)" version="0" />
+    <module reference="6fd1293f-7f65-4ffd-99dc-4719eca7c171(jetbrains.mps.ide.vcs.platform)" version="0" />
     <module reference="5ad14eca-28d7-4bce-b8e0-648908a49062(org.apache.batik)" version="0" />
   </dependencyVersions>
 </solution>

--- a/code/languages/com.mpsbasics/solutions/com.mpsbasics.editor.utils/models/com.mpsbasics.editor.utils.performance.mps
+++ b/code/languages/com.mpsbasics/solutions/com.mpsbasics.editor.utils/models/com.mpsbasics.editor.utils.performance.mps
@@ -1,0 +1,427 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:567b5936-84e7-4bfd-a79c-452e2eb73b3c(com.mpsbasics.editor.utils.performance)">
+  <persistence version="9" />
+  <languages>
+    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
+    <use id="760a0a8c-eabb-4521-8bfd-65db761a9ba3" name="jetbrains.mps.baseLanguage.logging" version="0" />
+  </languages>
+  <imports>
+    <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" />
+    <import index="dxuu" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:javax.swing(JDK/)" />
+    <import index="px75" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.leftHighlighter(MPS.Editor/)" />
+    <import index="alof" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide.project(MPS.Platform/)" />
+    <import index="exr9" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor(MPS.Editor/)" />
+    <import index="4nm9" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.project(MPS.IDEA/)" />
+    <import index="w1kc" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel(MPS.Core/)" />
+    <import index="t6h5" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang.reflect(JDK/)" />
+    <import index="lsse" ref="r:06e50ed3-c893-4772-ba4a-878fc9de01d0(jetbrains.mps.vcs.changesmanager.editor)" />
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
+  </imports>
+  <registry>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
+        <child id="1068498886297" name="rValue" index="37vLTx" />
+        <child id="1068498886295" name="lValue" index="37vLTJ" />
+      </concept>
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="8118189177080264853" name="jetbrains.mps.baseLanguage.structure.AlternativeType" flags="ig" index="nSUau">
+        <child id="8118189177080264854" name="alternative" index="nSUat" />
+      </concept>
+      <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+        <child id="1145553007750" name="creator" index="2ShVmc" />
+      </concept>
+      <concept id="1070462154015" name="jetbrains.mps.baseLanguage.structure.StaticFieldDeclaration" flags="ig" index="Wx3nA" />
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="4952749571008284462" name="jetbrains.mps.baseLanguage.structure.CatchVariable" flags="ng" index="XOnhg" />
+      <concept id="1182160077978" name="jetbrains.mps.baseLanguage.structure.AnonymousClassCreator" flags="nn" index="YeOm9">
+        <child id="1182160096073" name="cls" index="YeSDq" />
+      </concept>
+      <concept id="1081236700938" name="jetbrains.mps.baseLanguage.structure.StaticMethodDeclaration" flags="ig" index="2YIFZL" />
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
+      <concept id="1081256982272" name="jetbrains.mps.baseLanguage.structure.InstanceOfExpression" flags="nn" index="2ZW3vV">
+        <child id="1081256993305" name="classType" index="2ZW6by" />
+        <child id="1081256993304" name="leftExpression" index="2ZW6bz" />
+      </concept>
+      <concept id="1070533707846" name="jetbrains.mps.baseLanguage.structure.StaticFieldReference" flags="nn" index="10M0yZ">
+        <reference id="1144433057691" name="classifier" index="1PxDUh" />
+      </concept>
+      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
+        <child id="1070534934091" name="type" index="10QFUM" />
+        <child id="1070534934092" name="expression" index="10QFUP" />
+      </concept>
+      <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu" />
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <property id="1176718929932" name="isFinal" index="3TUv4t" />
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
+      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123134" name="parameter" index="3clF46" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123165" name="jetbrains.mps.baseLanguage.structure.InstanceMethodDeclaration" flags="ig" index="3clFb_" />
+      <concept id="1068580123152" name="jetbrains.mps.baseLanguage.structure.EqualsExpression" flags="nn" index="3clFbC" />
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
+      <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
+        <child id="1068580123160" name="condition" index="3clFbw" />
+        <child id="1068580123161" name="ifTrue" index="3clFbx" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
+        <property id="1068580123138" name="value" index="3clFbU" />
+      </concept>
+      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6" />
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
+        <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
+      </concept>
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+      </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
+      <concept id="3093926081414150598" name="jetbrains.mps.baseLanguage.structure.MultipleCatchClause" flags="ng" index="3uVAMA">
+        <child id="8276990574895933173" name="catchBody" index="1zc67A" />
+        <child id="8276990574895933172" name="throwable" index="1zc67B" />
+      </concept>
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="5351203823916750322" name="jetbrains.mps.baseLanguage.structure.TryUniversalStatement" flags="nn" index="3J1_TO">
+        <child id="8276990574886367510" name="catchClause" index="1zxBo5" />
+        <child id="8276990574886367508" name="body" index="1zxBo7" />
+      </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+      <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
+      <concept id="1170345865475" name="jetbrains.mps.baseLanguage.structure.AnonymousClass" flags="ig" index="1Y3b0j">
+        <reference id="1170346070688" name="classifier" index="1Y3XeK" />
+      </concept>
+    </language>
+    <language id="760a0a8c-eabb-4521-8bfd-65db761a9ba3" name="jetbrains.mps.baseLanguage.logging">
+      <concept id="2034914114981261497" name="jetbrains.mps.baseLanguage.logging.structure.LogLowLevelStatement" flags="ng" index="RRSsy">
+        <property id="2034914114981261751" name="severity" index="RRSoG" />
+        <child id="2034914114981261755" name="throwable" index="RRSow" />
+        <child id="2034914114981261753" name="message" index="RRSoy" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="312cEu" id="5n$6p7WMZoz">
+    <property role="TrG5h" value="VcsHighlighterDisabler" />
+    <node concept="Wx3nA" id="7OFgsunJoy5" role="jymVt">
+      <property role="TrG5h" value="ourGetStripsPainterMethod" />
+      <node concept="3uibUv" id="7OFgsunJoy6" role="1tU5fm">
+        <ref role="3uigEE" to="t6h5:~Method" resolve="Method" />
+      </node>
+      <node concept="3Tm6S6" id="7OFgsunJoy7" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="5n$6p7WMZMA" role="jymVt" />
+    <node concept="2YIFZL" id="5n$6p7WN70j" role="jymVt">
+      <property role="TrG5h" value="disableVcsHighlighter" />
+      <node concept="3clFbS" id="5n$6p7WN70m" role="3clF47">
+        <node concept="3cpWs8" id="5n$6p7WJKFq" role="3cqZAp">
+          <node concept="3cpWsn" id="5n$6p7WJKFp" role="3cpWs9">
+            <property role="3TUv4t" value="true" />
+            <property role="TrG5h" value="theEditorComponent" />
+            <node concept="3uibUv" id="5n$6p7WJKFr" role="1tU5fm">
+              <ref role="3uigEE" to="exr9:~EditorComponent" resolve="EditorComponent" />
+            </node>
+            <node concept="10QFUN" id="5n$6p7WJKFs" role="33vP2m">
+              <node concept="2OqwBi" id="5n$6p7WJKFG" role="10QFUP">
+                <node concept="37vLTw" id="5n$6p7WJKFw" role="2Oq$k0">
+                  <ref role="3cqZAo" node="5n$6p7WNdCw" resolve="editorContext" />
+                </node>
+                <node concept="liA8E" id="5n$6p7WJKFH" role="2OqNvi">
+                  <ref role="37wK5l" to="cj4x:~EditorContext.getEditorComponent()" resolve="getEditorComponent" />
+                </node>
+              </node>
+              <node concept="3uibUv" id="5n$6p7WJKFu" role="10QFUM">
+                <ref role="3uigEE" to="exr9:~EditorComponent" resolve="EditorComponent" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5n$6p7WJdhe" role="3cqZAp">
+          <node concept="2YIFZM" id="5n$6p7WJi3o" role="3clFbG">
+            <ref role="1Pybhc" to="dxuu:~SwingUtilities" resolve="SwingUtilities" />
+            <ref role="37wK5l" to="dxuu:~SwingUtilities.invokeLater(java.lang.Runnable)" resolve="invokeLater" />
+            <node concept="2ShNRf" id="5n$6p7WJi3p" role="37wK5m">
+              <node concept="YeOm9" id="5n$6p7WJi3q" role="2ShVmc">
+                <node concept="1Y3b0j" id="5n$6p7WJi3r" role="YeSDq">
+                  <ref role="1Y3XeK" to="wyt6:~Runnable" resolve="Runnable" />
+                  <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
+                  <node concept="3clFb_" id="5n$6p7WJi3s" role="jymVt">
+                    <property role="TrG5h" value="run" />
+                    <node concept="3clFbS" id="5n$6p7WJi3t" role="3clF47">
+                      <node concept="3J1_TO" id="5n$6p7WJi3u" role="3cqZAp">
+                        <node concept="3uVAMA" id="5n$6p7WJi3v" role="1zxBo5">
+                          <node concept="3clFbS" id="5n$6p7WJi3w" role="1zc67A">
+                            <node concept="RRSsy" id="5n$6p7WPbtN" role="3cqZAp">
+                              <property role="RRSoG" value="gZ5fh_4/error" />
+                              <node concept="Xl_RD" id="5n$6p7WPbtP" role="RRSoy">
+                                <property role="Xl_RC" value="Error while disabling the VCS highlighter" />
+                              </node>
+                              <node concept="37vLTw" id="5n$6p7WPfMP" role="RRSow">
+                                <ref role="3cqZAo" node="5n$6p7WJi3x" resolve="t" />
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="XOnhg" id="5n$6p7WJi3x" role="1zc67B">
+                            <property role="TrG5h" value="t" />
+                            <node concept="nSUau" id="5n$6p7WJi3y" role="1tU5fm">
+                              <node concept="3uibUv" id="5n$6p7WJi3z" role="nSUat">
+                                <ref role="3uigEE" to="wyt6:~Throwable" resolve="Throwable" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3clFbS" id="5n$6p7WJi3$" role="1zxBo7">
+                          <node concept="3cpWs8" id="5n$6p7WJi3_" role="3cqZAp">
+                            <node concept="3cpWsn" id="5n$6p7WJi3A" role="3cpWs9">
+                              <property role="TrG5h" value="leftHighlighter" />
+                              <node concept="3uibUv" id="5n$6p7WJi3B" role="1tU5fm">
+                                <ref role="3uigEE" to="px75:~LeftEditorHighlighter" resolve="LeftEditorHighlighter" />
+                              </node>
+                              <node concept="2OqwBi" id="5n$6p7WJi7O" role="33vP2m">
+                                <node concept="37vLTw" id="5n$6p7WJi4P" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="5n$6p7WJKFp" resolve="theEditorComponent" />
+                                </node>
+                                <node concept="liA8E" id="5n$6p7WJi7P" role="2OqNvi">
+                                  <ref role="37wK5l" to="exr9:~EditorComponent.getLeftEditorHighlighter()" resolve="getLeftEditorHighlighter" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="3cpWs8" id="5n$6p7WJi3J" role="3cqZAp">
+                            <node concept="3cpWsn" id="5n$6p7WJi3K" role="3cpWs9">
+                              <property role="TrG5h" value="ideaProject" />
+                              <node concept="3uibUv" id="5n$6p7WJi3L" role="1tU5fm">
+                                <ref role="3uigEE" to="4nm9:~Project" resolve="Project" />
+                              </node>
+                              <node concept="2YIFZM" id="5n$6p7WJi4T" role="33vP2m">
+                                <ref role="1Pybhc" to="alof:~ProjectHelper" resolve="ProjectHelper" />
+                                <ref role="37wK5l" to="alof:~ProjectHelper.toIdeaProject(jetbrains.mps.project.Project)" resolve="toIdeaProject" />
+                                <node concept="2OqwBi" id="5n$6p7WJilB" role="37wK5m">
+                                  <node concept="2OqwBi" id="5n$6p7WJicd" role="2Oq$k0">
+                                    <node concept="37vLTw" id="5n$6p7WJi80" role="2Oq$k0">
+                                      <ref role="3cqZAo" node="5n$6p7WNdCw" resolve="editorContext" />
+                                    </node>
+                                    <node concept="liA8E" id="5n$6p7WJice" role="2OqNvi">
+                                      <ref role="37wK5l" to="cj4x:~EditorContext.getOperationContext()" resolve="getOperationContext" />
+                                    </node>
+                                  </node>
+                                  <node concept="liA8E" id="5n$6p7WJilC" role="2OqNvi">
+                                    <ref role="37wK5l" to="w1kc:~IOperationContext.getProject()" resolve="getProject" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="3clFbJ" id="5n$6p7WJi3P" role="3cqZAp">
+                            <node concept="3clFbC" id="5n$6p7WJi3Q" role="3clFbw">
+                              <node concept="37vLTw" id="5n$6p7WJi3R" role="3uHU7B">
+                                <ref role="3cqZAo" node="5n$6p7WJi3K" resolve="ideaProject" />
+                              </node>
+                              <node concept="10Nm6u" id="5n$6p7WJi3S" role="3uHU7w" />
+                            </node>
+                            <node concept="3clFbS" id="5n$6p7WJi3T" role="3clFbx">
+                              <node concept="3cpWs6" id="5n$6p7WJi3U" role="3cqZAp" />
+                            </node>
+                          </node>
+                          <node concept="3cpWs8" id="5n$6p7WJi4a" role="3cqZAp">
+                            <node concept="3cpWsn" id="5n$6p7WJi4b" role="3cpWs9">
+                              <property role="TrG5h" value="vcsHighlighter" />
+                              <node concept="3uibUv" id="5n$6p7WJi4c" role="1tU5fm">
+                                <ref role="3uigEE" to="lsse:5zpsdFy5B1u" resolve="EditorHighlighter" />
+                              </node>
+                              <node concept="2OqwBi" id="5n$6p7WOYzN" role="33vP2m">
+                                <node concept="2YIFZM" id="5n$6p7WOYzO" role="2Oq$k0">
+                                  <ref role="37wK5l" to="lsse:31IQ8dwSM13" resolve="getInstance" />
+                                  <ref role="1Pybhc" to="lsse:5zpsdFy5CyP" resolve="EditorHighlighterFactory" />
+                                  <node concept="37vLTw" id="5n$6p7WOYzP" role="37wK5m">
+                                    <ref role="3cqZAo" node="5n$6p7WJi3K" resolve="ideaProject" />
+                                  </node>
+                                </node>
+                                <node concept="liA8E" id="5n$6p7WOYzQ" role="2OqNvi">
+                                  <ref role="37wK5l" to="lsse:1LVXsqEggg1" resolve="getHighlighter" />
+                                  <node concept="37vLTw" id="5n$6p7WOYzR" role="37wK5m">
+                                    <ref role="3cqZAo" node="5n$6p7WJKFp" resolve="theEditorComponent" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="3clFbJ" id="5n$6p7WJi4j" role="3cqZAp">
+                            <node concept="3clFbC" id="5n$6p7WJi4k" role="3clFbw">
+                              <node concept="37vLTw" id="5n$6p7WJi4l" role="3uHU7B">
+                                <ref role="3cqZAo" node="5n$6p7WJi4b" resolve="vcsHighlighter" />
+                              </node>
+                              <node concept="10Nm6u" id="5n$6p7WJi4m" role="3uHU7w" />
+                            </node>
+                            <node concept="3clFbS" id="5n$6p7WJi4n" role="3clFbx">
+                              <node concept="3cpWs6" id="5n$6p7WJi4o" role="3cqZAp" />
+                            </node>
+                          </node>
+                          <node concept="3clFbJ" id="7OFgsunJyn8" role="3cqZAp">
+                            <node concept="3clFbC" id="7OFgsunJyn9" role="3clFbw">
+                              <node concept="10M0yZ" id="7OFgsunJyn$" role="3uHU7B">
+                                <ref role="1PxDUh" node="5n$6p7WMZoz" resolve="VcsHighlighterDisabler" />
+                                <ref role="3cqZAo" node="7OFgsunJoy5" resolve="ourGetStripsPainterMethod" />
+                              </node>
+                              <node concept="10Nm6u" id="7OFgsunJynb" role="3uHU7w" />
+                            </node>
+                            <node concept="3clFbS" id="7OFgsunJynd" role="3clFbx">
+                              <node concept="3clFbF" id="7OFgsunJyne" role="3cqZAp">
+                                <node concept="37vLTI" id="7OFgsunJynf" role="3clFbG">
+                                  <node concept="10M0yZ" id="7OFgsunJyn_" role="37vLTJ">
+                                    <ref role="1PxDUh" node="5n$6p7WMZoz" resolve="VcsHighlighterDisabler" />
+                                    <ref role="3cqZAo" node="7OFgsunJoy5" resolve="ourGetStripsPainterMethod" />
+                                  </node>
+                                  <node concept="2OqwBi" id="7OFgsunJyrz" role="37vLTx">
+                                    <node concept="2OqwBi" id="7OFgsunJyok" role="2Oq$k0">
+                                      <node concept="37vLTw" id="7OFgsunJynM" role="2Oq$k0">
+                                        <ref role="3cqZAo" node="5n$6p7WJi4b" resolve="vcsHighlighter" />
+                                      </node>
+                                      <node concept="liA8E" id="7OFgsunJyol" role="2OqNvi">
+                                        <ref role="37wK5l" to="wyt6:~Object.getClass()" resolve="getClass" />
+                                      </node>
+                                    </node>
+                                    <node concept="liA8E" id="7OFgsunJyr$" role="2OqNvi">
+                                      <ref role="37wK5l" to="wyt6:~Class.getDeclaredMethod(java.lang.String,java.lang.Class...)" resolve="getDeclaredMethod" />
+                                      <node concept="Xl_RD" id="7OFgsunJyr_" role="37wK5m">
+                                        <property role="Xl_RC" value="getStripsPainter" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="3clFbF" id="7OFgsunJynk" role="3cqZAp">
+                                <node concept="2OqwBi" id="7OFgsunJyoA" role="3clFbG">
+                                  <node concept="37vLTw" id="7OFgsunJynS" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="7OFgsunJoy5" resolve="ourGetStripsPainterMethod" />
+                                  </node>
+                                  <node concept="liA8E" id="7OFgsunJyoB" role="2OqNvi">
+                                    <ref role="37wK5l" to="t6h5:~Method.setAccessible(boolean)" resolve="setAccessible" />
+                                    <node concept="3clFbT" id="7OFgsunJyoC" role="37wK5m">
+                                      <property role="3clFbU" value="true" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="3cpWs8" id="7OFgsunJyno" role="3cqZAp">
+                            <node concept="3cpWsn" id="7OFgsunJynn" role="3cpWs9">
+                              <property role="TrG5h" value="stripsPainter" />
+                              <node concept="3uibUv" id="7OFgsunJynp" role="1tU5fm">
+                                <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+                              </node>
+                              <node concept="2OqwBi" id="7OFgsunJyoT" role="33vP2m">
+                                <node concept="37vLTw" id="7OFgsunJynZ" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="7OFgsunJoy5" resolve="ourGetStripsPainterMethod" />
+                                </node>
+                                <node concept="liA8E" id="7OFgsunJyoU" role="2OqNvi">
+                                  <ref role="37wK5l" to="t6h5:~Method.invoke(java.lang.Object,java.lang.Object...)" resolve="invoke" />
+                                  <node concept="37vLTw" id="7OFgsunJyoV" role="37wK5m">
+                                    <ref role="3cqZAo" node="5n$6p7WJi4b" resolve="vcsHighlighter" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="3clFbJ" id="5n$6p7WJi4B" role="3cqZAp">
+                            <node concept="2ZW3vV" id="5n$6p7WJi4C" role="3clFbw">
+                              <node concept="37vLTw" id="5n$6p7WJi4D" role="2ZW6bz">
+                                <ref role="3cqZAo" node="7OFgsunJynn" resolve="stripsPainter" />
+                              </node>
+                              <node concept="3uibUv" id="5n$6p7WJi4E" role="2ZW6by">
+                                <ref role="3uigEE" to="px75:~AbstractFoldingAreaPainter" resolve="AbstractFoldingAreaPainter" />
+                              </node>
+                            </node>
+                            <node concept="3clFbS" id="5n$6p7WJi4F" role="3clFbx">
+                              <node concept="3clFbF" id="5n$6p7WJi4G" role="3cqZAp">
+                                <node concept="2OqwBi" id="5n$6p7WJibM" role="3clFbG">
+                                  <node concept="37vLTw" id="5n$6p7WJi5O" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="5n$6p7WJi3A" resolve="leftHighlighter" />
+                                  </node>
+                                  <node concept="liA8E" id="5n$6p7WJibN" role="2OqNvi">
+                                    <ref role="37wK5l" to="px75:~LeftEditorHighlighter.removeFoldingAreaPainter(jetbrains.mps.nodeEditor.leftHighlighter.AbstractFoldingAreaPainter)" resolve="removeFoldingAreaPainter" />
+                                    <node concept="10QFUN" id="5n$6p7WJibO" role="37wK5m">
+                                      <node concept="37vLTw" id="5n$6p7WJibP" role="10QFUP">
+                                        <ref role="3cqZAo" node="7OFgsunJynn" resolve="stripsPainter" />
+                                      </node>
+                                      <node concept="3uibUv" id="5n$6p7WJibQ" role="10QFUM">
+                                        <ref role="3uigEE" to="px75:~AbstractFoldingAreaPainter" resolve="AbstractFoldingAreaPainter" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3Tm1VV" id="5n$6p7WJi4L" role="1B3o_S" />
+                    <node concept="3cqZAl" id="5n$6p7WJi4M" role="3clF45" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="5n$6p7WNei9" role="3cqZAp" />
+        <node concept="3clFbH" id="5n$6p7WNei_" role="3cqZAp" />
+      </node>
+      <node concept="3Tm1VV" id="5n$6p7WMZUp" role="1B3o_S" />
+      <node concept="3cqZAl" id="5n$6p7WMZZM" role="3clF45" />
+      <node concept="37vLTG" id="5n$6p7WNdCw" role="3clF46">
+        <property role="TrG5h" value="editorContext" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3uibUv" id="5n$6p7WNdCv" role="1tU5fm">
+          <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="5n$6p7WMZPb" role="jymVt" />
+    <node concept="3Tm1VV" id="5n$6p7WMZo$" role="1B3o_S" />
+  </node>
+</model>
+


### PR DESCRIPTION
## Summary
- Add a reusable `VcsHighlighterDisabler` utility (`com.mpsbasics.editor.utils.performance`) that disables the VCS "changed lines" gutter highlighter for large editors, and wire it into the GSN `GoalStructure` editor's renderingCondition for goal structures with more than 100 top-level content elements — avoids a pathologically slow IntelliJ/MPS gutter-diff computation that could freeze the editor on large uncommitted diffs.
- Replace the per-`GoalStructureElementBase` expand/collapse "+"/"-" toggles in the `GOAL_STRUCTURE_TEXTUAL_FAST` notation from real Swing `JButton`s (`CellModel_JComponent`) with lightweight native `CellModel_Constant` cells wired to `CellActionType.CLICK` via new `CellActionMapDeclaration`s. Real Swing components registered per element were making `EditorComponent.setRootCell()`'s unconditional teardown/rebuild of all `EditorCell_WithComponent`s expensive on every keystroke when editing goal text via the Inspector on large goal structures.

## Test plan
- [x] Model rebuild (`MAKE`) succeeds with no typesystem errors on the touched roots
- [ ] Manually verify: opening/editing a large `GOAL_STRUCTURE_TEXTUAL_FAST` goal structure no longer freezes/lags when editing goal text via the Inspector
- [ ] Manually verify: the "+"/"-" toggles still expand/collapse goal-structure elements correctly
- [ ] Manually verify: VCS gutter highlighting is suppressed only for goal structures over the size threshold, and unaffected for smaller ones